### PR TITLE
Updated hp6632b.check_error_queue to work with instrument and nosetests

### DIFF
--- a/python/src/instruments/hp/hp6632b.py
+++ b/python/src/instruments/hp/hp6632b.py
@@ -350,17 +350,19 @@ class HP6632b(SCPIInstrument, HP6652a):
     def display_brightness(self, newval):
         raise NotImplementedError
 
-    #def check_error_queue(self):
-    #    """
-	#    Checks and clears the error queue for this device, returning a list of
-	#    :class:`~SCPIInstrument.ErrorCodes` or `int` elements for each error
-	#    reported by the connected instrument.
-	#    """
-    #    err = False
-    #    result = []
-    #    while (err != self.ErrorCodes.no_error):
-    #        print err
-    #        err = int(self.query('SYST:ERR?').split(',')[0])
-    #        result.append(self.ErrorCodes[err] if err in self.ErrorCodes else err)
+    def check_error_queue(self):
+        """
+        Checks and clears the error queue for this device, returning a list of
+        :class:`~SCPIInstrument.ErrorCodes` or `int` elements for each error
+        reported by the connected instrument.
+        """
+        done = False
+        result = []
+        while (not done):
+            err = int(self.query('SYST:ERR?').split(',')[0])
+            if err == self.ErrorCodes.no_error:
+                done = True
+            else:
+                result.append(self.ErrorCodes[err] if err in self.ErrorCodes else err)
 
-    #    return result
+        return result

--- a/python/src/instruments/tests/test_hp/__init__.py
+++ b/python/src/instruments/tests/test_hp/__init__.py
@@ -34,7 +34,7 @@ import numpy as np
 ## TESTS ######################################################################
 
 test_scpi_multimeter_name = make_name_test(ik.hp.HP6632b)
-    
+
 def test_hp6632b_display_textmode():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -58,7 +58,7 @@ def test_hp6632b_display_text():
         ]
     ) as psu:
         assert psu.display_text("TEST") == "TEST"
-        
+
 def test_hp6632b_output():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -71,7 +71,7 @@ def test_hp6632b_output():
     ) as psu:
         assert psu.output == False
         psu.output = True
-        
+
 def test_hp6632b_voltage():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -84,7 +84,7 @@ def test_hp6632b_voltage():
     ) as psu:
         unit_eq(psu.voltage, 10*pq.volt)
         psu.voltage = 1.0 * pq.volt
-        
+
 def test_hp6632b_voltage_sense():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -95,7 +95,7 @@ def test_hp6632b_voltage_sense():
         ]
     ) as psu:
         unit_eq(psu.voltage_sense, 10*pq.volt)
-        
+
 def test_hp6632b_overvoltage():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -108,7 +108,7 @@ def test_hp6632b_overvoltage():
     ) as psu:
         unit_eq(psu.overvoltage, 10*pq.volt)
         psu.overvoltage = 1.0 * pq.volt
-        
+
 def test_hp6632b_current():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -121,7 +121,7 @@ def test_hp6632b_current():
     ) as psu:
         unit_eq(psu.current, 10*pq.amp)
         psu.current = 1.0 * pq.amp
-        
+
 def test_hp6632b_current_sense():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -132,7 +132,7 @@ def test_hp6632b_current_sense():
         ]
     ) as psu:
         unit_eq(psu.current_sense, 10*pq.amp)
-        
+
 def test_hp6632b_overcurrent():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -145,7 +145,7 @@ def test_hp6632b_overcurrent():
     ) as psu:
         assert psu.overcurrent == False
         psu.overcurrent = True
-        
+
 def test_hp6632b_current_sense_range():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -158,7 +158,7 @@ def test_hp6632b_current_sense_range():
     ) as psu:
         unit_eq(psu.current_sense_range, 0.05*pq.amp)
         psu.current_sense_range = 1 * pq.amp
-        
+
 def test_hp6632b_output_dfi_source():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -171,7 +171,7 @@ def test_hp6632b_output_dfi_source():
     ) as psu:
         assert psu.output_dfi_source == psu.DFISource.operation
         psu.output_dfi_source = psu.DFISource.questionable
-        
+
 def test_hp6632b_output_remote_inhibit():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -184,7 +184,7 @@ def test_hp6632b_output_remote_inhibit():
     ) as psu:
         assert psu.output_remote_inhibit == psu.RemoteInhibit.live
         psu.output_remote_inhibit = psu.RemoteInhibit.latching
-        
+
 def test_hp6632b_digital_function():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -197,7 +197,7 @@ def test_hp6632b_digital_function():
     ) as psu:
         assert psu.digital_function == psu.DigitalFunction.remote_inhibit
         psu.digital_function = psu.DigitalFunction.data
-        
+
 def test_hp6632b_digital_data():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -210,7 +210,7 @@ def test_hp6632b_digital_data():
     ) as psu:
         assert psu.digital_data == 5
         psu.digital_data = 1
-        
+
 def test_hp6632b_sense_sweep_points():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -223,7 +223,7 @@ def test_hp6632b_sense_sweep_points():
     ) as psu:
         assert psu.sense_sweep_points == 5
         psu.sense_sweep_points = 2048
-        
+
 def test_hp6632b_sense_sweep_interval():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -236,7 +236,7 @@ def test_hp6632b_sense_sweep_interval():
     ) as psu:
         unit_eq(psu.sense_sweep_interval, 1.56e-05 * pq.second)
         psu.sense_sweep_interval = 1e-05 * pq.second
-        
+
 def test_hp6632b_sense_window():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -249,7 +249,7 @@ def test_hp6632b_sense_window():
     ) as psu:
         assert psu.sense_window == psu.SenseWindow.hanning
         psu.sense_window = psu.SenseWindow.rectangular
-        
+
 def test_hp6632b_output_protection_delay():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -262,7 +262,7 @@ def test_hp6632b_output_protection_delay():
     ) as psu:
         unit_eq(psu.output_protection_delay, 8e-02 * pq.second)
         psu.output_protection_delay = 5e-02 * pq.second
-        
+
 def test_hp6632b_voltage_alc_bandwidth():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -286,7 +286,7 @@ def test_hp6632b_voltage_trigger():
     ) as psu:
         unit_eq(psu.voltage_trigger, 1 * pq.volt)
         psu.voltage_trigger = 1 * pq.volt
-        
+
 def test_hp6632b_current_trigger():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -299,7 +299,7 @@ def test_hp6632b_current_trigger():
     ) as psu:
         unit_eq(psu.current_trigger, 0.1 * pq.amp)
         psu.current_trigger = 0.1 * pq.amp
-        
+
 def test_hp6632b_init_output_trigger():
     with expected_protocol(
         ik.hp.HP6632b,
@@ -310,19 +310,19 @@ def test_hp6632b_init_output_trigger():
         ]
     ) as psu:
         psu.init_output_trigger()
-        
+
 def test_hp6632b_check_error_queue():
     with expected_protocol(
         ik.hp.HP6632b,
         [
-            "SYST:ERR:CODE:ALL?",
+            "SYST:ERR?",
+            "SYST:ERR?",
         ] , [
-            "213,216"
+            '-222,"Data out of range"',
+            '+0,"No error"'
         ]
     ) as psu:
         err_queue = psu.check_error_queue()
         assert err_queue == [
-                                psu.ErrorCodes.ingrd_recv_buffer_overrun,
-                                psu.ErrorCodes.rs232_recv_framing_error
+                                psu.ErrorCodes.data_out_of_range
                             ], "got {}".format(err_queue)
-


### PR DESCRIPTION
Saw that my hp6632b.check_error_queue method did not work with nosetests. Here is my take 2, that also works against the instrument.
