### PR TITLE
Bugfix: Keithley580 do not parse terminator

### DIFF
--- a/instruments/instruments/keithley/keithley580.py
+++ b/instruments/instruments/keithley/keithley580.py
@@ -56,18 +56,18 @@ class Keithley580(Instrument):
         '''
         super(Keithley580, self).__init__(filelike)
         self.sendcmd('Y:X') # Removes the termination CRLF characters
-                           # from the instruments
-                           
+                            # from the instruments
+
     ## ENUMS ##
-    
+
     class Polarity(IntEnum):
         positive = 0
         negative = 1
-        
+
     class Drive(IntEnum):
         pulsed = 0
         dc = 1
-    
+
     class TriggerMode(IntEnum):
         talk_continuous = 0
         talk_one_shot = 1
@@ -75,20 +75,20 @@ class Keithley580(Instrument):
         get_one_shot = 3
         trigger_continuous = 4
         trigger_one_shot = 5
-        
+
     ## PROPERTIES ##
 
     @property
     def polarity(self):
         """
         Gets/sets instrument polarity.
-        
+
         Example use:
-        
+
         >>> import instruments as ik
         >>> keithley = ik.keithley.Keithley580.open_gpibusb('/dev/ttyUSB0', 1)
         >>> keithley.polarity = keithley.Polarity.positive
-        
+
         :type: `Keithley580.Polarity`
         """
         value = self.parse_status_word(self.get_status_word())['polarity']
@@ -104,23 +104,23 @@ class Keithley580(Instrument):
         if isinstance(newval, str):
             newval = Keithley580.Polarity[newval]
         if newval not in Keithley580.Polarity:
-            raise TypeError('Polarity must be specified as a ' 
+            raise TypeError('Polarity must be specified as a '
                             'Keithley580.Polarity, got {} '
                             'instead.'.format(newval))
-        
+
         self.sendcmd('P{}X'.format(newval.value))
 
     @property
     def drive(self, func):
         """
         Gets/sets the instrument drive to either pulsed or DC.
-        
+
         Example use:
-        
+
         >>> import instruments as ik
         >>> keithley = ik.keithley.Keithley580.open_gpibusb('/dev/ttyUSB0', 1)
         >>> keithley.drive = keithley.Drive.pulsed
-        
+
         :type: `Keithley580.Drive`
         """
         value = self.parse_status_word(self.get_status_word())['drive']
@@ -130,25 +130,25 @@ class Keithley580(Instrument):
         if  isinstance(newval, str):
             newval = Keithley580.Drive[newval]
         if newval not in Keithley580.Drive:
-            raise TypeError('Drive must be specified as a ' 
+            raise TypeError('Drive must be specified as a '
                             'Keithley580.Drive, got {} '
                             'instead.'.format(newval))
 
         self.sendcmd('D{}X'.format(newval.value))
-        
+
     @property
     def dry_circuit_test(self):
         """
         Gets/sets the 'dry circuit test' mode of the Keithley 580.
-        
-        This mode is used to minimize any physical and electrical changes in 
+
+        This mode is used to minimize any physical and electrical changes in
         the contact junction by limiting the maximum source voltage to 20mV.
         By limiting the voltage, the measuring circuit will leave the resistive
-        surface films built up on the contacts undisturbed. This allows for 
+        surface films built up on the contacts undisturbed. This allows for
         measurement of the resistance of these films.
-        
+
         See the Keithley 580 manual for more information.
-        
+
         :type: `bool`
         """
         return self.parse_status_word(self.get_status_word())['drycircuit']
@@ -157,14 +157,14 @@ class Keithley580(Instrument):
         if not isinstance(newval, bool):
             raise TypeError('DryCircuitTest mode must be a boolean.')
         self.sendcmd('C{}X'.format(int(newval)))
-     
+
     @property
     def operate(self):
         """
-        Gets/sets the operating mode of the Keithley 580. If set to true, the 
-        instrument will be in operate mode, while false sets the instruments 
+        Gets/sets the operating mode of the Keithley 580. If set to true, the
+        instrument will be in operate mode, while false sets the instruments
         into standby mode.
-        
+
         :type: `bool`
         """
         return self.parse_status_word(self.get_status_word())['operate']
@@ -173,17 +173,17 @@ class Keithley580(Instrument):
         if not isinstance(newval, bool):
             raise TypeError('Operate mode must be a boolean.')
         self.sendcmd('O{}X'.format(int(newval)))
-    
+
     @property
     def relative(self):
         """
-        Gets/sets the relative measurement mode of the Keithley 580. 
-        
-        As stated in the manual: The relative function is used to establish a 
-        baseline reading. This reading is subtracted from all subsequent 
+        Gets/sets the relative measurement mode of the Keithley 580.
+
+        As stated in the manual: The relative function is used to establish a
+        baseline reading. This reading is subtracted from all subsequent
         readings. The purpose of making relative measurements is to cancel test
         lead and offset resistances or to store an input as a reference level.
-        
+
         Once a relative level is established, it remains in effect until another
         relative level is set. The relative value is only good for the range the
         value was taken on and higher ranges. If a lower range is selected than
@@ -191,7 +191,7 @@ class Keithley580(Instrument):
         Relative cannot be activated when "OL" is displayed.
 
         See the manual for more information.
-        
+
         :type: `bool`
         """
         return self.parse_status_word(self.get_status_word())['relative']
@@ -200,27 +200,27 @@ class Keithley580(Instrument):
         if not isinstance(newval, bool):
             raise TypeError('Relative mode must be a boolean.')
         self.sendcmd('Z{}X'.format(int(newval)))
-        
+
     @property
     def trigger_mode(self):
         """
         Gets/sets the trigger mode of the Keithley 580.
-        
+
         There are two different trigger settings for three different sources.
         This means there are six different settings for the trigger mode.
-        
+
         The two types are continuous and one-shot. Continuous has the instrument
         continuously sample the resistance. One-shot performs a single
         resistance measurement.
-        
-        The three trigger sources are on talk, on GET, and on "X". On talk 
+
+        The three trigger sources are on talk, on GET, and on "X". On talk
         refers to addressing the instrument to talk over GPIB. On GET is when
-        the instrument receives the GPIB command byte for "group execute 
-        trigger". Last, on "X" is when one sends the ASCII character "X" to the 
-        instrument. This character is used as a general execute to confirm 
+        the instrument receives the GPIB command byte for "group execute
+        trigger". Last, on "X" is when one sends the ASCII character "X" to the
+        instrument. This character is used as a general execute to confirm
         commands send to the instrument. In InstrumentKit, "X" is sent after
         each command so it is not suggested that one uses on "X" triggering.
-        
+
         :type: `Keithley580.TriggerMode`
         """
         raise NotImplementedError
@@ -229,17 +229,17 @@ class Keithley580(Instrument):
         if  isinstance(newval, str):
             newval = Keithley580.TriggerMode[newval]
         if newval not in Keithley580.TriggerMode:
-            raise TypeError('Drive must be specified as a ' 
+            raise TypeError('Drive must be specified as a '
                             'Keithley580.TriggerMode, got {} '
                             'instead.'.format(newval))
         self.sendcmd('T{}X'.format(newval.value))
-        
+
     @property
     def input_range(self):
         """
-        Gets/sets the range of the Keithley 580 input terminals. The valid 
+        Gets/sets the range of the Keithley 580 input terminals. The valid
         ranges are one of ``{AUTO|2e-1|2|20|200|2000|2e4|2e5}``
-        
+
         :type: `~quantities.quantity.Quantity` or `str`
         """
         value = float(self.parse_status_word(self.get_status_word())['range'])
@@ -257,7 +257,7 @@ class Keithley580(Instrument):
                                  'the input range as a string.')
         if isinstance(newval, pq.quantity.Quantity):
             newval = float(newval)
-            
+
         if isinstance(newval, float) or isinstance(newval, int):
             if newval in valid:
                 newval = valid.index(newval)
@@ -268,12 +268,12 @@ class Keithley580(Instrument):
                             'or the string "auto", got {}'.format(type(newval)))
         self.sendcmd('R{}X'.format(newval))
 
-    ## METHODS ## 
+    ## METHODS ##
 
     def trigger(self):
         '''
         Tell the Keithley 580 to execute all commands that it has received.
-        
+
         Do note that this is different from the standard SCPI \*TRG command
         (which is not supported by the 580 anyways).
         '''
@@ -282,7 +282,7 @@ class Keithley580(Instrument):
     def auto_range(self):
         """
         Turn on auto range for the Keithley 580.
-        
+
         This is the same as calling the `Keithley580.set_resistance_range`
         method and setting the parameter to "AUTO".
         """
@@ -301,7 +301,7 @@ class Keithley580(Instrument):
         The keithley will not always respond with the statusword when asked. We
         use a simple heuristic here: request it up to 5 times, using a 1s
         delay to allow the keithley some thinking time.
-        
+
         :rtype: `str`
         """
         tries = 5
@@ -319,16 +319,16 @@ class Keithley580(Instrument):
 
     def parse_status_word(self, statusword):
         """
-        Parse the status word returned by the function 
+        Parse the status word returned by the function
         `~Keithley580.get_status_word`.
-        
+
         Returns a `dict` with the following keys:
         ``{drive,polarity,drycircuit,operate,range,relative,eoi,trigger,
         sqrondata,sqronerror,linefreq,terminator}``
-        
+
         :param statusword: Byte string to be unpacked and parsed
         :type: `str`
-        
+
         :rtype: `dict`
         """
         if statusword[:3] != '580':
@@ -336,8 +336,8 @@ class Keithley580(Instrument):
                              'prefix: {}'.format(statusword))
 
         (drive, polarity, drycircuit, operate, rng, \
-         relative, eoi, trigger, sqrondata, sqronerror, linefreq, \
-         terminator) = struct.unpack('@8c2s2s2c', statusword[3:])
+         relative, eoi, trigger, sqrondata, sqronerror, \
+         linefreq) = struct.unpack('@8c2s2s2', statusword[3:])
 
         valid = { 'drive'      : { '0': 'pulsed',
                                    '1': 'dc' },
@@ -379,10 +379,10 @@ class Keithley580(Instrument):
     def measure(self, mode = None):
         """
         Perform a measurement with the Keithley 580.
-        
+
         :param mode: This parameter is ignored for the Keithley 580 as the only
             valid mode is resistance.
-        
+
         :rtype: `~quantities.quantity.Quantity`
         """
         self.trigger()
@@ -391,17 +391,17 @@ class Keithley580(Instrument):
     def parse_measurement(self, measurement):
         """
         Parse the measurement string returned by the instrument.
-        
-        Returns a dict with the following keys: 
+
+        Returns a dict with the following keys:
         ``{status,polarity,drycircuit,drive,resistance}``
-        
+
         :param measurement: String to be unpacked and parsed
         :type: `str`
-        
+
         :rtype: `dict`
         """
-        (status, polarity, drycircuit, drive, resistance, terminator) = \
-            struct.unpack('@4c11sc', measurement)
+        (status, polarity, drycircuit, drive, resistance) = \
+            struct.unpack('@4c11s', measurement)
 
         valid = { 'status'     : { 'S' : 'standby',
                                    'N' : 'normal',
@@ -427,11 +427,11 @@ class Keithley580(Instrument):
                  'drycircuit': drycircuit,
                  'drive': drive,
                  'resistance': resistance }
-     
+
     ## COMMUNICATOR METHODS ##
-     
+
     def sendcmd(self, msg):
         super(Keithley580, self).sendcmd(msg + ':')
-        
+
     def query(self, msg, size=-1):
         return super(Keithley580, self).query(msg + ':', size)[:-1]


### PR DESCRIPTION
Do not look for the terminator in the parse functions, as this is stripped
already in the class specific query function.
