### PR TITLE
Added HP3456a System Multimeter

### DIFF
--- a/instruments/instruments/hp/__init__.py
+++ b/instruments/instruments/hp/__init__.py
@@ -1,3 +1,5 @@
+from instruments.hp.hp3456a import HP3456a
+
 from instruments.hp.hp6624a import (
     HP6624a,
     _HP6624aChannel

--- a/python/src/hp3456.py
+++ b/python/src/hp3456.py
@@ -1,0 +1,68 @@
+import logging
+import time
+import instruments as ik
+import quantities as pq
+
+dmm = ik.hp.HP3456a.open_gpibusb('/dev/ttyUSB0', 22)
+logging.basicConfig(level=logging.DEBUG)
+dmm._file.debug = True
+dmm.trigger_mode = dmm.TriggerMode.hold
+dmm.number_of_digits = 6
+dmm.auto_range()
+
+n = 10
+dmm.number_of_readings = n
+dmm.nplc = 1
+dmm.mode = dmm.Mode.resistance_2wire
+dmm.trigger()
+time.sleep(n * 0.04)
+v = dmm.fetch(dmm.Mode.resistance_2wire)
+print len(v)
+
+# Read registers
+dmm.nplc = 10
+print "n = {}".format(dmm.number_of_readings)
+print "g = {}".format(dmm.number_of_digits)
+print "p = {}".format(dmm.nplc)
+print "d = {}".format(dmm.delay)
+print dmm.mean
+print dmm.variance
+print dmm.count
+print dmm.lower
+print dmm.upper
+print dmm.r
+print dmm.y
+print dmm.z
+
+# Walk through input range
+dmm.nplc = 100
+print dmm.count
+print dmm.measure(dmm.Mode.ratio_dcv_dcv)
+print dmm.measure(dmm.Mode.resistance_2wire)
+for i in range(-1, 4):
+    value = (10 ** i) * pq.volt
+    dmm.input_range = value
+    print dmm.measure(dmm.Mode.dcv)
+
+# Walk through relative / null mode
+print dmm.relative
+dmm.relative = False
+print dmm.measure(dmm.Mode.resistance_2wire)
+dmm.relative = True
+print dmm.measure(dmm.Mode.resistance_2wire)
+dmm.relative = False
+print dmm.measure(dmm.Mode.resistance_2wire)
+
+# Measure with autozero off
+dmm.autozero = 0
+dmm.filter = 0
+dmm.auto_range()
+
+print dmm.measure(dmm.Mode.dcv)
+dmm.autozero = 1
+print dmm.measure(dmm.Mode.dcv)
+dmm.filter = 1
+print dmm.measure(dmm.Mode.dcv)
+dmm.autozero = 0
+print dmm.measure(dmm.Mode.dcv)
+

--- a/python/src/instruments/hp/hp3456a.py
+++ b/python/src/instruments/hp/hp3456a.py
@@ -1,0 +1,693 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+##
+# hp3456a.py: Driver for the HP3456a Digital Voltmeter.
+##
+# © 2014 Willem Dijkstra (wpd@xs4all.nl).
+#
+# This file is a part of the InstrumentKit project.
+# Licensed under the AGPL version 3.
+##
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+##
+
+## IMPORTS #####################################################################
+
+import time
+import struct
+from flufl.enum import Enum, IntEnum
+
+import quantities as pq
+import numpy as np
+
+from instruments.abstract_instruments import Multimeter
+
+## CLASSES #####################################################################
+
+class HP3456a(Multimeter):
+    """
+    The HP 3456a is a 6 1/2 digit bench multimeter. It supports DCV, ACV, ACV +
+    DCV, 2 wire Ohms, 4 wire Ohms, DCV/DCV Ratio, ACV/DCV Ratio, O.C. 2 wire
+    Ohms and O.C. 4 wire Ohms measurements.
+
+    It is a HPIB / pre-448.2 instrument.
+    """
+
+    def __init__(self, filelike):
+	"""
+        Initialise the instrument, and set the required eos, eoi needed for
+	communication.
+        """
+	super(HP3456a, self).__init__(filelike)
+        self.strip = 0
+        self.sendcmd('++read_tmo_ms 15000')
+        self.sendcmd('++auto 0')
+        self.sendcmd('++eoi 1')
+        self.sendcmd('++eos 0')
+        self.sendcmd('++eot_enable 1')
+	self.sendcmd('HO1T4SO1')
+        self._autozero = 1
+        self._filter = 0
+        self._nplc = 1
+        self._range = 1
+        self._null = False
+        self._delay = 0
+
+    ## ENUMS ##
+
+    class Mode(Enum):
+        """
+        Enum containing the different mode codes
+        """
+        #: DC voltage
+        dcv = 'S0F1'
+        #: AC voltage
+        acv = 'S0F2'
+        #: RMS of DC + AC voltage
+        acvdcv = 'S0F3'
+        #: 2 wire resistance
+        resistance_2wire = 'S0F4'
+        #: 4 wire resistance
+        resistance_4wire = 'S0F5'
+        #: ratio DC / DC voltage
+        ratio_dcv_dcv = 'S1F1'
+        #: ratio AC / DC voltage
+        ratio_acv_dcv = 'S1F2'
+        #: ratio (AC + DC) / DC voltage
+        ratio_acvdcv_dcv = 'S1F3'
+        #: offset compensated 2 wire resistance
+        oc_resistence_2wire = 'S1F4'
+        #: offset compensated 4 wire resistance
+        oc_resistence_4wire = 'S1F5'
+
+    class ValidRange(Enum):
+        """
+        Enum with the valid ranges for voltage, resistance, and number of powerline
+        integrations.
+
+        """
+        voltage = (1e-1, 1e0, 1e1, 1e2, 1e3)
+        resistance = (1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9)
+        nplc = (1e-1, 1e0, 1e1, 1e2)
+
+    class TriggerMode(IntEnum):
+        """
+        Enum with valid trigger modes.
+        """
+        internal = 1
+        external = 2
+        single = 3
+        hold = 4
+
+    class AutoZero(IntEnum):
+        """
+        Enum with valid autozero modes,
+        """
+        on = 1
+        off = 0
+
+    class Filter(IntEnum):
+        """
+        Enum with valid filter modes.
+        """
+        on = 1
+        off = 0
+
+    class Test(IntEnum):
+        """
+        Enum with test modes.
+        """
+        on = 1
+        off = 0
+
+    class Register(Enum):
+        """
+        Enum with the register names for all `HP3456a` internal registers.
+        """
+        number_of_readings = 'N'
+        number_of_digits = 'G'
+        nplc = 'I'
+        delay = 'D'
+        mean = 'M'
+        variance = 'V'
+        count = 'C'
+        lower = 'L'
+        r = 'R'
+        upper = 'U'
+        y = 'Y'
+        z = 'Z'
+
+    class MathMode(IntEnum):
+        """
+        Enum with the valid math modes
+        """
+        off = 0
+        pass_fail = 1
+        statistic = 2
+        null = 3
+        dbm = 4
+        thermistor_f = 5
+        thermistor_c = 6
+        scale = 7
+        percent = 8
+        db = 9
+
+    ## PROPERTIES ##
+
+    @property
+    def mode(self):
+        """
+        The HP3456a has no provisions to read the current mode via HPIB.
+        """
+        raise NotImplementedError
+
+    @mode.setter
+    def mode(self, newval):
+        """
+        Set the measurement mode.
+
+        :type: `HP3456a.Mode`
+        """
+        if isinstance(newval, str):
+            newval = self.Mode[newval]
+        if newval not in HP3456a.Mode:
+            raise TypeError("Mode must be specified as a HP3456a.Mode "
+                            "value, got {} instead.".format(newval))
+        self.sendcmd('{}'.format(newval.value))
+
+    @property
+    def autozero(self):
+        return self._autozero
+
+    @autozero.setter
+    def autozero(self, newval):
+        if isinstance(newval, str):
+            newval = self.AutoZero[newval]
+        if newval not in HP3456a.AutoZero:
+            raise TypeError("Autozero must be specified as a HP3456a.AutoZero "
+                            "value, got {} instead.".format(newval))
+        self._autozero = newval
+        print "autozero is ", self._autozero
+        self.sendcmd("Z{}".format(newval))
+
+    @property
+    def filter(self):
+        return self._filter
+
+    @filter.setter
+    def filter(self, newval):
+        if isinstance(newval, str):
+            newval = self.Filter[newval]
+        if newval not in HP3456a.Filter:
+            raise TypeError("Filter must be specified as a HP3456a.Filter "
+                            "value, got {} instead.".format(newval))
+        self._filter = newval
+        self.sendcmd('FL{}'.format(newval))
+
+    @property
+    def trigger_mode(self):
+        """
+        The HP3456a has no provisions to read the current trigger mode via HPIB.
+        """
+        raise NotImplementedError
+
+    @trigger_mode.setter
+    def trigger_mode(self, newval):
+        """
+        Set the trigger mode. Note that using `HP3456a.measure()` will override
+        the `trigger_mode` to `HP3456a.TriggerMode.single`.
+
+        :type: `HP3456a.TriggerMode`
+
+        """
+        if isinstance(newval, str):
+            newval = HP3456a.TriggerMode[newval]
+        if newval not in HP3456a.TriggerMode:
+            raise TypeError('Drive must be specified as a '
+                            'HP3456a.TriggerMode, got {} '
+                            'instead.'.format(newval))
+        self.sendcmd('T{}W'.format(newval.value))
+
+    @property
+    def number_of_readings(self):
+        """
+        Get the number of readings done per trigger/measurement cycle from
+        `HP3456a.Register.number_of_readings`.
+
+        :rtype: `float`
+        """
+        return self.register_read(HP3456a.Register.number_of_readings)
+
+    @number_of_readings.setter
+    def number_of_readings(self, value):
+        """
+        Set the number of readings to be done per trigger/measurement cycle in
+        `HP3456a.Register.number_of_readings`.
+
+        :type: `float`
+        """
+        self.register_write(HP3456a.Register.number_of_readings, value)
+
+    @property
+    def number_of_digits(self):
+        """
+        Get the number of digits used in measurements from
+        `HP3456a.Register.number_of_digits`.
+
+        :rtype: `float`
+        """
+        return self.register_read(HP3456a.Register.number_of_digits)
+
+    @number_of_digits.setter
+    def number_of_digits(self, value):
+        """
+        Set the number of digits used in measurments in
+        `HP3456a.Register.number_of_digits`. Higher values increase accuracy at
+        the cost of measurement speed.
+
+        :type: `int`
+        """
+        valid = (3, 4, 5, 6)
+        if value not in valid:
+            raise ValueError('Valid number_of_digits are: '
+                             '{}'.format(valid))
+
+        self.register_write(HP3456a.Register.number_of_digits, value)
+
+    @property
+    def nplc(self):
+        """
+        Get the number of powerline cycles to integrate per measurement from
+        `HP3456a.Register.nplc`.
+
+        :rtype: `float`
+        """
+        self._nplc = self.register_read(HP3456a.Register.nplc)
+        return self._nplc
+
+    @nplc.setter
+    def nplc(self, value):
+        """
+        Set the number of powerline cycles to integrate per measurement in
+        `HP3456a.Register.nplc`. Setting higher values increases accuracy at
+        the cost of a longer measurement time. The implicit assumption is that
+        the input reading is stable over the number of powerline cycles to
+        integrate.
+
+        :type: `int`
+
+        """
+        valid = HP3456a.ValidRange['nplc'].value
+        if isinstance(value, float) or isinstance(value, int):
+            if value in valid:
+                self._nplc = value
+                self.register_write(HP3456a.Register.nplc, value)
+            else:
+                raise ValueError('Valid nplc settings are: '
+                                 '{}'.format(valid))
+        else:
+            raise TypeError('NPLC must be specified as float or int, '
+                            'got {}'.format(type(value)))
+
+    @property
+    def delay(self):
+        """
+        Get the delay that is waited after a trigger for the input to settle from
+        `HP3456a.Register.delay`.
+
+        :rtype: `~quantaties.Quantity.s`
+        """
+        self._delay = self.register_read(HP3456a.Register.delay)
+        return self._delay * pq.s
+
+    @delay.setter
+    def delay(self, value):
+        """
+        Set the delay that is to be waited in seconds after a trigger for the input
+        to settle to `HP3456a.Register.delay`.
+
+        :units: As specified, or assumed to be :math:`\\text{s}` otherwise.
+        :type: `int` or `~quantaties.Quantity`.
+
+        """
+        self._delay = assume_units(value, pq.s).rescale(pq.s).magnitude
+        self.register_write(HP3456a.Register.delay, self._delay)
+
+    @property
+    def mean(self):
+        """
+        Get the mean over `HP3456a.Register.count` measurements from
+        `HP3456a.Register.mean` when in `HP3456a.MathMode.statistics`.
+
+        :rtype: `float`
+        """
+        return self.register_read(HP3456a.Register.mean)
+
+    @property
+    def variance(self):
+        """
+        Get the variance over `HP3456a.Register.count` measurements from
+        `HP3456a.Register.variance` when in `HP3456a.MathMode.statistics`.
+
+        :rtype: `float`
+        """
+        return self.register_read(HP3456a.Register.variance)
+
+    @property
+    def count(self):
+        """
+        Get the number of measurements taken from `HP3456a.Register.count` when in
+        `HP3456a.MathMode.statistics`.
+
+        :rtype: `int`
+        """
+        return int(self.register_read(HP3456a.Register.count))
+
+    @property
+    def lower(self):
+        """
+        Get the value in `HP3456a.Register.lower`, which indicates the lowest value
+        measurement made while in `HP3456a.MathMode.statistics`, or the lowest
+        value preset for `HP3456a.MathMode.pass_fail`.
+
+        :rtype: `float`
+        """
+        return self.register_read(HP3456a.Register.lower)
+
+    @lower.setter
+    def lower(self, value):
+        """
+        Set the value in `HP3456a.Register.lower`, which indicates the lowest value
+        measurement made while in `HP3456a.MathMode.statistics`, or the lowest
+        value preset for `HP3456a.MathMode.pass_fail`.
+
+        :type: `float`
+        """
+        self.register_write(HP3456a.Register.lower, value)
+
+    @property
+    def upper(self):
+        """
+        Get the value in `HP3456a.Register.upper`, which indicates the highest value
+        measurement made while in `HP3456a.MathMode.statistics`, or the highest
+        value preset for `HP3456a.MathMode.pass_fail`.
+
+        :rtype: `float`
+        """
+        return self.register_read(HP3456a.Register.upper)
+
+    @upper.setter
+    def upper(self, value):
+        """
+        Set the value in `HP3456a.Register.upper`, which indicates the highest value
+        measurement made while in `HP3456a.MathMode.statistics`, or the highest
+        value preset for `HP3456a.MathMode.pass_fail`.
+
+        :type: `float`
+        """
+        return self.register_write(HP3456a.Register.upper, value)
+
+    @property
+    def r(self):
+        """
+        Get the value in `HP3456a.Register.r`, which indicates the resistor value
+        used while in `HP3456a.MathMode.dbm` or the number of recalled readings
+        in reading storage mode.
+
+        :rtype: `float`
+        """
+        return self.register_read(HP3456a.Register.r)
+
+    @r.setter
+    def r(self, value):
+        """
+        Set the value in `HP3456a.Register.r`, which indicates the resistor value
+        used while in `HP3456a.MathMode.dbm` or the number of recalled readings
+        in reading storage mode.
+
+        :type: `float`
+        """
+        self.register_write(HP3456a.Register.r, value)
+
+    @property
+    def y(self):
+        """
+        Get the value in `HP3456a.Register.y` to be used in calculations when in
+        `HP3456a.MathMode.scale` or `HP3456a.MathMode.percent`.
+
+        :rtype: `float`
+        """
+        return self.register_read(HP3456a.Register.y)
+
+    @y.setter
+    def y(self, value):
+        """
+        Set the value in `HP3456a.Register.y` to be used in calculations when in
+        `HP3456a.MathMode.scale` or `HP3456a.MathMode.percent`.
+
+        :type: `float`
+        """
+        self.register_write(HP3456a.Register.y, value)
+
+    @property
+    def z(self):
+        """
+        Get the value in `HP3456a.Register.z` to be used in calculations when in
+        `HP3456a.MathMode.scale` or the first reading when in
+        `HP3456a.MathMode.statistics`.
+
+        :rtype: `float`
+        """
+        return self.register_read(HP3456a.Register.z)
+
+    @z.setter
+    def z(self, value):
+        """
+        Set the value in `HP3456a.Register.z` to be used in calculations when in
+        `HP3456a.MathMode.scale`.
+
+        :type: `float`
+        """
+        self.register_write(HP3456a.Register.z, value)
+
+    @property
+    def input_range(self):
+        """
+        Get the current input range setting of the multimeter.
+        """
+        raise NotImplementedError
+
+    @input_range.setter
+    def input_range(self, value):
+        """
+        Set the input range to be used. The `HP3456a` has separate ranges for
+        `~quantities.ohm` and for `~quantities.volt`. The range value sent to
+        the instrument depends on the unit set on the input range value. `auto`
+        selects auto ranging.
+
+        :type: `~quantities.Quantity`
+        """
+        if isinstance(value, str):
+            if value.lower() == 'auto':
+                self._range = 1
+                self.sendcmd('R{}W'.format(self._range))
+            else:
+                raise ValueError('Only "auto" is acceptable when specifying '
+                                 'the input range as a string.')
+
+        elif isinstance(value, pq.quantity.Quantity):
+            if (value.units == pq.volt):
+                valid = HP3456a.ValidRange.voltage.value
+            elif (value.units == pq.ohm):
+                valid = HP3456a.ValidRange.resistance.value
+            else:
+                raise ValueError('Value {} not quantity.volt or quantity.ohm'
+                                 ''.format(value))
+
+            value = float(value)
+            if value not in valid:
+                raise ValueError('Value {} outside valid ranges '
+                                 '{}'.format(value, valid))
+            value = valid.index(value) + 2
+            self._range = value
+            self.sendcmd('R{}W'.format(self._range))
+        else:
+            raise TypeError('Range setting must be specified as a float, int, '
+                            'or the string "auto", got {}'.format(type(value)))
+
+    @property
+    def relative(self):
+        """
+        Return if the instrument was previously set to `HP3456a.MathMode.Null`.
+
+        :rtype: `bool`
+
+        """
+        return self._null
+
+    @relative.setter
+    def relative(self, value):
+        """
+        Enter or disable `HP3456a.MathMode.Null` on the instrument. This setting is cached locally.
+
+        :type: `bool`
+        """
+        if value is True:
+            self._null = True
+            self.sendcmd('M{}'.format(HP3456a.MathMode.null.value))
+        elif value is False:
+            self._null = False
+            self.sendcmd('M{}'.format(HP3456a.MathMode.off.value))
+        else:
+            raise TypeError('Relative setting must be specified as a bool'
+                            ', got {}'.format(type(value)))
+
+    ## METHODS ##
+
+    def register_read(self, name):
+        """
+        Read a register on the HP3456a.
+
+        :type: `HP3456a.Register`
+        :rtype: `float`
+        """
+        if isinstance(name, str):
+            name = HP3456a.Register[name]
+        if name not in HP3456a.Register:
+            raise TypeError('register must be specified as a '
+                            'HP3456a.Register, got {} '
+                            'instead.'.format(name))
+        self.sendcmd('RE{}'.format(name.value))
+        time.sleep(.1)
+        return float(self.query('', size = -1))
+
+    def register_write(self, name, value):
+        """
+        Write a register on the HP3456a.
+
+        :type name: `HP3456a.Register`
+        :type value: `float`
+        """
+        if isinstance(name, str):
+            r = HP3456a.Register[name]
+        if name not in HP3456a.Register:
+            raise TypeError('register must be specified as a '
+                            'HP3456a.Register, got {} '
+                            'instead.'.format(name))
+        if name in [HP3456a.Register.mean, HP3456a.Register.variance, HP3456a.Register.count]:
+            raise ValueError('register {} is read only'.format(name))
+        self.sendcmd('W{}ST{}'.format(value, name.value))
+        time.sleep(.1)
+
+    def trigger(self):
+        """
+        Signal a single manual trigger event to the `HP3456a`.
+        """
+	self.sendcmd('T3')
+
+    def measure(self, mode = None):
+        """Instruct the HP3456a to perform a one time measurement. The measurement
+        will use the current set registers for the measurement
+        (number_of_readings, number_of_digits, nplc, delay, mean, lower, upper,
+        y and z) and will immediately take place.
+
+        Example usage:
+
+        >>> dmm = ik.hp.HP3456a.open_gpibusb('/dev/ttyUSB0', 22)
+        >>> dmm.number_of_digits = 6
+        >>> dmm.nplc = 1
+        >>> print dmm.measure(dmm.Mode.resistance_2wire)
+
+        :param mode: Desired measurement mode. If not specified, the previous
+        set mode will be used, but no measurement unit will be returned.
+
+        :type mode: `HP3456a.Mode`
+
+        :return: A measurement from the multimeter.
+        :rtype: `~quantities.quantity.Quantity`
+        """
+        if mode is not None:
+            modevalue = mode.value
+            units = UNITS[mode]
+        else:
+            modevalue = None
+            units = 1
+
+        self.sendcmd('{}W1STNT3'.format(modevalue))
+
+        value = self.query('', size=-1)
+        return float(value) * units
+
+    def fetch(self, mode = None):
+        """Retrieve n measurements after the HP3456a has been instructed to perform a
+        series of similar measurements. Typically the mode, range, nplc, analog
+        filter, autozero is set along with the number of measurements to
+        take. The series is then started at the trigger command.
+
+        Example usage:
+
+        >>> dmm.number_of_digits = 6
+        >>> dmm.auto_range()
+        >>> dmm.nplc = 1
+        >>> dmm.mode = dmm.Mode.resistance_2wire
+        >>> n = 100
+        >>> dmm.number_of_readings = n
+        >>> dmm.trigger()
+        >>> time.sleep(n * 0.04)
+        >>> v = dmm.fetch(dmm.Mode.resistance_2wire)
+        >>> print len(v)
+
+        :param mode: Desired measurement mode. If not specified, the previous
+        set mode will be used, but no measurement unit will be returned.
+
+        :type mode: `HP3456a.Mode`
+
+        :return: A series of measurements from the multimeter.
+        :rtype: `~quantities.quantity.Quantity`
+        """
+        if mode is not None:
+            modevalue = mode.value
+            units = UNITS[mode]
+        else:
+            modevalue = None
+            units = 1
+
+        value = self.query('', size=-1)
+        values = [float(x) * units for x in value.split(',')]
+        return values
+
+    def auto_range(self):
+
+        """
+        Set input range to auto. The `HP3456a` should upscale when a reading is at
+        120% and downscale when it below 11% full scale. Note that auto ranging
+        can increase the measurement time.
+        """
+        self.input_range = 'auto'
+
+## UNITS #######################################################################
+
+UNITS = {
+    None : 1,
+    HP3456a.Mode.dcv: pq.volt,
+    HP3456a.Mode.acv: pq.volt,
+    HP3456a.Mode.acvdcv: pq.volt,
+    HP3456a.Mode.resistance_2wire: pq.ohm,
+    HP3456a.Mode.resistance_4wire: pq.ohm,
+    HP3456a.Mode.ratio_dcv_dcv: 1,
+    HP3456a.Mode.ratio_acv_dcv: 1,
+    HP3456a.Mode.ratio_acvdcv_dcv: 1,
+    HP3456a.Mode.oc_resistence_2wire: pq.ohm,
+    HP3456a.Mode.oc_resistence_4wire: pq.ohm,
+}


### PR DESCRIPTION
Here is that HP3456a class I've been working on. There are a couple of warts left; the 3456a is an old instrument, that especially when set at high nplc and number of successive readings in one trigger will need adequate thinking time. The gpib_firmware settings needed to achieve this are set at **init** right now. These would need a similar treatment to self.terminator, but I thought it best to let you decide where that should go. After all, these settings would break with gpib_firmware<5.
