### PR TITLE
Refactor of PR #56

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,378 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
+disable=redefined-builtin,invalid-name,unsubscriptable-object,too-few-public-methods
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set). This supports can work
+# with qualified names.
+ignored-classes=
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/instruments/doc/examples/ex_thorlabstc200.py
+++ b/instruments/doc/examples/ex_thorlabstc200.py
@@ -1,0 +1,41 @@
+#Thorlabs Temperature Controller example
+
+import instruments as ik
+import quantities
+tc = ik.thorlabs.TC200.open_serial('/dev/tc200', 115200)
+
+
+tc.temperature = 70*quantities.degF
+print("The current temperature is: ", tc.temperature)
+
+tc.mode = tc.Mode.normal
+print("The current mode is: ", tc.mode)
+
+tc.enable = True
+print("The current enabled state is: ", tc.enable)
+
+tc.p = 200
+print("The current p gain is: ", tc.p)
+
+tc.i = 2
+print("The current i gain is: ", tc.i)
+
+tc.d = 2
+print("The current d gain is: ", tc.d)
+
+tc.degrees = quantities.degF
+print("The current degrees settings is: ", tc.degrees)
+
+tc.sensor = tc.Sensor.ptc100
+print("The current sensor setting is: ", tc.sensor)
+
+tc.beta = 3900
+print("The current beta settings is: ", tc.beta)
+
+tc.max_temperature = 150*quantities.degC
+print("The current max temperature setting is: ", tc.max_temperature)
+
+tc.max_power = 1000*quantities.mW
+print("The current max power setting is: ", tc.max_power)
+
+

--- a/instruments/doc/source/apiref/thorlabs.rst
+++ b/instruments/doc/source/apiref/thorlabs.rst
@@ -14,8 +14,8 @@ ThorLabs
     :members:
     :undoc-members:
 
-:class:`ThorLabsAPT`
-====================
+:class:`ThorLabsAPT` - ThorLabs APT Controller
+==============================================
 
 .. autoclass:: ThorLabsAPT
     :members:
@@ -33,17 +33,23 @@ ThorLabs
     :members:
     :undoc-members:
 
-:class:`SC10`
-=============
+:class:`SC10` - Optical Beam Shutter Controller
+===============================================
 
 .. autoclass:: SC10
     :members:
     :undoc-members:
 
-:class:`LCC25`
-==============
+:class:`LCC25` - Liquid Crystal Controller
+==========================================
 
 .. autoclass:: LCC25
     :members:
     :undoc-members:
 
+:class:`TC200` - Temperature Controller
+=======================================
+
+.. autoclass:: TC200
+    :members:
+    :undoc-members:

--- a/instruments/instruments/abstract_instruments/comm/loopback_communicator.py
+++ b/instruments/instruments/abstract_instruments/comm/loopback_communicator.py
@@ -1,14 +1,14 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-##
-# loopback_communicator.py: Loopback communicator, just prints what it receives  
+#
+# loopback_communicator.py: Loopback communicator, just prints what it receives
 #                           or queries return empty string
-##
-# © 2013-2015 Steven Casagrande (scasagrande@galvant.ca).
+#
+# © 2013-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
-##
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -21,76 +21,83 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
-##
+#
+#
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 import io
 from instruments.abstract_instruments.comm import AbstractCommunicator
 import sys
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
+
 
 class LoopbackCommunicator(io.IOBase, AbstractCommunicator):
+
     """
     Used for testing various controllers
     """
-    
+
     def __init__(self, stdin=None, stdout=None):
         AbstractCommunicator.__init__(self)
         self._terminator = '\n'
         self._stdout = stdout
         self._stdin = stdin
-    
-    ## PROPERTIES ##
-    
+
+    # PROPERTIES ##
+
     @property
     def address(self):
         return sys.stdin.name
+
     @address.setter
     def address(self, newval):
         raise NotImplementedError()
-        
+
     @property
     def terminator(self):
         return self._terminator
+
     @terminator.setter
     def terminator(self, newval):
         if not isinstance(newval, str):
             raise TypeError('Terminator must be specified '
-                              'as a single character string.')
+                            'as a single character string.')
         if len(newval) > 1:
             raise ValueError('Terminator for LoopbackCommunicator must only be 1 '
-                                'character long.')
+                             'character long.')
         self._terminator = newval
-        
+
     @property
     def timeout(self):
         return 0
+
     @timeout.setter
     def timeout(self, newval):
         pass
-        
-    ## FILE-LIKE METHODS ##
-    
+
+    # FILE-LIKE METHODS ##
+
     def close(self):
         try:
             self._stdin.close()
         except:
             pass
-        
-    def read(self, size):
+
+    def read(self, size=-1):
         """
         Gets desired response command from user
-        
+
+        :param int size: Number of characters to read. Default value of -1
+            will read until termination character is found.
         :rtype: `str`
         """
         if self._stdin is not None:
-            if (size >= 0):
+            if size >= 0:
                 input_var = self._stdin.read(size)
                 return input_var
-            elif (size == -1):
+            elif size == -1:
                 result = bytearray()
                 c = 0
                 while c != self._terminator:
@@ -105,43 +112,41 @@ class LoopbackCommunicator(io.IOBase, AbstractCommunicator):
         else:
             input_var = raw_input("Desired Response: ")
         return input_var
-        
+
     def write(self, msg):
         if self._stdout is not None:
             self._stdout.write(msg)
         else:
             print " <- {} ".format(repr(msg))
-        
-        
+
     def seek(self, offset):
         return NotImplemented
-        
+
     def tell(self):
         return NotImplemented
-        
+
     def flush_input(self):
         pass
-        
-    ## METHODS ##
-    
+
+    # METHODS ##
+
     def sendcmd(self, msg):
-        '''
+        """
         Receives a command and passes off to write function
-        
+
         :param str msg: The command to be received
-        '''
+        """
         if msg is not '':
-            msg = msg + self._terminator
+            msg = "{}{}".format(msg, self._terminator)
             self.write(msg)
-        
+
     def query(self, msg, size=-1):
-        '''
+        """
         Receives a query and returns the generated Response
-        
+
         :param str msg: The message to received
         :rtype: `str`
-        '''
+        """
         self.sendcmd(msg)
         resp = self.read(size)
         return resp
-

--- a/instruments/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/instruments/abstract_instruments/comm/serial_communicator.py
@@ -104,10 +104,10 @@ class SerialCommunicator(io.IOBase, AbstractCommunicator):
             self._conn.close()
         
     def read(self, size):
-        if (size >= 0):
+        if size >= 0:
             resp = self._conn.read(size)
             return resp
-        elif (size == -1):
+        elif size == -1:
             result = bytearray()
             c = 0
             while c != self._terminator:

--- a/instruments/instruments/abstract_instruments/instrument.py
+++ b/instruments/instruments/abstract_instruments/instrument.py
@@ -27,7 +27,6 @@
 
 import socket
 import urlparse
-from contextlib import contextmanager
 
 from instruments.abstract_instruments.comm import (
     SocketCommunicator,
@@ -86,7 +85,7 @@ class Instrument(object):
                             'object that is a subclass of '
                             'AbstractCommunicator.')
         self._prompt = None
-        self.terminator = "\n"
+        self._terminator = "\n"
 
     # COMMAND-HANDLING METHODS #
 
@@ -156,6 +155,7 @@ class Instrument(object):
     def readline(self):
         """
         Read a full line
+
         :return: the read line
         :rtype: `str`
         """
@@ -439,10 +439,12 @@ class Instrument(object):
         .. seealso::
             `~serial.Serial` for description of `port`, baud rates and timeouts.
         """
-        ser = serial_manager.new_serial_connection(port,
-                                                   baud=baud,
-                                                   timeout=timeout,
-                                                   write_timeout=write_timeout)
+        ser = serial_manager.new_serial_connection(
+            port,
+            baud=baud,
+            timeout=timeout,
+            write_timeout=write_timeout
+        )
         return cls(ser)
 
     @classmethod
@@ -468,12 +470,14 @@ class Instrument(object):
         .. seealso::
             `~serial.Serial` for description of `port` and timeouts.
 
-        .. _Galvant Industries GPIB-USB adapter: http://galvant.ca/shop/gpibusb/
+        .. _Galvant Industries GPIB-USB adapter: galvant.ca/#!/store/gpibusb
         """
-        ser = serial_manager.newSerialConnection(port,
-                                                 baud=460800,
-                                                 timeout=timeout,
-                                                 write_timeout=write_timeout)
+        ser = serial_manager.new_serial_connection(
+            port,
+            baud=460800,
+            timeout=timeout,
+            write_timeout=write_timeout
+        )
         return cls(GPIBCommunicator(ser, gpib_address))
 
     @classmethod

--- a/instruments/instruments/abstract_instruments/instrument.py
+++ b/instruments/instruments/abstract_instruments/instrument.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-##
+#
 # instrument.py: Provides base class for all instruments.
-##
+#
 # © 2013-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
-##
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -20,14 +20,11 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
-##
+#
+#
 
 # IMPORTS #####################################################################
 
-import serial
-import time
-import struct
 import socket
 import urlparse
 from contextlib import contextmanager
@@ -41,7 +38,6 @@ from instruments.abstract_instruments.comm import (
     GPIBCommunicator,
     AbstractCommunicator,
     USBTMCCommunicator,
-    SerialCommunicator,
     serial_manager
 )
 
@@ -89,17 +85,22 @@ class Instrument(object):
             raise TypeError('Instrument must be initialized with a filelike '
                             'object that is a subclass of '
                             'AbstractCommunicator.')
-        self.prompt = None
+        self._prompt = None
         self.terminator = "\n"
-    
-    ## COMMAND-HANDLING METHODS ##
+
+    # COMMAND-HANDLING METHODS #
 
     def _ack_expected(self, msg=""):
         return None
 
-    @contextmanager
-    def _sendcmd_manager(self, cmd):
-        yield
+    def sendcmd(self, cmd):
+        """
+        Sends a command without waiting for a response.
+
+        :param str cmd: String containing the command to
+            be sent.
+        """
+        self._file.sendcmd(str(cmd))
         ack_expected = self._ack_expected(cmd)
         if ack_expected is not None:
             ack = self.read()
@@ -111,22 +112,12 @@ class Instrument(object):
             if prompt != self.prompt:
                 raise IOError("Incorrect prompt message received: got {} "
                               "expected {}".format(prompt, self.prompt))
-    
-    def sendcmd(self, cmd):
-        """
-        Sends a command without waiting for a response. 
-        
-        :param str cmd: String containing the command to
-            be sent.
-        """
-        with self._sendcmd_manager(cmd):
-            self._file.sendcmd(str(cmd))
-        
+
     def query(self, cmd, size=-1):
         """
         Executes the given query.
-        
-        :param str cmd: String containing the query to 
+
+        :param str cmd: String containing the query to
             execute.
         :param int size: Number of bytes to be read. Default is read until
             termination character is found.
@@ -153,7 +144,7 @@ class Instrument(object):
     def read(self, size=-1):
         """
         Read the last line.
-        
+
         :param int size: Number of bytes to be read. Default is read until
             termination character is found.
         :return: The result of the read as returned by the
@@ -169,53 +160,53 @@ class Instrument(object):
         :rtype: `str`
         """
         return self._file.readline()
-        
-    ## PROPERTIES ##
-    
+
+    # PROPERTIES #
+
     @property
     def timeout(self):
-        '''
+        """
         Gets/sets the communication timeout for this instrument. Note that
         setting this value after opening the connection is not supported for
         all connection types.
-        
+
         :type: `int`
-        '''
+        """
         return self._file.timeout
 
     @timeout.setter
     def timeout(self, newval):
         self._file.timeout = newval
-    
+
     @property
     def address(self):
-        '''
+        """
         Gets/sets the target communication of the instrument.
-        
+
         This is useful for situations when running straight from a Python shell
         and your instrument has enumerated with a different address. An example
         when this can happen is if you are using a USB to Serial adapter and
         you disconnect/reconnect it.
-        
+
         :type: `int` for GPIB address, `str` for other
-        '''
+        """
         return self._file.address
 
     @address.setter
     def address(self, newval):
         self._file.address = newval
-            
+
     @property
     def terminator(self):
-        '''
+        """
         Gets/sets the terminator used for communication.
-        
-        For communication options where this is applicable, the value 
-        corresponds to the ASCII character used for termination in decimal 
+
+        For communication options where this is applicable, the value
+        corresponds to the ASCII character used for termination in decimal
         format. Example: 10 sets the character to NEWLINE.
-        
-        :type: `int`, or `str` for GPIB adapters. 
-        '''
+
+        :type: `int`, or `str` for GPIB adapters.
+        """
         return self._file.terminator
 
     @terminator.setter
@@ -245,59 +236,66 @@ class Instrument(object):
     def prompt(self, newval):
         self._prompt = newval
 
-    ## BASIC I/O METHODS ##
-    
+    # BASIC I/O METHODS #
+
     def write(self, msg):
-        '''
-        Write data string to GPIB connected instrument.
-        This function sends all the necessary GI-GPIB adapter internal commands
-        that are required for the specified instrument.  
-        '''
-        self._file.write(msg)        
-        
+        """
+        Write data string to the connected instrument. This will call
+        the write method for the attached filelike object. This will typically
+        bypass attaching any termination characters or other communication
+        channel related work.
+
+        .. seealso:: `Instrument.sendcmd` if you wish to send a string to the
+        instrument, while still having InstrumentKit handle termination
+        characters and other communication channel related work.
+
+        :param str msg: String that will be written to the filelike object
+            (`Instrument._file`) attached to this instrument.
+        """
+        self._file.write(msg)
+
     def binblockread(self, data_width, fmt=None):
-        '''
+        """"
         Read a binary data block from attached instrument.
         This requires that the instrument respond in a particular manner
         as EOL terminators naturally can not be used in binary transfers.
-        
+
         The format is as follows:
         #{number of following digits:1-9}{num of bytes to be read}{data bytes}
 
         :param int data_width: Specify the number of bytes wide each data
-            point is. One of [1,2].
-        
+            point is. One of [1,2,4].
+
         :param str fmt: Format string as specified by the :mod:`struct` module,
             or `None` to choose a format automatically based on the data
-            width.        
-        '''
-        #if(data_width not in [1,2]):
-        #    print 'Error: Data width must be 1 or 2.'
-        #    return 0
+            width. Typically you can just specify `data_width` and leave this
+            default.
+        """
         # This needs to be a # symbol for valid binary block
         symbol = self._file.read(1)
-        if(symbol != '#'): # Check to make sure block is valid
+        if symbol != '#':  # Check to make sure block is valid
             raise IOError('Not a valid binary block start. Binary blocks '
-                                'require the first character to be #.')
+                          'require the first character to be #.')
         else:
             # Read in the num of digits for next part
             digits = int(self._file.read(1))
-            
+
             # Read in the num of bytes to be read
             num_of_bytes = int(self._file.read(digits))
-            
+
             # Make or use the required format string.
             if fmt is None:
                 fmt = _DEFAULT_FORMATS[data_width]
-                
+
             # Read in the data bytes, and pass them to numpy using the specified
             # data type (format).
             return np.frombuffer(self._file.read(num_of_bytes), dtype=fmt)
-            
-    ## CLASS METHODS ##
 
-    URI_SCHEMES = ['serial', 'tcpip', 'gpib+usb', 'gpib+serial', 'visa', 'file', 'usbtmc']
-    
+    # CLASS METHODS #
+
+    URI_SCHEMES = ['serial', 'tcpip', 'gpib+usb',
+                   'gpib+serial', 'visa', 'file', 'usbtmc']
+
     @classmethod
     def open_from_uri(cls, uri):
         """
@@ -306,7 +304,7 @@ class Instrument(object):
         followed by a location that is interpreted differently for each
         scheme. The following examples URIs demonstrate the currently supported
         schemes and location formats::
-        
+
             serial://COM3
             serial:///dev/ttyACM0
             tcpip://192.168.0.10:4100
@@ -320,28 +318,28 @@ class Instrument(object):
         using the query parameter ``baud=``, as in the example
         ``serial://COM9?baud=115200``. If not specified, the baud rate
         is assumed to be 115200.
-            
+
         :param str uri: URI for the instrument to be loaded.
         :rtype: `Instrument`
-        
+
         .. seealso::
             `PySerial`_ documentation for serial port URI format
-            
+
         .. _PySerial: http://pyserial.sourceforge.net/
         """
         # Make sure that urlparse knows that we want query strings.
         for scheme in cls.URI_SCHEMES:
             if scheme not in urlparse.uses_query:
                 urlparse.uses_query.append(scheme)
-        
+
         # Break apart the URI using urlparse. This returns a named tuple whose
         # parts describe the incoming URI.
         parsed_uri = urlparse.urlparse(uri)
-        
+
         # We always want the query string to provide keyword args to the
         # class method.
         # FIXME: This currently won't work, as everything is strings,
-        #        but the other class methods expect ints or floats, depending. 
+        #        but the other class methods expect ints or floats, depending.
         kwargs = urlparse.parse_qs(parsed_uri.query)
         if parsed_uri.scheme == "serial":
             # Ex: serial:///dev/ttyACM0
@@ -359,7 +357,7 @@ class Instrument(object):
                 kwargs['baud'] = int(kwargs['baud'][0])
             else:
                 kwargs['baud'] = 115200
-                    
+
             return cls.open_serial(
                 dev_name,
                 **kwargs)
@@ -368,7 +366,8 @@ class Instrument(object):
             host, port = parsed_uri.netloc.split(":")
             port = int(port)
             return cls.open_tcpip(host, port, **kwargs)
-        elif parsed_uri.scheme == "gpib+usb" or parsed_uri.scheme == "gpib+serial":
+        elif parsed_uri.scheme == "gpib+usb" \
+                or parsed_uri.scheme == "gpib+serial":
             # Ex: gpib+usb://COM3/15
             #     scheme="gpib+usb", netloc="COM3", path="/15"
             # Make a new device path by joining the netloc (if any)
@@ -390,23 +389,25 @@ class Instrument(object):
             # Ex: usbtmc can take URIs exactly like visa://.
             return cls.open_visa(parsed_uri.netloc, **kwargs)
         elif parsed_uri.scheme == 'file':
-            return cls.open_file(os.path.join(parsed_uri.netloc, 
-                                               parsed_uri.path), **kwargs)
+            return cls.open_file(os.path.join(
+                parsed_uri.netloc,
+                parsed_uri.path
+            ), **kwargs)
         else:
             raise NotImplementedError("Invalid scheme or not yet "
-                                          "implemented.")
-    
+                                      "implemented.")
+
     @classmethod
     def open_tcpip(cls, host, port):
         """
         Opens an instrument, connecting via TCP/IP to a given host and TCP port.
-        
+
         :param str host: Name or IP address of the instrument.
         :param int port: TCP port on which the insturment is listening.
-        
+
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
-        
+
         .. seealso::
             `~socket.socket.connect` for description of `host` and `port`
             parameters in the TCP/IP address family.
@@ -414,42 +415,42 @@ class Instrument(object):
         conn = socket.socket()
         conn.connect((host, port))
         return cls(SocketCommunicator(conn))
-        
+
     @classmethod
-    def open_serial(cls, port, baud, timeout=3, writeTimeout=3):
+    def open_serial(cls, port, baud, timeout=3, write_timeout=3):
         """
         Opens an instrument, connecting via a physical or emulated serial port.
         Note that many instruments which connect via USB are exposed to the
         operating system as serial ports, so this method will very commonly
         be used for connecting instruments via USB.
-        
+
         :param str port: Name of the the port or device file to open a
             connection on. For example, ``"COM10"`` on Windows or
             ``"/dev/ttyUSB0"`` on Linux.
         :param int baud: The baud rate at which instrument communicates.
         :param float timeout: Number of seconds to wait when reading from the
             instrument before timing out.
-        :param float writeTimeout: Number of seconds to wait when writing to the
+        :param float write_timeout: Number of seconds to wait when writing to the
             instrument before timing out.
-        
+
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
-        
+
         .. seealso::
             `~serial.Serial` for description of `port`, baud rates and timeouts.
         """
-        ser = serial_manager.new_serial_connection(port, 
-                                     baud,
-                                     timeout, 
-                                     writeTimeout)
+        ser = serial_manager.new_serial_connection(port,
+                                                   baud=baud,
+                                                   timeout=timeout,
+                                                   write_timeout=write_timeout)
         return cls(ser)
-    
+
     @classmethod
-    def open_gpibusb(cls, port, gpib_address, timeout=3, writeTimeout=3):
+    def open_gpibusb(cls, port, gpib_address, timeout=3, write_timeout=3):
         """
         Opens an instrument, connecting via a
         `Galvant Industries GPIB-USB adapter`_.
-        
+
         :param str port: Name of the the port or device file to open a
             connection on. Note that because the GI GPIB-USB
             adapter identifies as a serial port to the operating system, this
@@ -458,22 +459,23 @@ class Instrument(object):
             the instrument.
         :param float timeout: Number of seconds to wait when reading from the
             instrument before timing out.
-        :param float writeTimeout: Number of seconds to wait when writing to the
+        :param float write_timeout: Number of seconds to wait when writing to the
             instrument before timing out.
-        
+
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
-        
+
         .. seealso::
             `~serial.Serial` for description of `port` and timeouts.
-            
+
         .. _Galvant Industries GPIB-USB adapter: http://galvant.ca/shop/gpibusb/
         """
-        ser = serialManager.newSerialConnection(port,
-                timeout=timeout,
-                 writeTimeout=writeTimeout)
+        ser = serial_manager.newSerialConnection(port,
+                                                 baud=460800,
+                                                 timeout=timeout,
+                                                 write_timeout=write_timeout)
         return cls(GPIBCommunicator(ser, gpib_address))
-        
+
     @classmethod
     def open_gpibethernet(cls, host, port, gpib_address):
         conn = socket.socket()
@@ -486,23 +488,23 @@ class Instrument(object):
         Opens an instrument, connecting using the VISA library. Note that
         `PyVISA`_ and a VISA implementation must both be present and installed
         for this method to function.
-        
+
         :param str resource_name: Name of a VISA resource representing the
             given instrument.
-        
+
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
-        
+
         .. seealso::
             `National Instruments help page on VISA resource names
             <http://zone.ni.com/reference/en-XX/help/371361J-01/lvinstio/visa_resource_name_generic/>`_.
-            
+
         .. _PyVISA: http://pyvisa.sourceforge.net/
         """
         if visa is None:
             raise ImportError("PyVISA is required for loading VISA "
-                                "instruments.")
-        if int(visa.__version__.replace('.',''))>= 160:
+                              "instruments.")
+        if int(visa.__version__.replace('.', '')) >= 160:
             ins = visa.ResourceManager().open_resource(resource_name)
         else:
             ins = visa.instrument(resource_name)
@@ -522,7 +524,7 @@ class Instrument(object):
     def open_usb(cls, vid, pid):
         """
         Opens an instrument, connecting via a raw USB stream.
-        
+
         .. note::
             Note that raw USB a very uncommon of connecting to instruments,
             even for those that are connected by USB. Most will identify as
@@ -533,16 +535,16 @@ class Instrument(object):
             kernel module is loaded. On Windows, some such devices can be opened
             using the VISA library and the `~instruments.Instrument.open_visa`
             method.
-        
+
         :param str vid: Vendor ID of the USB device to open.
         :param int pid: Product ID of the USB device to open.
-        
+
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
         """
         if usb is None:
             raise ImportError("USB support not imported. Do you have PyUSB "
-                                "version 1.0 or later?")
+                              "version 1.0 or later?")
 
         dev = usb.core.find(idVendor=vid, idProduct=pid)
         if dev is None:
@@ -554,24 +556,24 @@ class Instrument(object):
         # Copied from the tutorial at:
         #     http://pyusb.sourceforge.net/docs/1.0/tutorial.html
         cfg = dev.get_active_configuration()
-        interface_number = cfg[(0,0)].bInterfaceNumber
+        interface_number = cfg[(0, 0)].bInterfaceNumber
         alternate_setting = usb.control.get_interface(dev, interface_number)
         intf = usb.util.find_descriptor(
-            cfg, bInterfaceNumber = interface_number,
-            bAlternateSetting = alternate_setting
+            cfg, bInterfaceNumber=interface_number,
+            bAlternateSetting=alternate_setting
         )
 
         ep = usb.util.find_descriptor(
             intf,
-            custom_match = lambda e: \
-                usb.util.endpoint_direction(e.bEndpointAddress) == \
+            custom_match=lambda e:
+                usb.util.endpoint_direction(e.bEndpointAddress) ==
                 usb.util.ENDPOINT_OUT
-            )
+        )
         if ep is None:
             raise IOError("USB descriptor not found.")
 
         return cls(USBCommunicator(ep))
-        
+
     @classmethod
     def open_file(cls, filename):
         """
@@ -579,9 +581,9 @@ class Instrument(object):
         be read from and written to in order to communicate with the
         instrument. This may be the case, for instance, if the instrument
         is connected by the Linux ``usbtmc`` kernel driver.
-        
+
         :param str filename: Name of the character device to open.
-        
+
         :rtype: `Instrument`
         :return: Object representing the connected instrument.
         """

--- a/instruments/instruments/abstract_instruments/instrument.py
+++ b/instruments/instruments/abstract_instruments/instrument.py
@@ -39,6 +39,7 @@ from instruments.abstract_instruments.comm import (
     USBTMCCommunicator,
     serial_manager
 )
+from instruments.errors import AcknowledgementError, PromptError
 
 import os
 
@@ -104,13 +105,17 @@ class Instrument(object):
         if ack_expected is not None:
             ack = self.read()
             if ack != ack_expected:
-                raise IOError("Incorrect ACK message received: got {} "
-                              "expected {}".format(ack, ack_expected))
+                raise AcknowledgementError(
+                        "Incorrect ACK message received: got {} "
+                        "expected {}".format(ack, ack_expected)
+                )
         if self.prompt is not None:
             prompt = self.read()
             if prompt != self.prompt:
-                raise IOError("Incorrect prompt message received: got {} "
-                              "expected {}".format(prompt, self.prompt))
+                raise PromptError(
+                        "Incorrect prompt message received: got {} "
+                        "expected {}".format(prompt, self.prompt)
+                )
 
     def query(self, cmd, size=-1):
         """
@@ -128,16 +133,20 @@ class Instrument(object):
         if ack_expected is not None:
             ack = self._file.query(cmd)
             if ack != ack_expected:
-                raise IOError("Incorrect ACK message received: got {} "
-                              "expected {}".format(ack, ack_expected))
+                raise AcknowledgementError(
+                        "Incorrect ACK message received: got {} "
+                        "expected {}".format(ack, ack_expected)
+                )
             value = self.read(size)
         else:
             value = self._file.query(cmd, size)
         if self.prompt is not None:
             prompt = self.read()
             if prompt is not self.prompt:
-                raise IOError("Incorrect prompt message received: got {} "
-                              "expected {}".format(prompt, self.prompt))
+                raise PromptError(
+                        "Incorrect prompt message received: got {} "
+                        "expected {}".format(prompt, self.prompt)
+                )
         return value
 
     def read(self, size=-1):

--- a/instruments/instruments/abstract_instruments/instrument.py
+++ b/instruments/instruments/abstract_instruments/instrument.py
@@ -83,7 +83,15 @@ class Instrument(object):
     # This can and should be overriden in subclasses for instruments
     # that use different terminators.
     _terminator = "\n"
-    
+
+    # some instruments issue prompt characters to indicate that it is ready for input. This must be eliminated from
+    # the response
+    _prompt = ""
+
+    # Certain instruments (such as those produced by Thorlabs) echo the command back before producing the response.
+    # this boolean handles that change.
+    _echo = False
+
     def __init__(self, filelike):
         # Check to make sure filelike is a subclass of AbstractCommunicator
         if isinstance(filelike, AbstractCommunicator):
@@ -115,7 +123,12 @@ class Instrument(object):
             connected instrument.
         :rtype: `str`
         """
-        return self._file.query(cmd, size)
+        if not self._echo:
+            return self._file.query(cmd, size).replace(self.prompt, "")
+        else:
+            response = self._file.query(cmd, size)
+            response = self.readline().replace(self.prompt, "").replace(cmd, "").replace(self.terminator, "")
+            return response
 
     def read(self, size=-1):
         """
@@ -129,6 +142,13 @@ class Instrument(object):
         """
         return self._file.read(size)
 
+    def readline(self):
+        """
+        Read a full line
+        :return: the read line
+        :rtype: `str`
+        """
+        return self._file.readline()
         
     ## PROPERTIES ##
     
@@ -142,6 +162,7 @@ class Instrument(object):
         :type: `int`
         '''
         return self._file.timeout
+
     @timeout.setter
     def timeout(self, newval):
         self._file.timeout = newval
@@ -159,6 +180,7 @@ class Instrument(object):
         :type: `int` for GPIB address, `str` for other
         '''
         return self._file.address
+
     @address.setter
     def address(self, newval):
         self._file.address = newval
@@ -175,10 +197,42 @@ class Instrument(object):
         :type: `int`, or `str` for GPIB adapters. 
         '''
         return self._file.terminator
+
     @terminator.setter
     def terminator(self, newval):
         self._file.terminator = newval
-        
+
+    @property
+    def prompt(self):
+        '''
+        Gets/sets the prompt used for communication.
+
+        For communication options where this is applicable, the value
+        corresponds to the character used for prompt
+
+        :type: `int`, or `str` for GPIB adapters.
+        '''
+        if not hasattr(self._file, 'prompt'):
+            self._file.prompt = self._prompt
+        return self._file.prompt
+
+    @prompt.setter
+    def prompt(self, newval):
+        self._file.prompt = newval
+
+    @property
+    def echo(self):
+        '''
+        Gets/sets the echo setting
+        :type: `bool`
+        '''
+
+        return self._echo
+
+    @echo.setter
+    def echo(self, newval):
+        self._echo = newval
+
     ## BASIC I/O METHODS ##
     
     def write(self, msg):

--- a/instruments/instruments/errors.py
+++ b/instruments/instruments/errors.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+##
+# errors.py: Custom exception errors used by various instruments.
+##
+# © 2016 Steven Casagrande (scasagrande@galvant.ca).
+#
+# This file is a part of the InstrumentKit project.
+# Licensed under the AGPL version 3.
+##
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+##
+
+# IMPORTS #####################################################################
+
+# CLASSES #####################################################################
+
+
+class AcknowledgementError(IOError):
+    pass
+
+
+class PromptError(IOError):
+    pass

--- a/instruments/instruments/tests/test_property_factories.py
+++ b/instruments/instruments/tests/test_property_factories.py
@@ -187,7 +187,7 @@ def test_bool_property_writeonly_writing_passes():
     
     mock_instrument = BoolMock({'MOCK1?': 'OFF'})
     
-    mock_instrument.mock1 = "OFF"
+    mock_instrument.mock1 = False
 
 ## Enum Property Factories ##
     

--- a/instruments/instruments/tests/test_property_factories.py
+++ b/instruments/instruments/tests/test_property_factories.py
@@ -567,6 +567,28 @@ def test_unitful_property_maximum_value():
 
     mock_inst.unitful_property = 11
 
+def test_unitful_property_input_decoration():
+    class UnitfulMock(MockInstrument):
+        def input_decorator(input):
+            return '1'
+        a = unitful_property('MOCK:A', pq.hertz, input_decoration=input_decorator)
+
+    mock_instrument = UnitfulMock({'MOCK:A?': 'garbage'})
+
+    eq_(mock_instrument.a, 1 * pq.Hz)
+
+def test_unitful_property_output_decoration():
+    class UnitfulMock(MockInstrument):
+        def output_decorator(input):
+            return '1'
+        a = unitful_property('MOCK:A', pq.hertz, output_decoration=output_decorator)
+
+    mock_instrument = UnitfulMock()
+
+    mock_instrument.a = 345 * pq.hertz
+
+    eq_(mock_instrument.value, 'MOCK:A 1\n')
+
 ## String Property ##
 
 def test_string_property_basics():

--- a/instruments/instruments/tests/test_property_factories.py
+++ b/instruments/instruments/tests/test_property_factories.py
@@ -212,6 +212,19 @@ def test_enum_property():
     
     eq_(mock.value, 'MOCK:A?\nMOCK:B?\nMOCK:A bb\nMOCK:B aa\nMOCK:B bb\n')
 
+@raises(ValueError)
+def test_enum_property_invalid():
+    class SillyEnum(Enum):
+        a = 'aa'
+        b = 'bb'
+
+    class EnumMock(MockInstrument):
+        a = enum_property('MOCK:A', SillyEnum)
+
+    mock = EnumMock({'MOCK:A?': 'aa', 'MOCK:B?': 'bb'})
+
+    mock.a = 'c'
+
 def test_enum_property_set_fmt():
     class SillyEnum(Enum):
         a = 'aa'
@@ -524,6 +537,35 @@ def test_unitful_property_readonly_reading_passes():
     mock_inst = UnitfulMock({'MOCK?':'1'})
     
     eq_(mock_inst.unitful_property, 1 * pq.hertz)
+
+def test_unitful_property_valid_range():
+    class UnitfulMock(MockInstrument):
+        unitful_property = unitful_property('MOCK', pq.hertz, valid_range=(0, 10))
+
+    mock_inst = UnitfulMock()
+
+    mock_inst.unitful_property = 0
+    mock_inst.unitful_property = 10
+
+    eq_(mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0, 10))
+
+@raises(ValueError)
+def test_unitful_property_minimum_value():
+    class UnitfulMock(MockInstrument):
+        unitful_property = unitful_property('MOCK', pq.hertz, valid_range=(0, 10))
+
+    mock_inst = UnitfulMock()
+
+    mock_inst.unitful_property = -1
+
+@raises(ValueError)
+def test_unitful_property_maximum_value():
+    class UnitfulMock(MockInstrument):
+        unitful_property = unitful_property('MOCK', pq.hertz, valid_range=(0, 10))
+
+    mock_inst = UnitfulMock()
+
+    mock_inst.unitful_property = 11
 
 ## String Property ##
 

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-##
+#
 # __init__.py: Tests for Thorlabs-brand instruments.
-##
+#
 # © 2014-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
-##
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -20,9 +20,9 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+#
 
-## IMPORTS ####################################################################
+# IMPORTS ####################################################################
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq
@@ -30,7 +30,7 @@ from nose.tools import raises
 from flufl.enum import IntEnum
 import quantities as pq
 
-## TESTS ######################################################################
+# TESTS ######################################################################
 
 
 def test_lcc25_name():
@@ -616,7 +616,7 @@ def test_sc10_mode_invalid2():
 
 def test_sc10_trigger():
     with expected_protocol(
-        ik.thorlabs.SC10, 
+        ik.thorlabs.SC10,
         [
             "trig?",
             "trig=1"
@@ -950,8 +950,8 @@ def test_tc200_temperature():
         ],
         sep="\r"
     ) as tc:
-        assert tc.temperature == 30.0*pq.degC
-        tc.temperature = 40*pq.degC
+        assert tc.temperature == 30.0 * pq.degC
+        tc.temperature = 40 * pq.degC
 
 
 @raises(ValueError)
@@ -968,7 +968,7 @@ def test_tc200_temperature_range():
         ],
         sep="\r"
     ) as tc:
-        tc.temperature = 50*pq.degC
+        tc.temperature = 50 * pq.degC
 
 
 def test_tc200_pid():
@@ -1283,8 +1283,8 @@ def test_tc200_max_power():
         ],
         sep="\r"
     ) as tc:
-        assert tc.max_power == 15.0*pq.W
-        tc.max_power = 12*pq.W
+        assert tc.max_power == 15.0 * pq.W
+        tc.max_power = 12 * pq.W
 
 
 @raises(ValueError)
@@ -1335,9 +1335,9 @@ def test_tc200_max_temperature():
         ],
         sep="\r"
     ) as tc:
-        assert tc.max_temperature == 200.0*pq.degC
+        assert tc.max_temperature == 200.0 * pq.degC
         print "second test"
-        tc.max_temperature = 180*pq.degC
+        tc.max_temperature = 180 * pq.degC
 
 
 @raises(ValueError)

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -33,26 +33,6 @@ import quantities as pq
 ## TESTS ######################################################################
 
 
-@raises(ValueError)
-def test_voltage_latch_min():
-    ik.thorlabs.voltage_latch(-2)
-
-
-@raises(ValueError)
-def test_voltage_latch_max():
-    ik.thorlabs.voltage_latch(9999)
-
-
-@raises(ValueError)
-def test_slot_latch_min():
-    ik.thorlabs.slot_latch(-2)
-
-
-@raises(ValueError)
-def test_slot_latch_max():
-    ik.thorlabs.slot_latch(9999)
-
-
 def test_lcc25_name():
     with expected_protocol(
         ik.thorlabs.LCC25,
@@ -66,7 +46,7 @@ def test_lcc25_name():
         ],
         sep="\r"
     ) as lcc:
-        name = lcc.name()
+        name = lcc.name
         assert name == "bloopbloop", "got {} expected bloopbloop".format(name)
 
 
@@ -142,7 +122,7 @@ def test_lcc25_mode():
         lcc.mode = ik.thorlabs.LCC25.Mode.voltage1
 
 
-@raises(TypeError)
+@raises(ValueError)
 def test_lcc25_mode_invalid():
     with expected_protocol(
         ik.thorlabs.LCC25,
@@ -152,7 +132,7 @@ def test_lcc25_mode_invalid():
         lcc.mode = "blo"
 
 
-@raises(TypeError)
+@raises(ValueError)
 def test_lcc25_mode_invalid2():
     with expected_protocol(
         ik.thorlabs.LCC25,
@@ -160,7 +140,7 @@ def test_lcc25_mode_invalid2():
         []
     ) as lcc:
         blo = IntEnum("blo", "beep boop bop")
-        lcc.mode = blo.beep
+        lcc.mode = blo[0]
 
 
 def test_lcc25_enable():
@@ -274,9 +254,9 @@ def test_lcc25_voltage1():
 
 
 def test_check_cmd():
-    assert ik.thorlabs.check_cmd("blo") == 1
-    assert ik.thorlabs.check_cmd("CMD_NOT_DEFINED") == 0
-    assert ik.thorlabs.check_cmd("CMD_ARG_INVALID") == 0
+    assert ik.thorlabs._utils.check_cmd("blo") == 1
+    assert ik.thorlabs._utils.check_cmd("CMD_NOT_DEFINED") == 0
+    assert ik.thorlabs._utils.check_cmd("CMD_ARG_INVALID") == 0
 
 
 def test_lcc25_voltage2():
@@ -442,7 +422,7 @@ def test_lcc25_save():
         lcc.save()
 
 
-def test_lcc25_save_settings():
+def test_lcc25_set_settings():
     with expected_protocol(
         ik.thorlabs.LCC25,
         [
@@ -455,6 +435,17 @@ def test_lcc25_save_settings():
         sep="\r"
     ) as lcc:
         lcc.set_settings(2)
+
+
+@raises(ValueError)
+def test_lcc25_set_settings_invalid():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        [],
+        [],
+        sep="\r"
+    ) as lcc:
+        lcc.set_settings(5)
 
 
 def test_lcc25_get_settings():
@@ -470,6 +461,17 @@ def test_lcc25_get_settings():
         sep="\r"
     ) as lcc:
         lcc.get_settings(2)
+
+
+@raises(ValueError)
+def test_lcc25_get_settings_invalid():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        [],
+        [],
+        sep="\r"
+    ) as lcc:
+        lcc.get_settings(5)
 
 
 def test_lcc25_test_mode():

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -26,107 +26,255 @@
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq
-
-import cStringIO as StringIO
+from nose.tools import raises
+from flufl.enum import IntEnum
 import quantities as pq
 
 ## TESTS ######################################################################
+
+
+@raises(ValueError)
+def test_voltage_latch_min():
+    ik.thorlabs.voltage_latch(-2)
+
+
+@raises(ValueError)
+def test_voltage_latch_max():
+    ik.thorlabs.voltage_latch(9999)
+
+
+@raises(ValueError)
+def test_slot_latch_min():
+    ik.thorlabs.slot_latch(-2)
+
+
+@raises(ValueError)
+def test_slot_latch_max():
+    ik.thorlabs.slot_latch(9999)
+
+
+def test_lcc25_name():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "*idn?\r",
+        "*idn?\r>bloopbloop\r>\r"
+    ) as lcc:
+        assert lcc.name() == "bloopbloop"
+
 
 def test_lcc25_frequency():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "freq?\rfreq=10.0\r",
-        "\r>20\r"
+        "freq?\r>20\r"
     ) as lcc:
         unit_eq(lcc.frequency, pq.Quantity(20, "Hz"))
         lcc.frequency = 10.0
+
+
+@raises(ValueError)
+def test_lcc25_frequency_lowlimit():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "freq=0.0\r",
+        "freq=0.0\r>\r"
+    ) as lcc:
+        lcc.frequency = 0.0
+
+
+@raises(ValueError)
+def test_lcc25_frequency_highlimit():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "freq=160.0\r",
+        "freq=160.0\r>\r"
+    ) as lcc:
+        lcc.frequency = 160.0
+
 
 def test_lcc25_mode():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "mode?\rmode=1\r",
-        "\r>2\r"
+        "mode?\r>2\r"
     ) as lcc:
         assert lcc.mode == ik.thorlabs.LCC25.Mode.voltage2
         lcc.mode = ik.thorlabs.LCC25.Mode.voltage1
+
+
+@raises(TypeError)
+def test_lcc25_mode_invalid():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "mode=10\r",
+        "mode=10\r>0\r>\r"
+    ) as lcc:
+        lcc.mode = "blo"
+
+
+@raises(TypeError)
+def test_lcc25_mode_invalid2():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "mode=10\r",
+        "mode=10\r>0\r>\r"
+    ) as lcc:
+        blo = IntEnum("blo", "beep boop bop")
+        lcc.mode = blo.beep
+
 
 def test_lcc25_enable():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "enable?\renable=1\r",
-        ">\r>0\r"
+        "enable?>\r>0\r"
     ) as lcc:
         assert lcc.enable == False
         lcc.enable = True
+
+
+@raises(TypeError)
+def test_lcc25_enable_type():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "blo\r",
+        "blo\rblo\r>\r"
+    ) as lcc:
+        lcc.enable = "blo"
+
 
 def test_lcc25_extern():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "extern?\rextern=1\r",
-        ">\r>0\r"
+        "extern?>\r>0\r"
     ) as lcc:
         assert lcc.extern == False
         lcc.extern = True
+
+
+@raises(TypeError)
+def test_tc200_extern_type():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "blo\r",
+        "blo\rblo\r>\r"
+    ) as tc:
+        tc.extern = "blo"
+
 
 def test_lcc25_remote():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "remote?\rremote=1\r",
-        ">\r>0\r"
+        "remote?>\r>0\r"
     ) as lcc:
         assert lcc.remote == False
         lcc.remote = True
+
+
+@raises(TypeError)
+def test_tc200_remote_type():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "blo\r",
+        "blo\rblo\r>\r"
+    ) as tc:
+        tc.remote = "blo"
+
 
 def test_lcc25_voltage1():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "volt1?\rvolt1=10.0\r",
-        "\r20\r"
+        "volt1?\r>20\r"
     ) as lcc:
         unit_eq(lcc.voltage1, pq.Quantity(20, "V"))
         lcc.voltage1 = 10.0
+
+
+def test_check_cmd():
+    assert ik.thorlabs.check_cmd("blo") == 1
+    assert ik.thorlabs.check_cmd("CMD_NOT_DEFINED") == 0
+    assert ik.thorlabs.check_cmd("CMD_ARG_INVALID") == 0
+
 
 def test_lcc25_voltage2():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "volt2?\rvolt2=10.0\r",
-        "\r20\r"
+        "volt2?\r>20\r"
     ) as lcc:
         unit_eq(lcc.voltage2, pq.Quantity(20, "V"))
         lcc.voltage2 = 10.0
+
 
 def test_lcc25_minvoltage():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "min?\rmin=10.0\r",
-        "\r>20\r"
+        "min?\r>20\r"
     ) as lcc:
         unit_eq(lcc.min_voltage, pq.Quantity(20, "V"))
         lcc.min_voltage = 10.0
+
+
+def test_lcc25_maxvoltage():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "max?\rmax=10.0\r",
+        "max?\r>20\r"
+    ) as lcc:
+        unit_eq(lcc.max_voltage, pq.Quantity(20, "V"))
+        lcc.max_voltage = 10.0
+
 
 def test_lcc25_dwell():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "dwell?\rdwell=10\r",
-        "\r>20\r"
+        "dwell?\r>20\r"
     ) as lcc:
         unit_eq(lcc.dwell, pq.Quantity(20, "ms"))
         lcc.dwell = 10
+
+
+@raises(ValueError)
+def test_lcc25_dwell_positive():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "dwell=-10\r",
+        "dwell=-10\r>\r"
+    ) as lcc:
+        lcc.dwell = -10
+
 
 def test_lcc25_increment():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "increment?\rincrement=10.0\r",
-        "\r>20\r"
+        "increment?\r>20\r"
     ) as lcc:
         unit_eq(lcc.increment, pq.Quantity(20, "V"))
         lcc.increment = 10.0
+
+
+@raises(ValueError)
+def test_lcc25_increment_positive():
+    with expected_protocol(
+        ik.thorlabs.LCC25,
+        "increment=-10\r",
+        "increment=-10\r>\r"
+    ) as lcc:
+        lcc.increment = -10
+
+
 
 def test_lcc25_default():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "default\r",
-        "\r>\r"
+        "default\r>\r"
     ) as lcc:
         lcc.default()
 
@@ -134,151 +282,552 @@ def test_lcc25_save():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "save\r",
-        "\r>\r"
+        "save\r>\r"
     ) as lcc:
         lcc.save()
+
 
 def test_lcc25_save_settings():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "set=2\r",
-        "\r>\r"
+        "set=2\r>\r"
     ) as lcc:
         lcc.set_settings(2)
+
 
 def test_lcc25_get_settings():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "get=2\r",
-        "\r>\r"
+        "get=2\r>\r"
     ) as lcc:
         lcc.get_settings(2)
+
 
 def test_lcc25_test_mode():
     with expected_protocol(
         ik.thorlabs.LCC25,
         "test\r",
-        "\r>\r"
+        "test\r>\r"
     ) as lcc:
         lcc.test_mode()
+
+
+def test_sc10_name():
+    with expected_protocol(
+        ik.thorlabs.SC10,
+        "id?\r",
+        "id?\r>bloopbloop\r>\r"
+    ) as sc:
+        assert sc.name() == "bloopbloop"
+
 
 def test_sc10_enable():
     with expected_protocol(
         ik.thorlabs.SC10,
         "ens?\rens=1\r",
-        "\r>0\r>\r"
+        "ens?\r>0\r>\r"
     ) as sc:
         assert sc.enable == 0
         sc.enable = 1
+
+
+@raises(ValueError)
+def test_sc10_enable_invalid():
+    with expected_protocol(
+        ik.thorlabs.SC10,
+        "ens=10\r",
+        "ens=10\r>0\r>\r"
+    ) as sc:
+        sc.enable = 10
+
 
 def test_sc10_repeat():
     with expected_protocol(
         ik.thorlabs.SC10,
         "rep?\rrep=10\r",
-        "\r>20\r>\r"
+        "rep?\r>20\r>\r"
     ) as sc:
         assert sc.repeat == 20
         sc.repeat = 10
+
+
+@raises(ValueError)
+def test_sc10_repeat_invalid():
+    with expected_protocol(
+        ik.thorlabs.SC10,
+        "rep=-1\r",
+        "rep=-1\r>0\r>\r"
+    ) as sc:
+        sc.repeat = -1
+
 
 def test_sc10_mode():
     with expected_protocol(
         ik.thorlabs.SC10,
         "mode?\rmode=2\r",
-        "\r>1\r>\r"
+        "mode?\r>1\r>\r"
     ) as sc:
         assert sc.mode == ik.thorlabs.SC10.Mode.manual
         sc.mode = ik.thorlabs.SC10.Mode.auto
+
+
+@raises(TypeError)
+def test_sc10_mode_invalid():
+    with expected_protocol(
+        ik.thorlabs.SC10,
+        "mode=10\r",
+        "mode=10\r>0\r>\r"
+    ) as sc:
+        sc.mode = "blo"
+
+
+@raises(TypeError)
+def test_sc10_mode_invalid2():
+    with expected_protocol(
+        ik.thorlabs.SC10,
+        "mode=10\r",
+        "mode=10\r>0\r>\r"
+    ) as sc:
+        blo = IntEnum("blo", "beep boop bop")
+        sc.mode = blo.beep
+
 
 def test_sc10_trigger():
     with expected_protocol(
         ik.thorlabs.SC10, 
         "trig?\rtrig=1\r",
-        "\r>0\r>\r"
+        "trig?\r>0\r>\r"
     ) as sc:
         assert sc.trigger == 0
         sc.trigger = 1
+
+
+@raises(ValueError)
+def test_trigger_check():
+    ik.thorlabs.trigger_check(2)
+
+
+@raises(ValueError)
+def test_time_check_min():
+    ik.thorlabs.check_time(-1)
+
+
+@raises(ValueError)
+def test_time_check_max():
+    ik.thorlabs.check_time(9999999)
+
 
 def test_sc10_out_trigger():
     with expected_protocol(
         ik.thorlabs.SC10,
         "xto?\rxto=1\r",
-        "\r>0\r>\r"
+        "xto?\r>0\r>\r"
     ) as sc:
         assert sc.out_trigger == 0
         sc.out_trigger = 1
+
 
 def test_sc10_open_time():
     with expected_protocol(
         ik.thorlabs.SC10,
         "open?\ropen=10\r",
-        "\r20\r>\r"
+        "open?\r>20\r>\r"
     ) as sc:
         unit_eq(sc.open_time, pq.Quantity(20, "ms"))
         sc.open_time = 10.0
+
 
 def test_sc10_shut_time():
     with expected_protocol(
         ik.thorlabs.SC10,
         "shut?\rshut=10\r",
-        "\r20\r>\r"
+        "shut?\r>20\r>\r"
     ) as sc:
         unit_eq(sc.shut_time, pq.Quantity(20, "ms"))
         sc.shut_time = 10.0
 
-'''
-unit test for baud rate should be done very carefully, testing to change the 
-baud rate to something other then the current baud rate will cause the 
-connection to be unreadable.
+
 def test_sc10_baud_rate():
     with expected_protocol(ik.thorlabs.SC10, "baud?\rbaud=1\r", "\r>0\r>\r") as sc:
-        assert sc.baud_rate ==0
-        sc.baud_rate = 1
-'''
+        assert sc.baud_rate == 9600
+        sc.baud_rate = 115200
+
+
+def test_echo():
+    with expected_protocol(ik.thorlabs.SC10, "baud?\r", "\r>0\r>\r") as sc:
+        assert sc.baud_rate == 9600
+        assert sc.echo == True
+
+
+@raises(ValueError)
+def test_sc10_baud_rate_error():
+    with expected_protocol(ik.thorlabs.SC10, "\rbaud=1\r", "\r>\r") as sc:
+        sc.baud_rate = 115201
+
 
 def test_sc10_closed():
     with expected_protocol(
         ik.thorlabs.SC10,
         "closed?\r",
-        "\r1\r"
+        "closed?\r>1\r>"
     ) as sc:
         assert sc.closed
+
 
 def test_sc10_interlock():
     with expected_protocol(
         ik.thorlabs.SC10,
         "interlock?\r",
-        "\r1\r"
+        "interlock?\r>1\r>"
     ) as sc:
         assert sc.interlock
+
 
 def test_sc10_default():
     with expected_protocol(
         ik.thorlabs.SC10,
         "default\r",
-        "\r1\r"
+        "default\r>1\r>"
     ) as sc:
         assert sc.default()
+
 
 def test_sc10_save():
     with expected_protocol(
         ik.thorlabs.SC10,
         "savp\r",
-        "\r1\r"
+        "savp\r>1\r>"
     ) as sc:
         assert sc.save()
+
 
 def test_sc10_save_mode():
     with expected_protocol(
         ik.thorlabs.SC10,
         "save\r",
-        "\r1\r"
+        "save\r>1\r>"
     ) as sc:
         assert sc.save_mode()
+
 
 def test_sc10_restore():
     with expected_protocol(
         ik.thorlabs.SC10,
         "resp\r",
-        "\r1\r"
+        "resp\r>1\r>"
     ) as sc:
         assert sc.restore()
+
+
+def test_tc200_name():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "*idn?\r",
+        "*idn?\r>bloopbloop\r>\r"
+    ) as tc:
+        assert tc.name() == "bloopbloop"
+
+
+def test_tc200_mode():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "stat?\rmode=cycle\r",
+        "stat?\r>54\r>\r"
+    ) as tc:
+        assert tc.mode == ik.thorlabs.TC200.Mode.normal
+        tc.mode = ik.thorlabs.TC200.Mode.cycle
+
+
+def test_tc200_mode():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "stat?\rmode=cycle\r",
+        "stat?\r>54\r>\r"
+    ) as tc:
+        assert tc.mode == ik.thorlabs.TC200.Mode.normal
+        tc.mode = ik.thorlabs.TC200.Mode.cycle
+
+
+@raises(TypeError)
+def test_tc200_mode_error():
+    with expected_protocol(ik.thorlabs.TC200, 'blo', 'blo') as tc:
+        tc.mode = "blo"
+
+
+@raises(TypeError)
+def test_tc200_mode_error2():
+    with expected_protocol(ik.thorlabs.TC200, 'blo', 'blo') as tc:
+        blo = IntEnum("blo", "beep boop bop")
+        tc.mode = blo.beep
+
+
+def test_tc200_enable():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        ["stat?", "stat?", "ens", "stat?", "ens"],
+        ["stat?\r54\r>\n", "\r54\r>\n", "\r>\n", "\r55\r>\n", "\r>\n"],
+        sep="\r"
+    ) as tc:
+        assert tc.enable == 0
+        tc.enable = True
+        tc.enable = False
+
+
+@raises(TypeError)
+def test_tc200_enable_type():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "blo\r",
+        "blo\rblo\r>\r"
+    ) as tc:
+        tc.enable = "blo"
+
+
+def test_tc200_temperature():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        ["tact?", "tmax?", "tset=40.0"],
+        ["tact?\r>30 C\r>\n", "\r>250\r>", "\r>\r"],
+        sep="\r"
+    ) as tc:
+        assert tc.temperature == 30.0*pq.degC
+        tc.temperature = 40*pq.degC
+
+
+@raises(ValueError)
+def test_tc200_temperature_range():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        ["tmax?", "tset=50.0"],
+        ["tmax?\r>40\r>", "\r>\r"],
+        sep="\r"
+    ) as tc:
+        tc.temperature = 50*pq.degC
+
+
+def test_tc200_pid():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "pid?\rpgain=2\r",
+        "pid?\r>2 0 220 \r>"
+    ) as tc:
+        assert tc.p == 2
+        tc.p = 2
+
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "pid?\rigain=0\r",
+        "pid?\r>2 0 220 \r>\r"
+    ) as tc:
+        assert tc.i == 0
+        tc.i = 0
+
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "pid?\rdgain=220\r",
+        "pid?\r>2 0 220 \r>\r"
+    ) as tc:
+        assert tc.d == 220
+        tc.d = 220
+
+
+@raises(ValueError)
+def test_tc200_pmin():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "pgain=-1\r",
+        "pgain=-1\r>\r"
+    ) as tc:
+        tc.p = -1
+
+
+@raises(ValueError)
+def test_tc200_pmax():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "pgain=260\r",
+        "pgain=260\r>\r"
+    ) as tc:
+        tc.p = 260
+
+
+@raises(ValueError)
+def test_tc200_imin():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "igain=-1\r",
+        "igain=-1\r>\r"
+    ) as tc:
+        tc.i = -1
+
+
+@raises(ValueError)
+def test_tc200_imax():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "igain=260\r",
+        "igain=260\r>\r"
+    ) as tc:
+        tc.i = 260
+
+
+@raises(ValueError)
+def test_tc200_dmin():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "dgain=-1\r",
+        "dgain=-1\r>\r"
+    ) as tc:
+        tc.d = -1
+
+
+@raises(ValueError)
+def test_tc200_dmax():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "dgain=260\r",
+        "dgain=260\r>\r"
+    ) as tc:
+        tc.d = 260
+
+
+def test_tc200_degrees():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        ["stat?", "stat?", "stat?", "unit=c", "unit=f", "unit=k"],
+        ["stat?\r>44\n", "\r>54\n", "\r>0\n", ">\r", ">\r", ">\r"],
+        sep="\r"
+    ) as tc:
+        assert str(tc.degrees).split(" ")[1] == "K"
+        assert str(tc.degrees).split(" ")[1] == "degC"
+        assert tc.degrees == pq.degF
+
+        tc.degrees = pq.degC
+        tc.degrees = pq.degF
+        tc.degrees = pq.degK
+
+
+@raises(TypeError)
+def test_tc200_degrees_invalid():
+
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "unit=blo",
+        "unit=blo>\r"
+    ) as tc:
+        tc.degrees = "blo"
+
+
+def test_tc200_sensor():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "sns?\rsns=ptc100\r",
+        "sns?\r>Sensor = NTC10K, Beta = 5600\r>\r"
+    ) as tc:
+        assert tc.sensor == tc.Sensor.ntc10k
+        tc.sensor = tc.Sensor.ptc100
+
+
+@raises(TypeError)
+def test_tc200_sensor_error():
+    with expected_protocol(ik.thorlabs.TC200, 'blo', 'blo') as tc:
+        tc.sensor = "blo"
+
+
+@raises(TypeError)
+def test_tc200_sensor_error2():
+    with expected_protocol(ik.thorlabs.TC200, 'blo', 'blo') as tc:
+        blo = IntEnum("blo", "beep boop bop")
+        tc.sensor = blo.beep
+
+
+def test_tc200_beta():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "beta?\rbeta=2000\r",
+        "beta?\r>5600\r>\r"
+    ) as tc:
+        assert tc.beta == 5600
+        tc.beta = 2000
+
+
+@raises(ValueError)
+def test_tc200_beta_min():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "beta=200\r",
+        "beta=200\r>\r"
+    ) as tc:
+        tc.beta = 200
+
+
+@raises(ValueError)
+def test_tc200_beta_max():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "beta=20000\r",
+        "beta=20000\r>\r"
+    ) as tc:
+        tc.beta = 20000
+
+
+def test_tc200_max_power():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "pmax?\rPMAX=12.0\r",
+        "pmax?\r>15.0\r>\r"
+    ) as tc:
+        assert tc.max_power == 15.0*pq.W
+        tc.max_power = 12*pq.W
+
+
+@raises(ValueError)
+def test_tc200_power_min():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "PMAX=-2\r",
+        "PMAX=-2\r>\r"
+    ) as tc:
+        tc.max_power = -1
+
+
+@raises(ValueError)
+def test_tc200_power_max():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "PMAX=20000\r",
+        "PMAX=20000\r>\r"
+    ) as tc:
+        tc.max_power = 20000
+
+
+def test_tc200_max_temperature():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "tmax?\rTMAX=180.0\r",
+        "tmax?\r>200.0\r>\r"
+    ) as tc:
+        assert tc.max_temperature == 200.0*pq.degC
+        tc.max_temperature = 180*pq.degC
+
+
+@raises(ValueError)
+def test_tc200_temp_min():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "TMAX=-2\r",
+        "TMAX=-2\r>\r"
+    ) as tc:
+        tc.max_temperature = -1
+
+
+@raises(ValueError)
+def test_tc200_temp_max():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        "TMAX=20000\r",
+        "TMAX=20000\r>\r"
+    ) as tc:
+        tc.max_temperature = 20000

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -411,7 +411,6 @@ def test_lcc25_increment_positive():
         lcc.increment = -10
 
 
-
 def test_lcc25_default():
     with expected_protocol(
         ik.thorlabs.LCC25,
@@ -528,14 +527,8 @@ def test_sc10_enable():
 def test_sc10_enable_invalid():
     with expected_protocol(
         ik.thorlabs.SC10,
-        [
-            # "ens=10"
-        ],
-        [
-            # "ens=10",
-            # "0",
-            # ">"
-        ],
+        [],
+        [],
         sep="\r"
     ) as sc:
         sc.enable = 10
@@ -565,12 +558,8 @@ def test_sc10_repeat():
 def test_sc10_repeat_invalid():
     with expected_protocol(
         ik.thorlabs.SC10,
-        [
-            # "rep=-1\r"
-        ],
-        [
-            # "rep=-1\r>0\r>\r"
-        ],
+        [],
+        [],
         sep="\r"
     ) as sc:
         sc.repeat = -1
@@ -600,14 +589,8 @@ def test_sc10_mode():
 def test_sc10_mode_invalid():
     with expected_protocol(
         ik.thorlabs.SC10,
-        [
-            # "mode=10"
-        ],
-        [
-            # "mode=10",
-            # "0",
-            # ">"
-        ],
+        [],
+        [],
         sep="\r"
     ) as sc:
         sc.mode = "blo"
@@ -617,12 +600,8 @@ def test_sc10_mode_invalid():
 def test_sc10_mode_invalid2():
     with expected_protocol(
         ik.thorlabs.SC10,
-        [
-            # "mode=10\r"
-        ],
-        [
-            # "mode=10\r>0\r>\r"
-        ],
+        [],
+        [],
         sep="\r"
     ) as sc:
         blo = IntEnum("blo", "beep boop bop")
@@ -748,12 +727,8 @@ def test_sc10_baud_rate():
 def test_sc10_baud_rate_error():
     with expected_protocol(
         ik.thorlabs.SC10,
-        [
-            # "\rbaud=1\r"
-        ],
-        [
-            # "\r>\r"
-        ],
+        [],
+        [],
         sep="\r"
     ) as sc:
         sc.baud_rate = 115201

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -3,7 +3,7 @@
 ##
 # __init__.py: Tests for Thorlabs-brand instruments.
 ##
-# © 2014 Steven Casagrande (scasagrande@galvant.ca).
+# © 2014-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
@@ -56,17 +56,35 @@ def test_slot_latch_max():
 def test_lcc25_name():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "*idn?\r",
-        "*idn?\r>bloopbloop\r>\r"
+        [
+            "*idn?"
+        ],
+        [
+            "*idn?",
+            "bloopbloop",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
-        assert lcc.name() == "bloopbloop"
+        name = lcc.name()
+        assert name == "bloopbloop", "got {} expected bloopbloop".format(name)
 
 
 def test_lcc25_frequency():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "freq?\rfreq=10.0\r",
-        "freq?\r>20\r"
+        [
+            "freq?",
+            "freq=10.0"
+        ],
+        [
+            "freq?",
+            "20",
+            ">",
+            "freq=10.0",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         unit_eq(lcc.frequency, pq.Quantity(20, "Hz"))
         lcc.frequency = 10.0
@@ -76,8 +94,14 @@ def test_lcc25_frequency():
 def test_lcc25_frequency_lowlimit():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "freq=0.0\r",
-        "freq=0.0\r>\r"
+        [
+            "freq=0.0"
+        ],
+        [
+            "freq=0.0",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         lcc.frequency = 0.0
 
@@ -86,8 +110,14 @@ def test_lcc25_frequency_lowlimit():
 def test_lcc25_frequency_highlimit():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "freq=160.0\r",
-        "freq=160.0\r>\r"
+        [
+            "freq=160.0"
+        ],
+        [
+            "freq=160.0",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         lcc.frequency = 160.0
 
@@ -95,8 +125,18 @@ def test_lcc25_frequency_highlimit():
 def test_lcc25_mode():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "mode?\rmode=1\r",
-        "mode?\r>2\r"
+        [
+            "mode?",
+            "mode=1"
+        ],
+        [
+            "mode?",
+            "2",
+            ">",
+            "mode=1",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         assert lcc.mode == ik.thorlabs.LCC25.Mode.voltage2
         lcc.mode = ik.thorlabs.LCC25.Mode.voltage1
@@ -106,8 +146,8 @@ def test_lcc25_mode():
 def test_lcc25_mode_invalid():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "mode=10\r",
-        "mode=10\r>0\r>\r"
+        [],
+        []
     ) as lcc:
         lcc.mode = "blo"
 
@@ -116,8 +156,8 @@ def test_lcc25_mode_invalid():
 def test_lcc25_mode_invalid2():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "mode=10\r",
-        "mode=10\r>0\r>\r"
+        [],
+        []
     ) as lcc:
         blo = IntEnum("blo", "beep boop bop")
         lcc.mode = blo.beep
@@ -126,19 +166,29 @@ def test_lcc25_mode_invalid2():
 def test_lcc25_enable():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "enable?\renable=1\r",
-        "enable?>\r>0\r"
+        [
+            "enable?",
+            "enable=1"
+        ],
+        [
+            "enable?",
+            "0",
+            ">",
+            "enable=1",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
-        assert lcc.enable == False
+        assert lcc.enable is False
         lcc.enable = True
 
 
 @raises(TypeError)
-def test_lcc25_enable_type():
+def test_lcc25_enable_invalid_type():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "blo\r",
-        "blo\rblo\r>\r"
+        [],
+        []
     ) as lcc:
         lcc.enable = "blo"
 
@@ -146,19 +196,29 @@ def test_lcc25_enable_type():
 def test_lcc25_extern():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "extern?\rextern=1\r",
-        "extern?>\r>0\r"
+        [
+            "extern?",
+            "extern=1"
+        ],
+        [
+            "extern?",
+            "0",
+            ">",
+            "extern=1",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
-        assert lcc.extern == False
+        assert lcc.extern is False
         lcc.extern = True
 
 
 @raises(TypeError)
-def test_tc200_extern_type():
+def test_tc200_extern_invalid_type():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "blo\r",
-        "blo\rblo\r>\r"
+        [],
+        []
     ) as tc:
         tc.extern = "blo"
 
@@ -166,19 +226,29 @@ def test_tc200_extern_type():
 def test_lcc25_remote():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "remote?\rremote=1\r",
-        "remote?>\r>0\r"
+        [
+            "remote?",
+            "remote=1"
+        ],
+        [
+            "remote?",
+            "0",
+            ">",
+            "remote=1",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
-        assert lcc.remote == False
+        assert lcc.remote is False
         lcc.remote = True
 
 
 @raises(TypeError)
-def test_tc200_remote_type():
+def test_tc200_remote_invalid_type():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "blo\r",
-        "blo\rblo\r>\r"
+        [],
+        []
     ) as tc:
         tc.remote = "blo"
 
@@ -186,8 +256,18 @@ def test_tc200_remote_type():
 def test_lcc25_voltage1():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "volt1?\rvolt1=10.0\r",
-        "volt1?\r>20\r"
+        [
+            "volt1?",
+            "volt1=10.0"
+        ],
+        [
+            "volt1?",
+            "20",
+            ">",
+            "volt1=10.0",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         unit_eq(lcc.voltage1, pq.Quantity(20, "V"))
         lcc.voltage1 = 10.0
@@ -202,8 +282,18 @@ def test_check_cmd():
 def test_lcc25_voltage2():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "volt2?\rvolt2=10.0\r",
-        "volt2?\r>20\r"
+        [
+            "volt2?",
+            "volt2=10.0",
+        ],
+        [
+            "volt2?",
+            "20",
+            ">",
+            "volt2=10.0",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         unit_eq(lcc.voltage2, pq.Quantity(20, "V"))
         lcc.voltage2 = 10.0
@@ -212,8 +302,18 @@ def test_lcc25_voltage2():
 def test_lcc25_minvoltage():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "min?\rmin=10.0\r",
-        "min?\r>20\r"
+        [
+            "min?",
+            "min=10.0"
+        ],
+        [
+            "min?",
+            "20",
+            ">",
+            "min=10.0",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         unit_eq(lcc.min_voltage, pq.Quantity(20, "V"))
         lcc.min_voltage = 10.0
@@ -222,8 +322,18 @@ def test_lcc25_minvoltage():
 def test_lcc25_maxvoltage():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "max?\rmax=10.0\r",
-        "max?\r>20\r"
+        [
+            "max?",
+            "max=10.0"
+        ],
+        [
+            "max?",
+            "20",
+            ">",
+            "max=10.0",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         unit_eq(lcc.max_voltage, pq.Quantity(20, "V"))
         lcc.max_voltage = 10.0
@@ -232,8 +342,18 @@ def test_lcc25_maxvoltage():
 def test_lcc25_dwell():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "dwell?\rdwell=10\r",
-        "dwell?\r>20\r"
+        [
+            "dwell?",
+            "dwell=10"
+        ],
+        [
+            "dwell?",
+            "20",
+            ">",
+            "dwell=10",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         unit_eq(lcc.dwell, pq.Quantity(20, "ms"))
         lcc.dwell = 10
@@ -243,8 +363,14 @@ def test_lcc25_dwell():
 def test_lcc25_dwell_positive():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "dwell=-10\r",
-        "dwell=-10\r>\r"
+        [
+            "dwell=-10"
+        ],
+        [
+            "dwell=-10",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         lcc.dwell = -10
 
@@ -252,8 +378,18 @@ def test_lcc25_dwell_positive():
 def test_lcc25_increment():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "increment?\rincrement=10.0\r",
-        "increment?\r>20\r"
+        [
+            "increment?",
+            "increment=10.0"
+        ],
+        [
+            "increment?",
+            "20",
+            ">",
+            "increment=10.0",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         unit_eq(lcc.increment, pq.Quantity(20, "V"))
         lcc.increment = 10.0
@@ -263,8 +399,14 @@ def test_lcc25_increment():
 def test_lcc25_increment_positive():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "increment=-10\r",
-        "increment=-10\r>\r"
+        [
+            "increment=-10"
+        ],
+        [
+            "increment=-10",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         lcc.increment = -10
 
@@ -273,16 +415,30 @@ def test_lcc25_increment_positive():
 def test_lcc25_default():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "default\r",
-        "default\r>\r"
+        [
+            "default"
+        ],
+        [
+            "default",
+            "1",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         lcc.default()
+
 
 def test_lcc25_save():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "save\r",
-        "save\r>\r"
+        [
+            "save"
+        ],
+        [
+            "save",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         lcc.save()
 
@@ -290,8 +446,14 @@ def test_lcc25_save():
 def test_lcc25_save_settings():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "set=2\r",
-        "set=2\r>\r"
+        [
+            "set=2"
+        ],
+        [
+            "set=2",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         lcc.set_settings(2)
 
@@ -299,8 +461,14 @@ def test_lcc25_save_settings():
 def test_lcc25_get_settings():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "get=2\r",
-        "get=2\r>\r"
+        [
+            "get=2"
+        ],
+        [
+            "get=2",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         lcc.get_settings(2)
 
@@ -308,8 +476,14 @@ def test_lcc25_get_settings():
 def test_lcc25_test_mode():
     with expected_protocol(
         ik.thorlabs.LCC25,
-        "test\r",
-        "test\r>\r"
+        [
+            "test"
+        ],
+        [
+            "test",
+            ">"
+        ],
+        sep="\r"
     ) as lcc:
         lcc.test_mode()
 
@@ -317,8 +491,15 @@ def test_lcc25_test_mode():
 def test_sc10_name():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "id?\r",
-        "id?\r>bloopbloop\r>\r"
+        [
+            "id?"
+        ],
+        [
+            "id?",
+            "bloopbloop",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.name() == "bloopbloop"
 
@@ -326,8 +507,18 @@ def test_sc10_name():
 def test_sc10_enable():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "ens?\rens=1\r",
-        "ens?\r>0\r>\r"
+        [
+            "ens?",
+            "ens=1"
+        ],
+        [
+            "ens?",
+            "0",
+            ">",
+            "ens=1",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.enable == 0
         sc.enable = 1
@@ -337,8 +528,15 @@ def test_sc10_enable():
 def test_sc10_enable_invalid():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "ens=10\r",
-        "ens=10\r>0\r>\r"
+        [
+            # "ens=10"
+        ],
+        [
+            # "ens=10",
+            # "0",
+            # ">"
+        ],
+        sep="\r"
     ) as sc:
         sc.enable = 10
 
@@ -346,8 +544,18 @@ def test_sc10_enable_invalid():
 def test_sc10_repeat():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "rep?\rrep=10\r",
-        "rep?\r>20\r>\r"
+        [
+            "rep?",
+            "rep=10"
+        ],
+        [
+            "rep?",
+            "20",
+            ">",
+            "rep=10",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.repeat == 20
         sc.repeat = 10
@@ -357,8 +565,13 @@ def test_sc10_repeat():
 def test_sc10_repeat_invalid():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "rep=-1\r",
-        "rep=-1\r>0\r>\r"
+        [
+            # "rep=-1\r"
+        ],
+        [
+            # "rep=-1\r>0\r>\r"
+        ],
+        sep="\r"
     ) as sc:
         sc.repeat = -1
 
@@ -366,8 +579,18 @@ def test_sc10_repeat_invalid():
 def test_sc10_mode():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "mode?\rmode=2\r",
-        "mode?\r>1\r>\r"
+        [
+            "mode?",
+            "mode=2"
+        ],
+        [
+            "mode?",
+            "1",
+            ">",
+            "mode=2",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.mode == ik.thorlabs.SC10.Mode.manual
         sc.mode = ik.thorlabs.SC10.Mode.auto
@@ -377,8 +600,15 @@ def test_sc10_mode():
 def test_sc10_mode_invalid():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "mode=10\r",
-        "mode=10\r>0\r>\r"
+        [
+            # "mode=10"
+        ],
+        [
+            # "mode=10",
+            # "0",
+            # ">"
+        ],
+        sep="\r"
     ) as sc:
         sc.mode = "blo"
 
@@ -387,8 +617,13 @@ def test_sc10_mode_invalid():
 def test_sc10_mode_invalid2():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "mode=10\r",
-        "mode=10\r>0\r>\r"
+        [
+            # "mode=10\r"
+        ],
+        [
+            # "mode=10\r>0\r>\r"
+        ],
+        sep="\r"
     ) as sc:
         blo = IntEnum("blo", "beep boop bop")
         sc.mode = blo.beep
@@ -397,8 +632,18 @@ def test_sc10_mode_invalid2():
 def test_sc10_trigger():
     with expected_protocol(
         ik.thorlabs.SC10, 
-        "trig?\rtrig=1\r",
-        "trig?\r>0\r>\r"
+        [
+            "trig?",
+            "trig=1"
+        ],
+        [
+            "trig?",
+            "0",
+            ">",
+            "trig=1",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.trigger == 0
         sc.trigger = 1
@@ -422,8 +667,18 @@ def test_time_check_max():
 def test_sc10_out_trigger():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "xto?\rxto=1\r",
-        "xto?\r>0\r>\r"
+        [
+            "xto?",
+            "xto=1"
+        ],
+        [
+            "xto?",
+            "0",
+            ">",
+            "xto=1",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.out_trigger == 0
         sc.out_trigger = 1
@@ -432,8 +687,18 @@ def test_sc10_out_trigger():
 def test_sc10_open_time():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "open?\ropen=10\r",
-        "open?\r>20\r>\r"
+        [
+            "open?",
+            "open=10"
+        ],
+        [
+            "open?",
+            "20",
+            ">",
+            "open=10",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         unit_eq(sc.open_time, pq.Quantity(20, "ms"))
         sc.open_time = 10.0
@@ -442,36 +707,70 @@ def test_sc10_open_time():
 def test_sc10_shut_time():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "shut?\rshut=10\r",
-        "shut?\r>20\r>\r"
+        [
+            "shut?",
+            "shut=10"
+        ],
+        [
+            "shut?",
+            "20",
+            ">",
+            "shut=10",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         unit_eq(sc.shut_time, pq.Quantity(20, "ms"))
         sc.shut_time = 10.0
 
 
 def test_sc10_baud_rate():
-    with expected_protocol(ik.thorlabs.SC10, "baud?\rbaud=1\r", "\r>0\r>\r") as sc:
+    with expected_protocol(
+        ik.thorlabs.SC10,
+        [
+            "baud?",
+            "baud=1"
+        ],
+        [
+            "baud?",
+            "0",
+            ">",
+            "baud=1",
+            ">"
+        ],
+        sep="\r"
+    ) as sc:
         assert sc.baud_rate == 9600
         sc.baud_rate = 115200
 
 
-def test_echo():
-    with expected_protocol(ik.thorlabs.SC10, "baud?\r", "\r>0\r>\r") as sc:
-        assert sc.baud_rate == 9600
-        assert sc.echo == True
-
-
 @raises(ValueError)
 def test_sc10_baud_rate_error():
-    with expected_protocol(ik.thorlabs.SC10, "\rbaud=1\r", "\r>\r") as sc:
+    with expected_protocol(
+        ik.thorlabs.SC10,
+        [
+            # "\rbaud=1\r"
+        ],
+        [
+            # "\r>\r"
+        ],
+        sep="\r"
+    ) as sc:
         sc.baud_rate = 115201
 
 
 def test_sc10_closed():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "closed?\r",
-        "closed?\r>1\r>"
+        [
+            "closed?"
+        ],
+        [
+            "closed?",
+            "1",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.closed
 
@@ -479,8 +778,15 @@ def test_sc10_closed():
 def test_sc10_interlock():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "interlock?\r",
-        "interlock?\r>1\r>"
+        [
+            "interlock?"
+        ],
+        [
+            "interlock?",
+            "1",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.interlock
 
@@ -488,8 +794,15 @@ def test_sc10_interlock():
 def test_sc10_default():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "default\r",
-        "default\r>1\r>"
+        [
+            "default"
+        ],
+        [
+            "default",
+            "1",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.default()
 
@@ -497,8 +810,15 @@ def test_sc10_default():
 def test_sc10_save():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "savp\r",
-        "savp\r>1\r>"
+        [
+            "savp"
+        ],
+        [
+            "savp",
+            "1",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.save()
 
@@ -506,8 +826,15 @@ def test_sc10_save():
 def test_sc10_save_mode():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "save\r",
-        "save\r>1\r>"
+        [
+            "save"
+        ],
+        [
+            "save",
+            "1",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.save_mode()
 
@@ -515,8 +842,15 @@ def test_sc10_save_mode():
 def test_sc10_restore():
     with expected_protocol(
         ik.thorlabs.SC10,
-        "resp\r",
-        "resp\r>1\r>"
+        [
+            "resp"
+        ],
+        [
+            "resp",
+            "1",
+            ">"
+        ],
+        sep="\r"
     ) as sc:
         assert sc.restore()
 
@@ -524,8 +858,15 @@ def test_sc10_restore():
 def test_tc200_name():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "*idn?\r",
-        "*idn?\r>bloopbloop\r>\r"
+        [
+            "*idn?"
+        ],
+        [
+            "*idn?",
+            "bloopbloop",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         assert tc.name() == "bloopbloop"
 
@@ -533,32 +874,45 @@ def test_tc200_name():
 def test_tc200_mode():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "stat?\rmode=cycle\r",
-        "stat?\r>54\r>\r"
+        [
+            "stat?",
+            "stat?",
+            "mode=cycle"
+        ],
+        [
+            "stat?",
+            "{}>".format(str(unichr(0))),
+            "stat?",
+            "{}>".format(str(unichr(2))),
+            "mode=cycle",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
-        assert tc.mode == ik.thorlabs.TC200.Mode.normal
-        tc.mode = ik.thorlabs.TC200.Mode.cycle
-
-
-def test_tc200_mode():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        "stat?\rmode=cycle\r",
-        "stat?\r>54\r>\r"
-    ) as tc:
-        assert tc.mode == ik.thorlabs.TC200.Mode.normal
+        assert tc.mode == tc.Mode.normal
+        assert tc.mode == tc.Mode.cycle
         tc.mode = ik.thorlabs.TC200.Mode.cycle
 
 
 @raises(TypeError)
 def test_tc200_mode_error():
-    with expected_protocol(ik.thorlabs.TC200, 'blo', 'blo') as tc:
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        [],
+        [],
+        sep="\r"
+    ) as tc:
         tc.mode = "blo"
 
 
 @raises(TypeError)
 def test_tc200_mode_error2():
-    with expected_protocol(ik.thorlabs.TC200, 'blo', 'blo') as tc:
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        [],
+        [],
+        sep="\r"
+    ) as tc:
         blo = IntEnum("blo", "beep boop bop")
         tc.mode = blo.beep
 
@@ -566,8 +920,30 @@ def test_tc200_mode_error2():
 def test_tc200_enable():
     with expected_protocol(
         ik.thorlabs.TC200,
-        ["stat?", "stat?", "ens", "stat?", "ens"],
-        ["stat?\r54\r>\n", "\r54\r>\n", "\r>\n", "\r55\r>\n", "\r>\n"],
+        [
+            "stat?",
+            "stat?",
+            "ens",
+            "stat?",
+            "ens"
+        ],
+        [
+            "stat?",
+            "54",
+            ">",
+
+            "stat?",
+            "54",
+            ">",
+            "ens",
+            ">",
+
+            "stat?",
+            "55",
+            ">",
+            "ens",
+            ">"
+        ],
         sep="\r"
     ) as tc:
         assert tc.enable == 0
@@ -579,8 +955,9 @@ def test_tc200_enable():
 def test_tc200_enable_type():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "blo\r",
-        "blo\rblo\r>\r"
+        [],
+        [],
+        sep="\r"
     ) as tc:
         tc.enable = "blo"
 
@@ -588,8 +965,21 @@ def test_tc200_enable_type():
 def test_tc200_temperature():
     with expected_protocol(
         ik.thorlabs.TC200,
-        ["tact?", "tmax?", "tset=40.0"],
-        ["tact?\r>30 C\r>\n", "\r>250\r>", "\r>\r"],
+        [
+            "tact?",
+            "tmax?",
+            "tset=40.0"
+        ],
+        [
+            "tact?",
+            "30 C",
+            ">",
+            "tmax?",
+            "250",
+            ">",
+            "tset=40.0",
+            ">"
+        ],
         sep="\r"
     ) as tc:
         assert tc.temperature == 30.0*pq.degC
@@ -600,8 +990,14 @@ def test_tc200_temperature():
 def test_tc200_temperature_range():
     with expected_protocol(
         ik.thorlabs.TC200,
-        ["tmax?", "tset=50.0"],
-        ["tmax?\r>40\r>", "\r>\r"],
+        [
+            "tmax?"
+        ],
+        [
+            "tmax?",
+            "40",
+            ">"
+        ],
         sep="\r"
     ) as tc:
         tc.temperature = 50*pq.degC
@@ -610,24 +1006,54 @@ def test_tc200_temperature_range():
 def test_tc200_pid():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "pid?\rpgain=2\r",
-        "pid?\r>2 0 220 \r>"
+        [
+            "pid?",
+            "pgain=2"
+        ],
+        [
+            "pid?",
+            "2 0 220",
+            ">",
+            "pgain=2",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         assert tc.p == 2
         tc.p = 2
 
     with expected_protocol(
         ik.thorlabs.TC200,
-        "pid?\rigain=0\r",
-        "pid?\r>2 0 220 \r>\r"
+        [
+            "pid?",
+            "igain=0"
+        ],
+        [
+            "pid?",
+            "2 0 220",
+            ">",
+            "igain=0",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         assert tc.i == 0
         tc.i = 0
 
     with expected_protocol(
         ik.thorlabs.TC200,
-        "pid?\rdgain=220\r",
-        "pid?\r>2 0 220 \r>\r"
+        [
+            "pid?",
+            "dgain=220"
+        ],
+        [
+            "pid?",
+            "2 0 220",
+            ">",
+            "dgain=220",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         assert tc.d == 220
         tc.d = 220
@@ -637,8 +1063,14 @@ def test_tc200_pid():
 def test_tc200_pmin():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "pgain=-1\r",
-        "pgain=-1\r>\r"
+        [
+            "pgain=-1"
+        ],
+        [
+            "pgain=-1",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.p = -1
 
@@ -647,8 +1079,14 @@ def test_tc200_pmin():
 def test_tc200_pmax():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "pgain=260\r",
-        "pgain=260\r>\r"
+        [
+            "pgain=260"
+        ],
+        [
+            "pgain=260",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.p = 260
 
@@ -657,8 +1095,14 @@ def test_tc200_pmax():
 def test_tc200_imin():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "igain=-1\r",
-        "igain=-1\r>\r"
+        [
+            "igain=-1"
+        ],
+        [
+            "igain=-1",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.i = -1
 
@@ -667,8 +1111,14 @@ def test_tc200_imin():
 def test_tc200_imax():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "igain=260\r",
-        "igain=260\r>\r"
+        [
+            "igain=260"
+        ],
+        [
+            "igain=260",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.i = 260
 
@@ -677,8 +1127,14 @@ def test_tc200_imax():
 def test_tc200_dmin():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "dgain=-1\r",
-        "dgain=-1\r>\r"
+        [
+            "dgain=-1"
+        ],
+        [
+            "dgain=-1",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.d = -1
 
@@ -687,8 +1143,14 @@ def test_tc200_dmin():
 def test_tc200_dmax():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "dgain=260\r",
-        "dgain=260\r>\r"
+        [
+            "dgain=260"
+        ],
+        [
+            "dgain=260",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.d = 260
 
@@ -696,8 +1158,31 @@ def test_tc200_dmax():
 def test_tc200_degrees():
     with expected_protocol(
         ik.thorlabs.TC200,
-        ["stat?", "stat?", "stat?", "unit=c", "unit=f", "unit=k"],
-        ["stat?\r>44\n", "\r>54\n", "\r>0\n", ">\r", ">\r", ">\r"],
+        [
+            "stat?",
+            "stat?",
+            "stat?",
+            "unit=c",
+            "unit=f",
+            "unit=k"
+        ],
+        [
+            "stat?",
+            "44",
+            ">",
+            "stat?",
+            "54",
+            ">",
+            "stat?",
+            "0",
+            ">",
+            "unit=c",
+            ">",
+            "unit=f",
+            ">",
+            "unit=k",
+            ">"
+        ],
         sep="\r"
     ) as tc:
         assert str(tc.degrees).split(" ")[1] == "K"
@@ -714,8 +1199,9 @@ def test_tc200_degrees_invalid():
 
     with expected_protocol(
         ik.thorlabs.TC200,
-        "unit=blo",
-        "unit=blo>\r"
+        [],
+        [],
+        sep="\r"
     ) as tc:
         tc.degrees = "blo"
 
@@ -723,8 +1209,18 @@ def test_tc200_degrees_invalid():
 def test_tc200_sensor():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "sns?\rsns=ptc100\r",
-        "sns?\r>Sensor = NTC10K, Beta = 5600\r>\r"
+        [
+            "sns?",
+            "sns=ptc100"
+        ],
+        [
+            "sns?",
+            "Sensor = NTC10K, Beta = 5600",
+            ">",
+            "sns=ptc100",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         assert tc.sensor == tc.Sensor.ntc10k
         tc.sensor = tc.Sensor.ptc100
@@ -732,13 +1228,21 @@ def test_tc200_sensor():
 
 @raises(TypeError)
 def test_tc200_sensor_error():
-    with expected_protocol(ik.thorlabs.TC200, 'blo', 'blo') as tc:
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        [],
+        []
+    ) as tc:
         tc.sensor = "blo"
 
 
 @raises(TypeError)
 def test_tc200_sensor_error2():
-    with expected_protocol(ik.thorlabs.TC200, 'blo', 'blo') as tc:
+    with expected_protocol(
+        ik.thorlabs.TC200,
+            [],
+            []
+    ) as tc:
         blo = IntEnum("blo", "beep boop bop")
         tc.sensor = blo.beep
 
@@ -746,8 +1250,18 @@ def test_tc200_sensor_error2():
 def test_tc200_beta():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "beta?\rbeta=2000\r",
-        "beta?\r>5600\r>\r"
+        [
+            "beta?",
+            "beta=2000"
+        ],
+        [
+            "beta?",
+            "5600",
+            ">",
+            "beta=2000",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         assert tc.beta == 5600
         tc.beta = 2000
@@ -757,8 +1271,14 @@ def test_tc200_beta():
 def test_tc200_beta_min():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "beta=200\r",
-        "beta=200\r>\r"
+        [
+            "beta=200"
+        ],
+        [
+            "beta=200",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.beta = 200
 
@@ -767,8 +1287,14 @@ def test_tc200_beta_min():
 def test_tc200_beta_max():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "beta=20000\r",
-        "beta=20000\r>\r"
+        [
+            "beta=20000"
+        ],
+        [
+            "beta=20000",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.beta = 20000
 
@@ -776,8 +1302,18 @@ def test_tc200_beta_max():
 def test_tc200_max_power():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "pmax?\rPMAX=12.0\r",
-        "pmax?\r>15.0\r>\r"
+        [
+            "pmax?",
+            "PMAX=12.0"
+        ],
+        [
+            "pmax?",
+            "15.0",
+            ">",
+            "PMAX=12.0",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         assert tc.max_power == 15.0*pq.W
         tc.max_power = 12*pq.W
@@ -787,8 +1323,14 @@ def test_tc200_max_power():
 def test_tc200_power_min():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "PMAX=-2\r",
-        "PMAX=-2\r>\r"
+        [
+            "PMAX=-2"
+        ],
+        [
+            "PMAX=-2",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.max_power = -1
 
@@ -797,8 +1339,14 @@ def test_tc200_power_min():
 def test_tc200_power_max():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "PMAX=20000\r",
-        "PMAX=20000\r>\r"
+        [
+            "PMAX=20000"
+        ],
+        [
+            "PMAX=20000",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.max_power = 20000
 
@@ -806,10 +1354,21 @@ def test_tc200_power_max():
 def test_tc200_max_temperature():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "tmax?\rTMAX=180.0\r",
-        "tmax?\r>200.0\r>\r"
+        [
+            "tmax?",
+            "TMAX=180.0"
+        ],
+        [
+            "tmax?",
+            "200.0",
+            ">",
+            "TMAX=180.0",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         assert tc.max_temperature == 200.0*pq.degC
+        print "second test"
         tc.max_temperature = 180*pq.degC
 
 
@@ -817,8 +1376,14 @@ def test_tc200_max_temperature():
 def test_tc200_temp_min():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "TMAX=-2\r",
-        "TMAX=-2\r>\r"
+        [
+            "TMAX=-2"
+        ],
+        [
+            "TMAX=-2",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.max_temperature = -1
 
@@ -827,7 +1392,13 @@ def test_tc200_temp_min():
 def test_tc200_temp_max():
     with expected_protocol(
         ik.thorlabs.TC200,
-        "TMAX=20000\r",
-        "TMAX=20000\r>\r"
+        [
+            "TMAX=20000"
+        ],
+        [
+            "TMAX=20000",
+            ">"
+        ],
+        sep="\r"
     ) as tc:
         tc.max_temperature = 20000

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -935,11 +935,27 @@ def test_tc200_temperature():
         ik.thorlabs.TC200,
         [
             "tact?",
+        ],
+        [
+            "tact?",
+            "30 C",
+            ">",
+        ],
+        sep="\r"
+    ) as tc:
+        assert tc.temperature == 30.0 * pq.degC
+
+
+def test_tc200_temperature_set():
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        [
+            "tset?",
             "tmax?",
             "tset=40.0"
         ],
         [
-            "tact?",
+            "tset?",
             "30 C",
             ">",
             "tmax?",
@@ -950,8 +966,8 @@ def test_tc200_temperature():
         ],
         sep="\r"
     ) as tc:
-        assert tc.temperature == 30.0 * pq.degC
-        tc.temperature = 40 * pq.degC
+        assert tc.temperature_set == 30.0 * pq.degC
+        tc.temperature_set = 40 * pq.degC
 
 
 @raises(ValueError)
@@ -968,7 +984,7 @@ def test_tc200_temperature_range():
         ],
         sep="\r"
     ) as tc:
-        tc.temperature = 50 * pq.degC
+        tc.temperature_set = 50 * pq.degC
 
 
 def test_tc200_pid():
@@ -1025,6 +1041,30 @@ def test_tc200_pid():
     ) as tc:
         assert tc.d == 220
         tc.d = 220
+
+    with expected_protocol(
+        ik.thorlabs.TC200,
+        [
+            "pid?",
+            "pgain=2",
+            "igain=0",
+            "dgain=220"
+        ],
+        [
+            "pid?",
+            "2 0 220",
+            ">",
+            "pgain=2",
+            ">",
+            "igain=0",
+            ">",
+            "dgain=220",
+            ">"
+        ],
+        sep="\r"
+    ) as tc:
+        assert tc.pid == [2, 0, 220]
+        tc.pid = (2, 0, 220)
 
 
 @raises(ValueError)
@@ -1194,7 +1234,7 @@ def test_tc200_sensor():
         tc.sensor = tc.Sensor.ptc100
 
 
-@raises(TypeError)
+@raises(ValueError)
 def test_tc200_sensor_error():
     with expected_protocol(
         ik.thorlabs.TC200,
@@ -1204,7 +1244,7 @@ def test_tc200_sensor_error():
         tc.sensor = "blo"
 
 
-@raises(TypeError)
+@raises(ValueError)
 def test_tc200_sensor_error2():
     with expected_protocol(
         ik.thorlabs.TC200,
@@ -1272,13 +1312,13 @@ def test_tc200_max_power():
         ik.thorlabs.TC200,
         [
             "pmax?",
-            "PMAX=12.0"
+            "pmax=12.0"
         ],
         [
             "pmax?",
             "15.0",
             ">",
-            "PMAX=12.0",
+            "pmax=12.0",
             ">"
         ],
         sep="\r"
@@ -1324,19 +1364,18 @@ def test_tc200_max_temperature():
         ik.thorlabs.TC200,
         [
             "tmax?",
-            "TMAX=180.0"
+            "tmax=180.0"
         ],
         [
             "tmax?",
             "200.0",
             ">",
-            "TMAX=180.0",
+            "tmax=180.0",
             ">"
         ],
         sep="\r"
     ) as tc:
         assert tc.max_temperature == 200.0 * pq.degC
-        print "second test"
         tc.max_temperature = 180 * pq.degC
 
 

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -856,9 +856,11 @@ def test_tc200_mode():
         ],
         [
             "stat?",
-            "{}>".format(str(unichr(0))),
+            "0",
+            ">",
             "stat?",
-            "{}>".format(str(unichr(2))),
+            "2",
+            ">",
             "mode=cycle",
             ">"
         ],

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -415,6 +415,7 @@ def test_lcc25_save():
         ],
         [
             "save",
+            "1",
             ">"
         ],
         sep="\r"
@@ -430,6 +431,7 @@ def test_lcc25_set_settings():
         ],
         [
             "set=2",
+            "1",
             ">"
         ],
         sep="\r"
@@ -456,6 +458,7 @@ def test_lcc25_get_settings():
         ],
         [
             "get=2",
+            "1",
             ">"
         ],
         sep="\r"
@@ -482,6 +485,7 @@ def test_lcc25_test_mode():
         ],
         [
             "test",
+            "1",
             ">"
         ],
         sep="\r"
@@ -502,7 +506,7 @@ def test_sc10_name():
         ],
         sep="\r"
     ) as sc:
-        assert sc.name() == "bloopbloop"
+        assert sc.name == "bloopbloop"
 
 
 def test_sc10_enable():
@@ -521,11 +525,11 @@ def test_sc10_enable():
         ],
         sep="\r"
     ) as sc:
-        assert sc.enable == 0
-        sc.enable = 1
+        assert sc.enable == False
+        sc.enable = True
 
 
-@raises(ValueError)
+@raises(TypeError)
 def test_sc10_enable_invalid():
     with expected_protocol(
         ik.thorlabs.SC10,
@@ -587,7 +591,7 @@ def test_sc10_mode():
         sc.mode = ik.thorlabs.SC10.Mode.auto
 
 
-@raises(TypeError)
+@raises(ValueError)
 def test_sc10_mode_invalid():
     with expected_protocol(
         ik.thorlabs.SC10,
@@ -598,7 +602,7 @@ def test_sc10_mode_invalid():
         sc.mode = "blo"
 
 
-@raises(TypeError)
+@raises(ValueError)
 def test_sc10_mode_invalid2():
     with expected_protocol(
         ik.thorlabs.SC10,
@@ -607,7 +611,7 @@ def test_sc10_mode_invalid2():
         sep="\r"
     ) as sc:
         blo = IntEnum("blo", "beep boop bop")
-        sc.mode = blo.beep
+        sc.mode = blo[0]
 
 
 def test_sc10_trigger():
@@ -628,21 +632,6 @@ def test_sc10_trigger():
     ) as sc:
         assert sc.trigger == 0
         sc.trigger = 1
-
-
-@raises(ValueError)
-def test_trigger_check():
-    ik.thorlabs.trigger_check(2)
-
-
-@raises(ValueError)
-def test_time_check_min():
-    ik.thorlabs.check_time(-1)
-
-
-@raises(ValueError)
-def test_time_check_max():
-    ik.thorlabs.check_time(9999999)
 
 
 def test_sc10_out_trigger():
@@ -682,7 +671,7 @@ def test_sc10_open_time():
         sep="\r"
     ) as sc:
         unit_eq(sc.open_time, pq.Quantity(20, "ms"))
-        sc.open_time = 10.0
+        sc.open_time = 10
 
 
 def test_sc10_shut_time():

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -254,9 +254,9 @@ def test_lcc25_voltage1():
 
 
 def test_check_cmd():
-    assert ik.thorlabs._utils.check_cmd("blo") == 1
-    assert ik.thorlabs._utils.check_cmd("CMD_NOT_DEFINED") == 0
-    assert ik.thorlabs._utils.check_cmd("CMD_ARG_INVALID") == 0
+    assert ik.thorlabs.thorlabs_utils.check_cmd("blo") == 1
+    assert ik.thorlabs.thorlabs_utils.check_cmd("CMD_NOT_DEFINED") == 0
+    assert ik.thorlabs.thorlabs_utils.check_cmd("CMD_ARG_INVALID") == 0
 
 
 def test_lcc25_voltage2():

--- a/instruments/instruments/tests/test_util_fns.py
+++ b/instruments/instruments/tests/test_util_fns.py
@@ -31,7 +31,7 @@ from nose.tools import raises, eq_
 
 from instruments.util_fns import (
     ProxyList,
-    assume_units
+    assume_units, convert_temperature
 )
 
 from flufl.enum import Enum
@@ -134,7 +134,37 @@ def test_assume_units_correct():
     
     # Check that raw scalars are made unitful.
     eq_(assume_units(1, 'm').rescale('mm').magnitude, 1000)
-    
+
+def test_temperature_conversion():
+    blo = 70.0*pq.degF
+    out = convert_temperature(blo, pq.degC)
+    eq_(out.magnitude, 21.11111111111111)
+    out = convert_temperature(blo, pq.degK)
+    eq_(out.magnitude, 294.2055555555555)
+    out = convert_temperature(blo, pq.degF)
+    eq_(out.magnitude, 70.0)
+
+    blo = 20.0*pq.degC
+    out = convert_temperature(blo, pq.degF)
+    eq_(out.magnitude, 68)
+    out = convert_temperature(blo, pq.degC)
+    eq_(out.magnitude, 20.0)
+    out = convert_temperature(blo, pq.degK)
+    eq_(out.magnitude, 293.15)
+
+    blo = 270*pq.degK
+    out = convert_temperature(blo, pq.degC)
+    eq_(out.magnitude, -3.1499999999999773)
+    out = convert_temperature(blo, pq.degF)
+    eq_(out.magnitude, 141.94736842105263)
+    out = convert_temperature(blo, pq.K)
+    eq_(out.magnitude, 270)
+
+@raises(ValueError)
+def test_temperater_conversion_failure():
+    blo = 70.0*pq.degF
+    convert_temperature(blo, pq.V)
+
 @raises(ValueError)
 def test_assume_units_failures():
     assume_units(1, 'm').rescale('s')

--- a/instruments/instruments/thorlabs/__init__.py
+++ b/instruments/instruments/thorlabs/__init__.py
@@ -2,5 +2,6 @@ from instruments.thorlabs.thorlabsapt import (
     ThorLabsAPT, APTPiezoStage, APTStrainGaugeReader, APTMotorController
 )
 from instruments.thorlabs.pm100usb import PM100USB
-from instruments.thorlabs.lcc25 import LCC25
-from instruments.thorlabs.sc10 import SC10
+from instruments.thorlabs.lcc25 import LCC25, voltage_latch, slot_latch, check_cmd
+from instruments.thorlabs.sc10 import SC10, trigger_check, check_time
+from instruments.thorlabs.tc200 import TC200

--- a/instruments/instruments/thorlabs/__init__.py
+++ b/instruments/instruments/thorlabs/__init__.py
@@ -3,5 +3,5 @@ from instruments.thorlabs.thorlabsapt import (
 )
 from instruments.thorlabs.pm100usb import PM100USB
 from instruments.thorlabs.lcc25 import LCC25
-from instruments.thorlabs.sc10 import SC10, trigger_check, check_time
+from instruments.thorlabs.sc10 import SC10
 from instruments.thorlabs.tc200 import TC200

--- a/instruments/instruments/thorlabs/__init__.py
+++ b/instruments/instruments/thorlabs/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from instruments.thorlabs.thorlabsapt import (
     ThorLabsAPT, APTPiezoStage, APTStrainGaugeReader, APTMotorController
 )

--- a/instruments/instruments/thorlabs/__init__.py
+++ b/instruments/instruments/thorlabs/__init__.py
@@ -2,6 +2,6 @@ from instruments.thorlabs.thorlabsapt import (
     ThorLabsAPT, APTPiezoStage, APTStrainGaugeReader, APTMotorController
 )
 from instruments.thorlabs.pm100usb import PM100USB
-from instruments.thorlabs.lcc25 import LCC25, voltage_latch, slot_latch, check_cmd
+from instruments.thorlabs.lcc25 import LCC25
 from instruments.thorlabs.sc10 import SC10, trigger_check, check_time
 from instruments.thorlabs.tc200 import TC200

--- a/instruments/instruments/thorlabs/_abstract.py
+++ b/instruments/instruments/thorlabs/_abstract.py
@@ -3,7 +3,7 @@
 ##
 # _packets.py: Module for working with ThorLabs packets.
 ##
-# © 2013 Steven Casagrande (scasagrande@galvant.ca).
+# © 2013-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
@@ -22,12 +22,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 ##
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
+
+from __future__ import absolute_import
+from __future__ import division
 
 from instruments.thorlabs import _packets
 from instruments.abstract_instruments.instrument import Instrument
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
 
 class ThorLabsInstrument(Instrument):
 

--- a/instruments/instruments/thorlabs/_cmds.py
+++ b/instruments/instruments/thorlabs/_cmds.py
@@ -3,7 +3,7 @@
 ##
 # _cmds.py: Command mneonics for APT protocol.
 ##
-# © 2013 Steven Casagrande (scasagrande@galvant.ca).
+# © 2013-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
@@ -22,15 +22,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 ##
 
-## FEATURES ####################################################################
+# IMPORTS #####################################################################
 
+from __future__ import absolute_import
 from __future__ import division
-
-## IMPORTS #####################################################################
-
 from flufl.enum import IntEnum
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
+
 
 class ThorLabsCommands(IntEnum):
     # General System Commands

--- a/instruments/instruments/thorlabs/_packets.py
+++ b/instruments/instruments/thorlabs/_packets.py
@@ -3,7 +3,7 @@
 ##
 # _packets.py: Module for working with ThorLabs packets.
 ##
-# © 2013 Steven Casagrande (scasagrande@galvant.ca).
+# © 2013-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
@@ -22,16 +22,19 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 ##
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
+
+from __future__ import absolute_import
+from __future__ import division
 
 import struct
 
-## STRUCTS #####################################################################
+# STRUCTS #####################################################################
 
 message_header_nopacket = struct.Struct('<HBBBB')
 message_header_wpacket  = struct.Struct('<HHBB')
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
 
 class ThorLabsPacket(object):
     def __init__(self,

--- a/instruments/instruments/thorlabs/_utils.py
+++ b/instruments/instruments/thorlabs/_utils.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+##
+# _utils.py: Utility functions for Thorlabs-brand instruments.
+##
+# © 2016 Steven Casagrande (scasagrande@galvant.ca).
+#
+# This file is a part of the InstrumentKit project.
+# Licensed under the AGPL version 3.
+##
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+##
+
+
+def check_cmd(response):
+    """
+    Checks the for the two common Thorlabs error messages; CMD_NOT_DEFINED and
+    CMD_ARG_INVALID
+
+    :param response: the response from the device
+    :return: 1 if not found, 0 otherwise
+    :rtype: int
+    """
+    if response != "CMD_NOT_DEFINED" and response != "CMD_ARG_INVALID":
+        return 1
+    else:
+        return 0

--- a/instruments/instruments/thorlabs/lcc25.py
+++ b/instruments/instruments/thorlabs/lcc25.py
@@ -28,7 +28,7 @@
 import quantities as pq
 from flufl.enum import IntEnum
 
-from instruments.thorlabs._utils import check_cmd
+from instruments.thorlabs.thorlabs_utils import check_cmd
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import enum_property, bool_property, unitful_property

--- a/instruments/instruments/thorlabs/lcc25.py
+++ b/instruments/instruments/thorlabs/lcc25.py
@@ -215,8 +215,8 @@ class LCC25(Instrument):
         doc="""
         Gets/sets the dwell time for voltages for the test mode.
 
-        :units: As specified (if a `~quantities.quantity.Quantity`) or assumed to be
-            of units milliseconds.
+        :units: As specified (if a `~quantities.quantity.Quantity`) or assumed
+            to be of units milliseconds.
         :rtype: `~quantities.quantity.Quantity`
         """
     )
@@ -257,34 +257,48 @@ class LCC25(Instrument):
 
         :rtype: `int`
         """
-        self.sendcmd("save")
+        response = self.query("save")
+        return check_cmd(response)
 
     def set_settings(self, slot):
         """
         Saves the current settings to memory.
 
+        Returns 1 if successful, zero otherwise.
+
         :param slot: Memory slot to use, valid range `[1,4]`
         :type slot: `int`
+        :rtype: `int`
         """
         if slot not in xrange(1, 5):
             raise ValueError("Cannot set memory out of `[1,4]` range")
-        self.sendcmd("set={}".format(slot))
+        response = self.query("set={}".format(slot))
+        return check_cmd(response)
 
     def get_settings(self, slot):
         """
         Gets the current settings to memory.
 
+        Returns 1 if successful, zero otherwise.
+
         :param slot: Memory slot to use, valid range `[1,4]`
         :type slot: `int`
+        :rtype: `int`
         """
         if slot not in xrange(1, 5):
             raise ValueError("Cannot set memory out of `[1,4]` range")
-        self.sendcmd("get={}".format(slot))
+        response = self.query("get={}".format(slot))
+        return check_cmd(response)
 
     def test_mode(self):
         """
         Puts the LCC in test mode - meaning it will increment the output
         voltage from the minimum value to the maximum value, in increments,
         waiting for the dwell time
+
+        Returns 1 if successful, zero otherwise.
+
+        :rtype: `int`
         """
-        self.sendcmd("test")
+        response = self.query("test")
+        return check_cmd(response)

--- a/instruments/instruments/thorlabs/lcc25.py
+++ b/instruments/instruments/thorlabs/lcc25.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-##
+#
 # lcc25.py: class for the Thorlabs LCC25 Liquid Crystal Controller
-##
+#
 # © 2014-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
-##
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -20,10 +20,10 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+#
 # LCC25 Class contributed by Catherine Holloway
 #
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 import quantities as pq
 from flufl.enum import IntEnum
@@ -73,17 +73,19 @@ def check_cmd(response):
         return 0
 
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
 
 class LCC25(Instrument):
+
     """
     The LCC25 is a controller for the thorlabs liquid crystal modules.
-    it can set two voltages and then oscillate between them at a specific 
+    it can set two voltages and then oscillate between them at a specific
     repetition rate.
-    
+
     The user manual can be found here:
     http://www.thorlabs.com/thorcat/18800/LCC25-Manual.pdf
     """
+
     def __init__(self, filelike):
         super(LCC25, self).__init__(filelike)
         self.terminator = "\r"
@@ -92,15 +94,15 @@ class LCC25(Instrument):
 
     def _ack_expected(self, msg=""):
         return msg
-        
-    ## ENUMS ##
-    
+
+    # ENUMS #
+
     class Mode(IntEnum):
         normal = 0
         voltage1 = 1
         voltage2 = 2
-    
-    ## PROPERTIES ##
+
+    # PROPERTIES #
 
     def name(self):
         """
@@ -113,15 +115,15 @@ class LCC25(Instrument):
     @property
     def frequency(self):
         """
-        Gets/sets the frequency at which the LCC oscillates between the 
+        Gets/sets the frequency at which the LCC oscillates between the
         two voltages.
-        
-        :units: As specified (if a `~quantities.Quantity`) or assumed to be
-            of units Hertz.
-        :rtype: `~quantities.Quantity`
+
+        :units: As specified (if a `~quantities.quantity.Quantity`) or assumed
+            to be of units Hertz.
+        :rtype: `~quantities.quantity.Quantity`
         """
         response = self.query("freq?")
-        return float(response)*pq.Hz
+        return float(response) * pq.Hz
 
     @frequency.setter
     def frequency(self, newval):
@@ -136,7 +138,7 @@ class LCC25(Instrument):
     def mode(self):
         """
         Gets/sets the output mode of the LCC25
-        
+
         :rtype: `LCC25.Mode`
         """
         response = self.query("mode?")
@@ -146,19 +148,19 @@ class LCC25(Instrument):
     def mode(self, newval):
         if not hasattr(newval, 'enum'):
             raise TypeError("Mode setting must be a `LCC25.Mode` value, "
-                "got {} instead.".format(type(newval)))
+                            "got {} instead.".format(type(newval)))
         if newval.enum is not LCC25.Mode:
             raise TypeError("Mode setting must be a `LCC25.Mode` value, "
-                "got {} instead.".format(type(newval)))
+                            "got {} instead.".format(type(newval)))
         self.sendcmd("mode={}".format(newval.value))
 
     @property
     def enable(self):
         """
         Gets/sets the output enable status.
-        
+
         If output enable is on (`True`), there is a voltage on the output.
-        
+
         :rtype: `bool`
         """
         response = self.query("enable?")
@@ -170,15 +172,15 @@ class LCC25(Instrument):
             raise TypeError("LLC25 enable property must be specified with a "
                             "boolean.")
         self.sendcmd("enable={}".format(int(newval)))
-    
+
     @property
     def extern(self):
         """
         Gets/sets the use of the external TTL modulation.
-        
+
         Value is `True` for external TTL modulation and `False` for internal
         modulation.
-        
+
         :rtype: `bool`
         """
         response = self.query("extern?")
@@ -196,10 +198,10 @@ class LCC25(Instrument):
     def remote(self):
         """
         Gets/sets front panel lockout status for remote instrument operation.
-        
+
         Value is `False` for normal operation and `True` to lock out the front
         panel buttons.
-        
+
         :rtype: `bool`
         """
         response = self.query("remote?")
@@ -216,13 +218,13 @@ class LCC25(Instrument):
     def voltage1(self):
         """
         Gets/sets the voltage value for output 1.
-        
+
         :units: As specified (if a `~quantities.Quantity`) or assumed to be
             of units Volts.
         :rtype: `~quantities.Quantity`
         """
         response = self.query("volt1?")
-        return float(response)*pq.V
+        return float(response) * pq.V
 
     @voltage1.setter
     def voltage1(self, newval):
@@ -234,13 +236,13 @@ class LCC25(Instrument):
     def voltage2(self):
         """
         Gets/sets the voltage value for output 2.
-        
+
         :units: As specified (if a `~quantities.Quantity`) or assumed to be
             of units Volts.
         :rtype: `~quantities.Quantity`
         """
         response = self.query("volt2?")
-        return float(response)*pq.V
+        return float(response) * pq.V
 
     @voltage2.setter
     def voltage2(self, newval):
@@ -252,13 +254,13 @@ class LCC25(Instrument):
     def min_voltage(self):
         """
         Gets/sets the minimum voltage value for the test mode.
-        
+
         :units: As specified (if a `~quantities.Quantity`) or assumed to be
             of units Volts.
         :rtype: `~quantities.Quantity`
         """
         response = self.query("min?")
-        return float(response)*pq.V
+        return float(response) * pq.V
 
     @min_voltage.setter
     def min_voltage(self, newval):
@@ -268,16 +270,16 @@ class LCC25(Instrument):
     @property
     def max_voltage(self):
         """
-        Gets/sets the maximum voltage value for the test mode. If the maximum 
+        Gets/sets the maximum voltage value for the test mode. If the maximum
         voltage is less than the minimum voltage, nothing happens.
-        
+
         :units: As specified (if a `~quantities.Quantity`) or assumed to be
             of units Volts.
         :rtype: `~quantities.Quantity`
-        
+
         """
         response = self.query("max?")
-        return float(response)*pq.V
+        return float(response) * pq.V
 
     @max_voltage.setter
     def max_voltage(self, newval):
@@ -289,13 +291,13 @@ class LCC25(Instrument):
     def dwell(self):
         """
         Gets/sets the dwell time for voltages for the test mode.
-        
+
         :units: As specified (if a `~quantities.Quantity`) or assumed to be
             of units milliseconds.
         :rtype: `~quantities.Quantity`
         """
         response = self.query("dwell?")
-        return float(response)*pq.ms
+        return float(response) * pq.ms
 
     @dwell.setter
     def dwell(self, newval):
@@ -308,13 +310,13 @@ class LCC25(Instrument):
     def increment(self):
         """
         Gets/sets the voltage increment for voltages for the test mode.
-        
+
         :units: As specified (if a `~quantities.Quantity`) or assumed to be
             of units Volts.
         :rtype: `~quantities.Quantity`
         """
         response = self.query("increment?")
-        return float(response)*pq.V
+        return float(response) * pq.V
 
     @increment.setter
     def increment(self, newval):
@@ -323,13 +325,13 @@ class LCC25(Instrument):
             raise ValueError("Increment voltage must be positive")
         self.sendcmd("increment={}".format(newval))
 
-    ## METHODS ##
+    # METHODS ##
     def default(self):
         """
         Restores instrument to factory settings.
-        
+
         Returns 1 if successful, 0 otherwise
-        
+
         :rtype: `int`
         """
         response = self.query("default")
@@ -338,9 +340,9 @@ class LCC25(Instrument):
     def save(self):
         """
         Stores the parameters in static memory
-        
+
         Returns 1 if successful, zero otherwise.
-        
+
         :rtype: `int`
         """
         self.sendcmd("save")
@@ -348,12 +350,12 @@ class LCC25(Instrument):
     def set_settings(self, slot):
         """
         Saves the current settings to memory
-        
+
         Returns 1 if successful, zero otherwise.
-        
+
         :param slot: Memory slot to use, valid range `[1,4]`
         :type slot: `int`
-        
+
         :rtype: `int`
         """
         slot_latch(slot)
@@ -362,27 +364,25 @@ class LCC25(Instrument):
     def get_settings(self, slot):
         """
         Gets the current settings to memory
-        
+
         Returns 1 if successful, zero otherwise.
-        
+
         :param slot: Memory slot to use, valid range `[1,4]`
         :type slot: `int`
-        
+
         :rtype: `int`
         """
         slot_latch(slot)
         self.sendcmd("get={}".format(slot))
 
-
     def test_mode(self):
         """
-        Puts the LCC in test mode - meaning it will increment the output 
-        voltage from the minimum value to the maximum value, in increments, 
+        Puts the LCC in test mode - meaning it will increment the output
+        voltage from the minimum value to the maximum value, in increments,
         waiting for the dwell time
-        
+
         Returns 1 if successful, zero otherwise.
-        
+
         :rtype: `int`
         """
         self.sendcmd("test")
-

--- a/instruments/instruments/thorlabs/lcc25.py
+++ b/instruments/instruments/thorlabs/lcc25.py
@@ -23,6 +23,11 @@
 #
 # LCC25 Class contributed by Catherine Holloway
 #
+"""
+Provides the support for the Thorlabs LCC25 liquid crystal controller.
+
+Class originally contributed by Catherine Holloway.
+"""
 
 # IMPORTS #####################################################################
 
@@ -63,6 +68,10 @@ class LCC25(Instrument):
     # ENUMS #
 
     class Mode(IntEnum):
+
+        """
+        Enum containing valid output modes of the LCC25
+        """
         normal = 0
         voltage1 = 1
         voltage2 = 2

--- a/instruments/instruments/thorlabs/lcc25.py
+++ b/instruments/instruments/thorlabs/lcc25.py
@@ -23,7 +23,12 @@
 #
 # LCC25 Class contributed by Catherine Holloway
 #
+
 # IMPORTS #####################################################################
+
+from __future__ import absolute_import
+from __future__ import division
+from builtins import range
 
 import quantities as pq
 from flufl.enum import IntEnum
@@ -270,7 +275,7 @@ class LCC25(Instrument):
         :type slot: `int`
         :rtype: `int`
         """
-        if slot not in xrange(1, 5):
+        if slot not in range(1, 5):
             raise ValueError("Cannot set memory out of `[1,4]` range")
         response = self.query("set={}".format(slot))
         return check_cmd(response)
@@ -285,7 +290,7 @@ class LCC25(Instrument):
         :type slot: `int`
         :rtype: `int`
         """
-        if slot not in xrange(1, 5):
+        if slot not in range(1, 5):
             raise ValueError("Cannot set memory out of `[1,4]` range")
         response = self.query("get={}".format(slot))
         return check_cmd(response)

--- a/instruments/instruments/thorlabs/lcc25.py
+++ b/instruments/instruments/thorlabs/lcc25.py
@@ -3,7 +3,7 @@
 ##
 # lcc25.py: class for the Thorlabs LCC25 Liquid Crystal Controller
 ##
-# © 2014 Steven Casagrande (scasagrande@galvant.ca).
+# © 2014-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
@@ -48,6 +48,7 @@ def voltage_latch(newval):
 def slot_latch(slot):
     """
     Makes sure that the slot is within the number of defined values
+
     :param slot: the slot number
     :type slot: int
     """
@@ -59,7 +60,9 @@ def slot_latch(slot):
 
 def check_cmd(response):
     """
-    Checks the for the two common Thorlabs error messages; CMD_NOT_DEFINED and CMD_ARG_INVALID
+    Checks the for the two common Thorlabs error messages; CMD_NOT_DEFINED and
+    CMD_ARG_INVALID
+
     :param response: the response from the device
     :return: 1 if not found, 0 otherwise
     :rtype: int
@@ -86,6 +89,9 @@ class LCC25(Instrument):
         self.terminator = "\r"
         self.prompt = ">"
         self.echo = True
+
+    def _ack_expected(self, msg=""):
+        return msg
         
     ## ENUMS ##
     
@@ -98,7 +104,9 @@ class LCC25(Instrument):
 
     def name(self):
         """
-        gets the name and version number of the device
+        Gets the name and version number of the device
+
+        :rtype: `str`
         """
         return self.query("*idn?")
 
@@ -335,8 +343,7 @@ class LCC25(Instrument):
         
         :rtype: `int`
         """
-        response = self.query("save")
-        return check_cmd(response)
+        self.sendcmd("save")
 
     def set_settings(self, slot):
         """
@@ -350,10 +357,9 @@ class LCC25(Instrument):
         :rtype: `int`
         """
         slot_latch(slot)
-        response = self.query("set={}".format(slot))
-        return check_cmd(response)
+        self.sendcmd("set={}".format(slot))
 
-    def get_settings(self,slot):
+    def get_settings(self, slot):
         """
         Gets the current settings to memory
         
@@ -365,8 +371,8 @@ class LCC25(Instrument):
         :rtype: `int`
         """
         slot_latch(slot)
-        response = self.query("get={}".format(slot))
-        return check_cmd(response)
+        self.sendcmd("get={}".format(slot))
+
 
     def test_mode(self):
         """
@@ -378,5 +384,5 @@ class LCC25(Instrument):
         
         :rtype: `int`
         """
-        response = self.query("test")
-        return check_cmd(response)
+        self.sendcmd("test")
+

--- a/instruments/instruments/thorlabs/lcc25.py
+++ b/instruments/instruments/thorlabs/lcc25.py
@@ -99,7 +99,7 @@ class LCC25(Instrument):
 
         :rtype: `LCC25.Mode`
         """
-     )
+    )
 
     enable = bool_property(
         "enable",

--- a/instruments/instruments/thorlabs/pm100usb.py
+++ b/instruments/instruments/thorlabs/pm100usb.py
@@ -3,7 +3,7 @@
 ##
 # pm100usb.py: Driver class for the PM100USB power meter.
 ##
-# © 2013 Steven Casagrande (scasagrande@galvant.ca).
+# © 2013-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
@@ -22,11 +22,10 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 ##
 
-## FEATURES ####################################################################
+# IMPORTS #####################################################################
 
+from __future__ import absolute_import
 from __future__ import division
-
-## IMPORTS #####################################################################
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import enum_property
@@ -37,13 +36,14 @@ from collections import defaultdict
 import quantities as pq
 from collections import namedtuple
 
-## LOGGING #####################################################################
+# LOGGING #####################################################################
 
 import logging
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
+
 
 class PM100USB(SCPIInstrument):
     """

--- a/instruments/instruments/thorlabs/sc10.py
+++ b/instruments/instruments/thorlabs/sc10.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-##
+#
 # sc10.py: Class for the thorlabs sc10 Shutter Controller
-##
+#
 # © 2014-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
-##
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -20,10 +20,10 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+#
 # SC10 Class contributed by Catherine Holloway
 #
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 import quantities as pq
 from flufl.enum import IntEnum
@@ -58,11 +58,13 @@ def check_time(newval):
 
 
 class SC10(Instrument):
+
     """
     The SC10 is a shutter controller, to be used with the Thorlabs SH05 and SH1.
     The user manual can be found here:
     http://www.thorlabs.com/thorcat/8600/SC10-Manual.pdf
     """
+
     def __init__(self, filelike):
         super(SC10, self).__init__(filelike)
         self.terminator = '\r'
@@ -72,16 +74,16 @@ class SC10(Instrument):
     def _ack_expected(self, msg=""):
         return msg
 
-    ## ENUMS ##
-    
+    # ENUMS ##
+
     class Mode(IntEnum):
         manual = 1
         auto = 2
         single = 3
         repeat = 4
         external = 5
-        
-    ## PROPERTIES ##
+
+    # PROPERTIES ##
 
     def name(self):
         """
@@ -94,7 +96,7 @@ class SC10(Instrument):
     def enable(self):
         """
         Gets/sets the shutter enable status, 0 for disabled, 1 if enabled
-        
+
         :type: `int`
         """
         response = self.query("ens?")
@@ -105,14 +107,14 @@ class SC10(Instrument):
         if newval == 0 or newval == 1:
             self.sendcmd("ens={}".format(newval))
         else:
-            raise ValueError("Invalid value for enable, must be 0 or 1")        
+            raise ValueError("Invalid value for enable, must be 0 or 1")
 
     @property
     def repeat(self):
         """
         Gets/sets the repeat count for repeat mode. Valid range is [1,99]
         inclusive.
-        
+
         :type: `int`
         """
         response = self.query("rep?")
@@ -125,7 +127,7 @@ class SC10(Instrument):
             self.read()
         else:
             raise ValueError("Invalid value for repeat count, must be "
-                             "between 1 and 99")        
+                             "between 1 and 99")
 
     @property
     def mode(self):
@@ -141,21 +143,20 @@ class SC10(Instrument):
     def mode(self, newval):
         if not hasattr(newval, 'enum'):
             raise TypeError("Mode setting must be a `SC10.Mode` value, "
-                "got {} instead.".format(type(newval)))
+                            "got {} instead.".format(type(newval)))
         if newval.enum is not SC10.Mode:
             raise TypeError("Mode setting must be a `SC10.Mode` value, "
-                "got {} instead.".format(type(newval)))
-        
-        self.sendcmd("mode={}".format(newval.value))
+                            "got {} instead.".format(type(newval)))
 
+        self.sendcmd("mode={}".format(newval.value))
 
     @property
     def trigger(self):
         """
         Gets/sets the trigger source.
-        
+
         0 for internal trigger, 1 for external trigger
-        
+
         :type: `int`
         """
         response = self.query("trig?")
@@ -170,10 +171,10 @@ class SC10(Instrument):
     def out_trigger(self):
         """
         Gets/sets the out trigger source.
-        
-        0 trigger out follows shutter output, 1 trigger out follows 
+
+        0 trigger out follows shutter output, 1 trigger out follows
         controller output
-        
+
         :type: `int`
         """
         response = self.query("xto?")
@@ -184,36 +185,36 @@ class SC10(Instrument):
         trigger_check(newval)
         self.sendcmd("xto={}".format(newval))
 
-    ###I'm not sure how to handle checking for the number of digits yet.
+    # I'm not sure how to handle checking for the number of digits yet.
     @property
     def open_time(self):
         """
         Gets/sets the amount of time that the shutter is open, in ms
-        
+
         :units: As specified (if a `~quantities.Quantity`) or assumed to be
             of units milliseconds.
         :type: `~quantities.Quantity`
         """
         response = self.query("open?")
-        return float(response)*pq.ms
+        return float(response) * pq.ms
 
     @open_time.setter
     def open_time(self, newval):
         newval = int(assume_units(newval, pq.ms).rescale(pq.ms).magnitude)
         check_time(newval)
         self.sendcmd("open={}".format(newval))
-    
+
     @property
     def shut_time(self):
         """
         Gets/sets the amount of time that the shutter is closed, in ms
-        
+
         :units: As specified (if a `~quantities.Quantity`) or assumed to be
             of units milliseconds.
         :rtype: `~quantities.Quantity`
         """
         response = self.query("shut?")
-        return float(response)*pq.ms
+        return float(response) * pq.ms
 
     @shut_time.setter
     def shut_time(self, newval):
@@ -221,14 +222,13 @@ class SC10(Instrument):
         check_time(newval)
         self.sendcmd("shut={}".format(newval))
 
-
     @property
     def baud_rate(self):
         """
         Gets/sets the instrument baud rate.
-        
+
         Valid baud rates are 9600 and 115200.
-        
+
         :type: `int`
         """
         response = self.query("baud?")
@@ -240,40 +240,40 @@ class SC10(Instrument):
             raise ValueError("Invalid baud rate mode")
         else:
             self.sendcmd("baud={}".format(0 if newval == 9600 else 1))
-    
+
     @property
     def closed(self):
         """
         Gets the shutter closed status.
-        
+
         `True` represents the shutter is closed, and `False` for the shutter is
         open.
-        
+
         :rtype: `bool`
         """
         response = self.query("closed?")
         return True if int(response) is 1 else False
-    
+
     @property
     def interlock(self):
         """
         Gets the interlock tripped status.
-        
+
         Returns `True` if the interlock is tripped, and `False` otherwise.
-        
+
         :rtype: `bool`
         """
         response = self.query("interlock?")
         return True if int(response) is 1 else False
 
-    ## Methods ##
-        
+    # Methods ##
+
     def default(self):
         """
         Restores instrument to factory settings.
-        
+
         Returns 1 if successful, zero otherwise.
-        
+
         :rtype: `int`
         """
         response = self.query("default")
@@ -282,9 +282,9 @@ class SC10(Instrument):
     def save(self):
         """
         Stores the parameters in static memory
-        
+
         Returns 1 if successful, zero otherwise.
-        
+
         :rtype: `int`
         """
         response = self.query("savp")
@@ -293,9 +293,9 @@ class SC10(Instrument):
     def save_mode(self):
         """
         Stores output trigger mode and baud rate settings in memory.
-        
+
         Returns 1 if successful, zero otherwise.
-        
+
         :rtype: `int`
         """
         response = self.query("save")
@@ -304,9 +304,9 @@ class SC10(Instrument):
     def restore(self):
         """
         Loads the settings from memory.
-        
+
         Returns 1 if successful, zero otherwise.
-        
+
         :rtype: `int`
         """
         response = self.query("resp")

--- a/instruments/instruments/thorlabs/sc10.py
+++ b/instruments/instruments/thorlabs/sc10.py
@@ -29,32 +29,12 @@ import quantities as pq
 from flufl.enum import IntEnum
 
 from instruments.abstract_instruments import Instrument
-from instruments.util_fns import assume_units
+from instruments.util_fns import (
+    bool_property, enum_property, int_property, unitful_property
+)
 from instruments.thorlabs._utils import check_cmd
 
-
-def trigger_check(newval):
-    """
-    Validate the trigger
-    :param newval: trigger
-    :type newval: int
-    :return:
-    """
-    if newval != 0 and newval != 1:
-        raise ValueError("Not a valid value for trigger mode")
-
-
-def check_time(newval):
-    """
-    Validate the shutter time
-    :param newval: the new time
-    :type newval: int
-    :return:
-    """
-    if newval < 0:
-        raise ValueError("Duration cannot be negative")
-    if newval > 999999:
-        raise ValueError("Duration is too long")
+# CLASSES #####################################################################
 
 
 class SC10(Instrument):
@@ -69,12 +49,11 @@ class SC10(Instrument):
         super(SC10, self).__init__(filelike)
         self.terminator = '\r'
         self.prompt = '>'
-        self.echo = True
 
     def _ack_expected(self, msg=""):
         return msg
 
-    # ENUMS ##
+    # ENUMS #
 
     class Mode(IntEnum):
         manual = 1
@@ -83,93 +62,75 @@ class SC10(Instrument):
         repeat = 4
         external = 5
 
-    # PROPERTIES ##
+    # PROPERTIES #
 
+    @property
     def name(self):
         """
         Gets the name and version number of the device.
-        """
-        response = self.query("id?")
-        return response
 
-    @property
-    def enable(self):
+        :return: Name and verison number of the device
+        :rtype: `str`
         """
-        Gets/sets the shutter enable status, 0 for disabled, 1 if enabled
+        return self.query("id?")
 
-        :type: `int`
+    enable = bool_property(
+        "ens",
+        "1",
+        "0",
+        set_fmt="{}={}",
+        doc="""
+        Gets/sets the shutter enable status, False for disabled, True if
+        enabled
+
+        If output enable is on (`True`), there is a voltage on the output.
+
+        :rtype: `bool`
         """
-        response = self.query("ens?")
-        return int(response)
+    )
 
-    @enable.setter
-    def enable(self, newval):
-        if newval == 0 or newval == 1:
-            self.sendcmd("ens={}".format(newval))
-        else:
-            raise ValueError("Invalid value for enable, must be 0 or 1")
-
-    @property
-    def repeat(self):
-        """
+    repeat = int_property(
+        "rep",
+        valid_set=xrange(1, 100),
+        set_fmt="{}={}",
+        doc="""
         Gets/sets the repeat count for repeat mode. Valid range is [1,99]
         inclusive.
 
         :type: `int`
         """
-        response = self.query("rep?")
-        return int(response)
+    )
 
-    @repeat.setter
-    def repeat(self, newval):
-        if 0 < newval < 100:
-            self.sendcmd("rep={}".format(newval))
-            self.read()
-        else:
-            raise ValueError("Invalid value for repeat count, must be "
-                             "between 1 and 99")
+    mode = enum_property(
+        "mode",
+        Mode,
+        input_decoration=int,
+        set_fmt="{}={}",
+        doc="""
+        Gets/sets the output mode of the LCC25
 
-    @property
-    def mode(self):
+        :rtype: `LCC25.Mode`
         """
-        Gets/sets the output mode of the SC10.
+    )
 
-        :type: `SC10.Mode`
-        """
-        response = self.query("mode?")
-        return SC10.Mode[int(response)]
-
-    @mode.setter
-    def mode(self, newval):
-        if not hasattr(newval, 'enum'):
-            raise TypeError("Mode setting must be a `SC10.Mode` value, "
-                            "got {} instead.".format(type(newval)))
-        if newval.enum is not SC10.Mode:
-            raise TypeError("Mode setting must be a `SC10.Mode` value, "
-                            "got {} instead.".format(type(newval)))
-
-        self.sendcmd("mode={}".format(newval.value))
-
-    @property
-    def trigger(self):
-        """
+    trigger = int_property(
+        "trig",
+        valid_set=xrange(0, 2),
+        set_fmt="{}={}",
+        doc="""
         Gets/sets the trigger source.
 
         0 for internal trigger, 1 for external trigger
 
         :type: `int`
         """
-        response = self.query("trig?")
-        return int(response)
+    )
 
-    @trigger.setter
-    def trigger(self, newval):
-        trigger_check(newval)
-        self.sendcmd("trig={}".format(newval))
-
-    @property
-    def out_trigger(self):
-        """
+    out_trigger = int_property(
+        "xto",
+        valid_set=xrange(0, 2),
+        set_fmt="{}={}",
+        doc="""
         Gets/sets the out trigger source.
 
         0 trigger out follows shutter output, 1 trigger out follows
@@ -177,50 +138,37 @@ class SC10(Instrument):
 
         :type: `int`
         """
-        response = self.query("xto?")
-        return int(response)
+    )
 
-    @out_trigger.setter
-    def out_trigger(self, newval):
-        trigger_check(newval)
-        self.sendcmd("xto={}".format(newval))
-
-    # I'm not sure how to handle checking for the number of digits yet.
-    @property
-    def open_time(self):
-        """
+    open_time = unitful_property(
+        "open",
+        pq.ms,
+        format_code="{:.0f}",
+        set_fmt="{}={}",
+        valid_range=(0, 999999),
+        doc="""
         Gets/sets the amount of time that the shutter is open, in ms
 
-        :units: As specified (if a `~quantities.Quantity`) or assumed to be
-            of units milliseconds.
-        :type: `~quantities.Quantity`
+        :units: As specified (if a `~quantities.quantity.Quantity`) or assumed
+            to be of units milliseconds.
+        :type: `~quantities.quantity.Quantity`
         """
-        response = self.query("open?")
-        return float(response) * pq.ms
+    )
 
-    @open_time.setter
-    def open_time(self, newval):
-        newval = int(assume_units(newval, pq.ms).rescale(pq.ms).magnitude)
-        check_time(newval)
-        self.sendcmd("open={}".format(newval))
-
-    @property
-    def shut_time(self):
-        """
+    shut_time = unitful_property(
+        "shut",
+        pq.ms,
+        format_code="{:.0f}",
+        set_fmt="{}={}",
+        valid_range=(0, 999999),
+        doc="""
         Gets/sets the amount of time that the shutter is closed, in ms
 
-        :units: As specified (if a `~quantities.Quantity`) or assumed to be
-            of units milliseconds.
-        :rtype: `~quantities.Quantity`
+        :units: As specified (if a `~quantities.quantity.Quantity`) or assumed
+            to be of units milliseconds.
+        :type: `~quantities.quantity.Quantity`
         """
-        response = self.query("shut?")
-        return float(response) * pq.ms
-
-    @shut_time.setter
-    def shut_time(self, newval):
-        newval = int(assume_units(newval, pq.ms).rescale(pq.ms).magnitude)
-        check_time(newval)
-        self.sendcmd("shut={}".format(newval))
+    )
 
     @property
     def baud_rate(self):
@@ -241,9 +189,12 @@ class SC10(Instrument):
         else:
             self.sendcmd("baud={}".format(0 if newval == 9600 else 1))
 
-    @property
-    def closed(self):
-        """
+    closed = bool_property(
+        "closed",
+        "1",
+        "0",
+        readonly=True,
+        doc="""
         Gets the shutter closed status.
 
         `True` represents the shutter is closed, and `False` for the shutter is
@@ -251,22 +202,23 @@ class SC10(Instrument):
 
         :rtype: `bool`
         """
-        response = self.query("closed?")
-        return True if int(response) is 1 else False
+    )
 
-    @property
-    def interlock(self):
-        """
+    interlock = bool_property(
+        "interlock",
+        "1",
+        "0",
+        readonly=True,
+        doc="""
         Gets the interlock tripped status.
 
         Returns `True` if the interlock is tripped, and `False` otherwise.
 
         :rtype: `bool`
         """
-        response = self.query("interlock?")
-        return True if int(response) is 1 else False
+    )
 
-    # Methods ##
+    # Methods #
 
     def default(self):
         """

--- a/instruments/instruments/thorlabs/sc10.py
+++ b/instruments/instruments/thorlabs/sc10.py
@@ -23,10 +23,15 @@
 #
 # SC10 Class contributed by Catherine Holloway
 #
+
 # IMPORTS #####################################################################
 
-import quantities as pq
+from __future__ import absolute_import
+from __future__ import division
+from builtins import range
+
 from flufl.enum import IntEnum
+import quantities as pq
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import (
@@ -91,7 +96,7 @@ class SC10(Instrument):
 
     repeat = int_property(
         "rep",
-        valid_set=xrange(1, 100),
+        valid_set=range(1, 100),
         set_fmt="{}={}",
         doc="""
         Gets/sets the repeat count for repeat mode. Valid range is [1,99]
@@ -115,7 +120,7 @@ class SC10(Instrument):
 
     trigger = int_property(
         "trig",
-        valid_set=xrange(0, 2),
+        valid_set=range(0, 2),
         set_fmt="{}={}",
         doc="""
         Gets/sets the trigger source.
@@ -128,7 +133,7 @@ class SC10(Instrument):
 
     out_trigger = int_property(
         "xto",
-        valid_set=xrange(0, 2),
+        valid_set=range(0, 2),
         set_fmt="{}={}",
         doc="""
         Gets/sets the out trigger source.

--- a/instruments/instruments/thorlabs/sc10.py
+++ b/instruments/instruments/thorlabs/sc10.py
@@ -3,7 +3,7 @@
 ##
 # sc10.py: Class for the thorlabs sc10 Shutter Controller
 ##
-# © 2014 Steven Casagrande (scasagrande@galvant.ca).
+# © 2014-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
@@ -68,6 +68,10 @@ class SC10(Instrument):
         self.terminator = '\r'
         self.prompt = '>'
         self.echo = True
+
+    def _ack_expected(self, msg=""):
+        return msg
+
     ## ENUMS ##
     
     class Mode(IntEnum):
@@ -98,9 +102,8 @@ class SC10(Instrument):
 
     @enable.setter
     def enable(self, newval):
-        if newval == 0 or newval ==1:
+        if newval == 0 or newval == 1:
             self.sendcmd("ens={}".format(newval))
-            self.read()
         else:
             raise ValueError("Invalid value for enable, must be 0 or 1")        
 
@@ -144,8 +147,8 @@ class SC10(Instrument):
                 "got {} instead.".format(type(newval)))
         
         self.sendcmd("mode={}".format(newval.value))
-        self.read()        
-    
+
+
     @property
     def trigger(self):
         """
@@ -162,8 +165,7 @@ class SC10(Instrument):
     def trigger(self, newval):
         trigger_check(newval)
         self.sendcmd("trig={}".format(newval))
-        self.read()
-    
+
     @property
     def out_trigger(self):
         """
@@ -218,8 +220,8 @@ class SC10(Instrument):
         newval = int(assume_units(newval, pq.ms).rescale(pq.ms).magnitude)
         check_time(newval)
         self.sendcmd("shut={}".format(newval))
-        self.read()
-    
+
+
     @property
     def baud_rate(self):
         """
@@ -229,8 +231,8 @@ class SC10(Instrument):
         
         :type: `int`
         """
-        response = self.sendcmd("baud?")
-        return 115200 if response else 9600
+        response = self.query("baud?")
+        return 115200 if int(response) else 9600
 
     @baud_rate.setter
     def baud_rate(self, newval):

--- a/instruments/instruments/thorlabs/sc10.py
+++ b/instruments/instruments/thorlabs/sc10.py
@@ -30,7 +30,7 @@ from flufl.enum import IntEnum
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import assume_units
-from instruments.thorlabs import check_cmd
+from instruments.thorlabs._utils import check_cmd
 
 
 def trigger_check(newval):

--- a/instruments/instruments/thorlabs/sc10.py
+++ b/instruments/instruments/thorlabs/sc10.py
@@ -32,7 +32,7 @@ from instruments.abstract_instruments import Instrument
 from instruments.util_fns import (
     bool_property, enum_property, int_property, unitful_property
 )
-from instruments.thorlabs._utils import check_cmd
+from instruments.thorlabs.thorlabs_utils import check_cmd
 
 # CLASSES #####################################################################
 

--- a/instruments/instruments/thorlabs/sc10.py
+++ b/instruments/instruments/thorlabs/sc10.py
@@ -23,6 +23,11 @@
 #
 # SC10 Class contributed by Catherine Holloway
 #
+"""
+Provides the support for the Thorlabs SC10 optical beam shutter controller.
+
+Class originally contributed by Catherine Holloway.
+"""
 
 # IMPORTS #####################################################################
 
@@ -61,6 +66,10 @@ class SC10(Instrument):
     # ENUMS #
 
     class Mode(IntEnum):
+
+        """
+        Enum containing valid output modes of the SC10
+        """
         manual = 1
         auto = 2
         single = 3
@@ -112,9 +121,9 @@ class SC10(Instrument):
         input_decoration=int,
         set_fmt="{}={}",
         doc="""
-        Gets/sets the output mode of the LCC25
+        Gets/sets the output mode of the SC10
 
-        :rtype: `LCC25.Mode`
+        :rtype: `SC10.Mode`
         """
     )
 

--- a/instruments/instruments/thorlabs/tc200.py
+++ b/instruments/instruments/thorlabs/tc200.py
@@ -23,7 +23,11 @@
 #
 # TC200 Class contributed by Catherine Holloway
 #
+
 # IMPORTS #####################################################################
+
+from __future__ import absolute_import
+from __future__ import division
 
 import quantities as pq
 from flufl.enum import IntEnum

--- a/instruments/instruments/thorlabs/tc200.py
+++ b/instruments/instruments/thorlabs/tc200.py
@@ -23,17 +23,24 @@
 #
 # TC200 Class contributed by Catherine Holloway
 #
+"""
+Provides the support for the Thorlabs TC200 temperature controller.
+
+Class originally contributed by Catherine Holloway.
+"""
 
 # IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
+from builtins import range, map
 
 import quantities as pq
-from flufl.enum import IntEnum
+from flufl.enum import IntEnum, Enum
 
 from instruments.abstract_instruments import Instrument
-from instruments.util_fns import assume_units, convert_temperature
+from instruments.util_fns import convert_temperature
+from instruments.util_fns import enum_property, unitful_property, int_property
 
 # CLASSES #####################################################################
 
@@ -60,14 +67,22 @@ class TC200(Instrument):
     # ENUMS #
 
     class Mode(IntEnum):
+
+        """
+        Enum containing valid output modes of the TC200.
+        """
         normal = 0
         cycle = 1
 
-    class Sensor(IntEnum):
-        ptc100 = 0
-        ptc1000 = 1
-        th10k = 2
-        ntc10k = 3
+    class Sensor(Enum):
+
+        """
+        Enum containing valid temperature sensor types for the TC200.
+        """
+        ptc100 = "ptc100"
+        ptc1000 = "ptc1000"
+        th10k = "th10k"
+        ntc10k = "ntc10k"
 
     # PROPERTIES #
 
@@ -128,10 +143,14 @@ class TC200(Instrument):
         elif not newval and self.enable:
             self.sendcmd("ens")
 
-    @property
-    def temperature(self):
-        """
-        Gets/sets the temperature
+    temperature = unitful_property(
+        "tact",
+        units=pq.degC,
+        readonly=True,
+        input_decoration=lambda x: x.replace(
+            " C", "").replace(" F", "").replace(" K", ""),
+        doc="""
+        Gets the actual temperature of the sensor
 
         :units: As specified (if a `~quantities.quantity.Quantity`) or assumed
             to be of units degrees C.
@@ -139,16 +158,45 @@ class TC200(Instrument):
         :return: the temperature (in degrees C)
         :rtype: `~quantities.quantity.Quantity`
         """
-        response = self.query("tact?").replace(
+    )
+
+    max_temperature = unitful_property(
+        "tmax",
+        units=pq.degC,
+        format_code="{:.1f}",
+        set_fmt="{}={}",
+        valid_range=(20, 205),
+        doc="""
+        Gets/sets the maximum temperature
+
+        :return: the maximum temperature (in deg C)
+        :units: As specified or assumed to be degree Celsius. Returns with
+            units degC.
+        :rtype: `~quantities.quantity.Quantity`
+        """
+    )
+
+    @property
+    def temperature_set(self):
+        """
+        Gets/sets the actual temperature of the sensor
+
+        :units: As specified (if a `~quantities.quantity.Quantity`) or assumed
+            to be of units degrees C.
+        :type: `~quantities.quantity.Quantity` or `int`
+        :return: the temperature (in degrees C)
+        :rtype: `~quantities.quantity.Quantity`
+        """
+        response = self.query("tset?").replace(
             " C", "").replace(" F", "").replace(" K", "")
         return float(response) * pq.degC
 
-    @temperature.setter
-    def temperature(self, newval):
+    @temperature_set.setter
+    def temperature_set(self, newval):
         # the set temperature is always in celsius
         newval = convert_temperature(newval, pq.degC).magnitude
         if newval < 20.0 or newval > self.max_temperature:
-            raise ValueError("Temperature is out of range.")
+            raise ValueError("Temperature set is out of range.")
         out_query = "tset={}".format(newval)
         self.sendcmd(out_query)
 
@@ -160,15 +208,12 @@ class TC200(Instrument):
         :return: the p-gain (in nnn)
         :rtype: `int`
         """
-        response = self.query("pid?")
-        return int(response.split(" ")[0])
+        return self.pid[0]
 
     @p.setter
     def p(self, newval):
-        if newval < 1:
-            raise ValueError("P-Value is too low.")
-        if newval > 250:
-            raise ValueError("P-Value is too high")
+        if newval not in range(1, 251):
+            raise ValueError("P-value not in [1, 250]")
         self.sendcmd("pgain={}".format(newval))
 
     @property
@@ -179,15 +224,12 @@ class TC200(Instrument):
         :return: the i-gain (in nnn)
         :rtype: `int`
         """
-        response = self.query("pid?")
-        return int(response.split(" ")[1])
+        return self.pid[1]
 
     @i.setter
     def i(self, newval):
-        if newval < 0:
-            raise ValueError("I-Value is too low.")
-        if newval > 250:
-            raise ValueError("I-Value is too high")
+        if newval not in range(0, 251):
+            raise ValueError("I-value not in [0, 250]")
         self.sendcmd("igain={}".format(newval))
 
     @property
@@ -198,16 +240,38 @@ class TC200(Instrument):
         :return: the d-gain (in nnn)
         :type: `int`
         """
-        response = self.query("pid?")
-        return int(response.split(" ")[2])
+        return self.pid[2]
 
     @d.setter
     def d(self, newval):
-        if newval < 0:
-            raise ValueError("D-Value is too low.")
-        if newval > 250:
-            raise ValueError("D-Value is too high")
+        if newval not in range(0, 251):
+            raise ValueError("D-value not in [0, 250]")
         self.sendcmd("dgain={}".format(newval))
+
+    @property
+    def pid(self):
+        """
+        Gets/sets all three PID values at the same time. See `TC200.p`,
+        `TC200.i`, and `TC200.d` for individual restrictions.
+
+        If `None` is specified then the corresponding PID value is not changed.
+
+        :return: List of integers of PID values. In order [P, I, D].
+        :type: `list` or `tuple`
+        :rtype: `list`
+        """
+        return list(map(int, self.query("pid?").split()))
+
+    @pid.setter
+    def pid(self, newval):
+        if not isinstance(newval, list) and not isinstance(newval, tuple):
+            raise TypeError("Setting PID must be specified as a list or tuple")
+        if newval[0] is not None:
+            self.p = newval[0]
+        if newval[1] is not None:
+            self.i = newval[1]
+        if newval[2] is not None:
+            self.d = newval[2]
 
     @property
     def degrees(self):
@@ -237,89 +301,46 @@ class TC200(Instrument):
         else:
             raise TypeError("Invalid temperature type")
 
-    @property
-    def sensor(self):
-        """
+    sensor = enum_property(
+        "sns",
+        Sensor,
+        input_decoration=lambda x: x.split(
+            ",")[0].split("=")[1].strip().lower(),
+        set_fmt="{}={}",
+        doc="""
         Gets/sets the current thermistor type. Used for converting resistances
         to temperatures.
 
         :return: The thermistor type
         :type: `TC200.Sensor`
         """
-        response = self.query("sns?")
-        response = response.split(",")[0].replace(
-            "Sensor = ", '').replace(self.terminator, "").replace(" ", "")
-        return TC200.Sensor(response.lower())
+    )
 
-    @sensor.setter
-    def sensor(self, newval):
-        if not hasattr(newval, 'enum'):
-            raise TypeError("Sensor setting must be a `TC200.Sensor` value, "
-                            "got {} instead.".format(type(newval)))
-
-        if newval.enum is not TC200.Sensor:
-            raise TypeError("Sensor setting must be a `TC200.Sensor` value, "
-                            "got {} instead.".format(type(newval)))
-        self.sendcmd("sns={}".format(newval.name))
-
-    @property
-    def beta(self):
-        """
+    beta = int_property(
+        "beta",
+        valid_set=range(2000, 6001),
+        set_fmt="{}={}",
+        doc="""
         Gets/sets the beta value of the thermistor curve.
+
+        Value within [2000, 6000]
 
         :return: the gain (in nnn)
         :type: `int`
         """
-        response = self.query("beta?")
-        return int(response)
+    )
 
-    @beta.setter
-    def beta(self, newval):
-        if newval < 2000:
-            raise ValueError("Beta Value is too low.")
-        if newval > 6000:
-            raise ValueError("Beta Value is too high")
-        self.sendcmd("beta={}".format(newval))
-
-    @property
-    def max_power(self):
-        """
+    max_power = unitful_property(
+        "pmax",
+        units=pq.W,
+        format_code="{:.1f}",
+        set_fmt="{}={}",
+        valid_range=(0.1, 18.0),
+        doc="""
         Gets/sets the maximum power
 
         :return: The maximum power
         :units: Watts (linear units)
         :type: `~quantities.quantity.Quantity`
         """
-        response = self.query("pmax?")
-        return float(response) * pq.W
-
-    @max_power.setter
-    def max_power(self, newval):
-        newval = assume_units(newval, pq.W).rescale(pq.W).magnitude
-        if newval < 0.1:
-            raise ValueError("Power is too low.")
-        if newval > 18.0:
-            raise ValueError("Power is too high")
-        self.sendcmd("PMAX={}".format(newval))
-
-    @property
-    def max_temperature(self):
-        """
-        Gets/sets the maximum temperature
-
-        :return: the maximum temperature (in deg C)
-        :units: As specified or assumed to be degree Celsius. Returns with
-            units degC.
-        :rtype: `~quantities.quantity.Quantity`
-        """
-        response = self.query("tmax?").replace(" C", "")
-        return float(response) * pq.degC
-
-    @max_temperature.setter
-    def max_temperature(self, newval):
-        newval = convert_temperature(newval, pq.degC).magnitude
-        if newval < 20:
-            raise ValueError("Temperature is too low.")
-        if newval > 205.0:
-            raise ValueError("Temperature is too high")
-        self.sendcmd("TMAX={}".format(newval))
+    )

--- a/instruments/instruments/thorlabs/tc200.py
+++ b/instruments/instruments/thorlabs/tc200.py
@@ -1,0 +1,307 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+##
+# tc200.py: class for the Thorlabs TC200 Temperature Controller
+##
+# © 2014 Steven Casagrande (scasagrande@galvant.ca).
+#
+# This file is a part of the InstrumentKit project.
+# Licensed under the AGPL version 3.
+##
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+##
+# TC200 Class contributed by Catherine Holloway
+#
+## IMPORTS #####################################################################
+
+import quantities as pq
+from flufl.enum import IntEnum
+
+from instruments.abstract_instruments import Instrument
+from instruments.util_fns import assume_units, convert_temperature
+
+## CLASSES #####################################################################
+
+
+class TC200(Instrument):
+    """
+    The TC200 is is a controller for the voltage across a heating element. It can also read in the temperature off of a
+    thermistor and implements a PID control to keep the temperature at a set value.
+    The user manual can be found here:
+    http://www.thorlabs.com/thorcat/12500/TC200-Manual.pdf
+    """
+    def __init__(self, filelike):
+        super(TC200, self).__init__(filelike)
+        self.terminator = "\r"
+        self.prompt = ">"
+        self.echo = True
+
+    ## ENUMS ##
+
+    class Mode(IntEnum):
+        normal = 0
+        cycle = 1
+
+    class Sensor(IntEnum):
+        ptc100 = 0
+        ptc1000 = 1
+        th10k = 2
+        ntc10k = 3
+
+    ## PROPERTIES ##
+
+    def name(self):
+        """
+        gets the name and version number of the device
+        :return: the name string of the device
+        :rtype: str
+        """
+        response = self.query("*idn?")
+        return response
+
+    @property
+    def mode(self):
+        """
+        Gets/sets the output mode of the TC200
+
+        :type: `TC200.Mode`
+        """
+        response = self.query("stat?")
+        response_code = (int(response) << 1) % 2
+        return TC200.Mode[response_code]
+
+    @mode.setter
+    def mode(self, newval):
+        if not hasattr(newval, 'enum'):
+            raise TypeError("Mode setting must be a `TC200.Mode` value, "
+                "got {} instead.".format(type(newval)))
+        if newval.enum is not TC200.Mode:
+            raise TypeError("Mode setting must be a `TC200.Mode` value, "
+                "got {} instead.".format(type(newval)))
+        out_query = "mode={}".format(newval.name)
+        self.query(out_query)
+
+    @property
+    def enable(self):
+        """
+        Gets/sets the heater enable status.
+
+        If output enable is on (`True`), there is a voltage on the output.
+
+        :rtype: `bool`
+        """
+        response = self.query("stat?")
+        return True if int(response) % 2 is 1 else False
+
+    @enable.setter
+    def enable(self, newval):
+        if not isinstance(newval, bool):
+            raise TypeError("TC200 enable property must be specified with a "
+                            "boolean.")
+        # the "ens" command is a toggle, we need to track two different cases, when it should be on and it is off,
+        # and when it is off and should be on
+        if newval and not self.enable:
+            self.query("ens")
+        elif not newval and self.enable:
+            self.query("ens")
+
+    @property
+    def temperature(self):
+        """
+        Gets/sets the temperature
+
+        :return: the temperature (in degrees C)
+        :rtype: float
+        """
+        response = self.query("tact?").replace(" C", "").replace(" F", "").replace(" K", "")
+        return float(response)*pq.degC
+
+    @temperature.setter
+    def temperature(self, newval):
+        # the set temperature is always in celsius
+        newval = convert_temperature(newval, pq.degC).magnitude
+        if newval < 20.0 or newval > self.max_temperature:
+            raise ValueError("Temperature is out of range.")
+        out_query = "tset={}".format(newval)
+        self.query(out_query)
+
+    @property
+    def p(self):
+        """
+        Gets/sets the pgain
+
+        :return: the gain (in nnn)
+        :rtype: int
+        """
+        response = self.query("pid?")
+        return int(response.split(" ")[0])
+
+    @p.setter
+    def p(self, newval):
+        if newval < 1:
+            raise ValueError("P-Value is too low.")
+        if newval > 250:
+            raise ValueError("P-Value is too high")
+        self.query("pgain={}".format(newval))
+
+    @property
+    def i(self):
+        """
+        Gets/sets the igain
+
+        :return: the gain
+        :rtype: int
+        """
+        response = self.query("pid?")
+        return int(response.split(" ")[1])
+
+    @i.setter
+    def i(self, newval):
+        if newval < 0:
+            raise ValueError("I-Value is too low.")
+        if newval > 250:
+            raise ValueError("I-Value is too high")
+        self.query("igain={}".format(newval))
+
+    @property
+    def d(self):
+        """
+        Gets/sets the dgain
+
+        :return: the gain (in nnn)
+        :rtype: int
+        """
+        response = self.query("pid?")
+        return int(response.split(" ")[2])
+
+    @d.setter
+    def d(self, newval):
+        if newval < 0:
+            raise ValueError("D-Value is too low.")
+        if newval > 250:
+            raise ValueError("D-Value is too high")
+        self.query("dgain={}".format(newval))
+
+    @property
+    def degrees(self):
+        """
+        Gets/sets the mode of the temperature measurement.
+
+        :type: `~quantities.unitquantity.UnitTemperature`
+        """
+        response = self.query("stat?")
+        response = int(response)
+        if (response >> 4) % 2 and (response >> 5) % 2:
+            return pq.degC
+        elif (response >> 5) % 2:
+            return pq.degK
+        else:
+            return pq.degF
+
+    @degrees.setter
+    def degrees(self, newval):
+        if newval is pq.degC:
+            self.query("unit=c")
+        elif newval is pq.degF:
+            self.query("unit=f")
+        elif newval is pq.degK:
+            self.query("unit=k")
+        else:
+            raise TypeError("Invalid temperature type")
+
+    @property
+    def sensor(self):
+        """
+        Gets/sets the current thermistor type. Used for converting resistances to temperatures.
+
+        :rtype: TC200.Sensor
+
+        """
+        response = self.query("sns?")
+        response = response.split(",")[0].replace("Sensor = ", '').replace(self.terminator, "").replace(" ", "")
+        return TC200.Sensor(response.lower())
+
+    @sensor.setter
+    def sensor(self, newval):
+        if not hasattr(newval, 'enum'):
+            raise TypeError("Sensor setting must be a `TC200.Sensor` value, "
+                "got {} instead.".format(type(newval)))
+
+        if newval.enum is not TC200.Sensor:
+            raise TypeError("Sensor setting must be a `TC200.Sensor` value, "
+                "got {} instead.".format(type(newval)))
+        self.query("sns={}".format(newval.name))
+
+    @property
+    def beta(self):
+        """
+        Gets/sets the beta value of the thermistor curve.
+
+        :return: the gain (in nnn)
+        :rtype: int
+        """
+        response = self.query("beta?")
+        return int(response)
+
+    @beta.setter
+    def beta(self, newval):
+        if newval < 2000:
+            raise ValueError("Beta Value is too low.")
+        if newval > 6000:
+            raise ValueError("Beta Value is too high")
+        self.query("beta={}".format(newval))
+
+    @property
+    def max_power(self):
+        """
+        Gets/sets the maximum power
+
+        :return: the maximum power (in Watts)
+        :rtype: `~quantities.Quantity`
+        """
+        response = self.query("pmax?")
+        return float(response)*pq.W
+
+    @max_power.setter
+    def max_power(self, newval):
+        newval = assume_units(newval, pq.W).rescale(pq.W).magnitude
+        if newval < 0.1:
+            raise ValueError("Power is too low.")
+        if newval > 18.0:
+            raise ValueError("Power is too high")
+        self.query("PMAX={}".format(newval))
+
+    @property
+    def max_temperature(self):
+        """
+        Gets/sets the maximum temperature
+
+        :return: the maximum temperature (in deg C)
+        :rtype: `~quantities.Quantity`
+        """
+        response = self.query("tmax?").replace(" C","")
+        return float(response)*pq.degC
+
+    @max_temperature.setter
+    def max_temperature(self, newval):
+        newval = convert_temperature(newval, pq.degC).magnitude
+        if newval < 20:
+            raise ValueError("Temperature is too low.")
+        if newval > 205.0:
+            raise ValueError("Temperature is too high")
+        self.query("TMAX={}".format(newval))
+
+    # The Cycles functionality of the TC200 is currently unimplemented, as it is complex, and its functionality is
+    # redundant given a python interface to TC200
+

--- a/instruments/instruments/thorlabs/tc200.py
+++ b/instruments/instruments/thorlabs/tc200.py
@@ -84,8 +84,8 @@ class TC200(Instrument):
 
         :type: `TC200.Mode`
         """
-        response = self.query("stat?", 1)
-        response_code = (ord(response) >> 1) % 2
+        response = self.query("stat?")
+        response_code = (int(response) >> 1) % 2
         return TC200.Mode[response_code]
 
     @mode.setter

--- a/instruments/instruments/thorlabs/thorlabs_utils.py
+++ b/instruments/instruments/thorlabs/thorlabs_utils.py
@@ -21,6 +21,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
+"""
+Contains common utility functions for Thorlabs-brand instruments
+"""
 
 
 def check_cmd(response):

--- a/instruments/instruments/thorlabs/thorlabs_utils.py
+++ b/instruments/instruments/thorlabs/thorlabs_utils.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-##
-# _utils.py: Utility functions for Thorlabs-brand instruments.
-##
+#
+# thorlabs_utils.py: Utility functions for Thorlabs-brand instruments.
+#
 # © 2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
-##
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -20,7 +20,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+#
 
 
 def check_cmd(response):

--- a/instruments/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/instruments/thorlabs/thorlabsapt.py
@@ -3,7 +3,7 @@
 ##
 # thorlabsapt.py: Driver for the Thorlabs APT Controller.
 ##
-# © 2013 Steven Casagrande (scasagrande@galvant.ca).
+# © 2013-2016 Steven Casagrande (scasagrande@galvant.ca).
 #
 # This file is a part of the InstrumentKit project.
 # Licensed under the AGPL version 3.
@@ -22,24 +22,20 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 ##
 
-## FEATURES ####################################################################
+# IMPORTS #####################################################################
 
+from __future__ import absolute_import
 from __future__ import division
-
-## IMPORTS #####################################################################
-
-from instruments.thorlabs import _abstract
-from instruments.thorlabs import _packets
-from instruments.thorlabs import _cmds
-
-from flufl.enum import IntEnum
-
-import quantities as pq
+from builtins import range
 
 import re
 import struct
 
-## LOGGING #####################################################################
+import quantities as pq
+
+from instruments.thorlabs import _abstract, _packets, _cmds
+
+# LOGGING #####################################################################
 
 import logging
 from instruments.util_fns import NullHandler
@@ -47,7 +43,8 @@ from instruments.util_fns import NullHandler
 logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
+
 
 class ThorLabsAPT(_abstract.ThorLabsInstrument):
     '''
@@ -143,7 +140,7 @@ class ThorLabsAPT(_abstract.ThorLabsInstrument):
 
         # Create a tuple of channels of length _n_channel_type
         if self._n_channels > 0:
-            self._channel = list(self._channel_type(self, chan_idx) for chan_idx in xrange(self._n_channels) )
+            self._channel = list(self._channel_type(self, chan_idx) for chan_idx in range(self._n_channels) )
     
     @property
     def serial_number(self):
@@ -175,7 +172,7 @@ class ThorLabsAPT(_abstract.ThorLabsInstrument):
         # If we remove channels, remove them from the end of the list.
         if nch > self._n_channels:
             self._channel = self._channel + \
-                list( self._channel_type(self, chan_idx) for chan_idx in xrange(self._n_channels, nch) )
+                list( self._channel_type(self, chan_idx) for chan_idx in range(self._n_channels, nch) )
         elif nch < self._n_channels:
             self._channel = self._channel[:nch]
         self._n_channels = nch
@@ -248,7 +245,7 @@ class APTPiezoDevice(ThorLabsAPT):
                                       param2=None,
                                       dest=self._dest,
                                       source=0x01,
-                                      data=struct.pack('<H', int(round(255*intensity))))
+                                      data=struct.pack('<H', int(round(255*intensity))))  # pylint: disable=round-builtin
         self.sendpacket(pkt)
     
     _channel_type = PiezoDeviceChannel
@@ -380,7 +377,7 @@ class APTMotorController(ThorLabsAPT):
             :param str motor_model: Name of the model of the attached motor,
                 as indicated in the APT protocol documentation (page 14, v9).
             """
-            for driver_re, motor_dict in self.__SCALE_FACTORS_BY_MODEL.iteritems():
+            for driver_re, motor_dict in self.__SCALE_FACTORS_BY_MODEL.items():
                 if driver_re.match(self._apt.model_number) is not None:
                     if motor_model in motor_dict:
                         self.scale_factors = motor_dict[motor_model]
@@ -413,7 +410,7 @@ class APTMotorController(ThorLabsAPT):
             
             status_dict = dict(
                 (key, (status_bits & bit_mask > 0))
-                for key, bit_mask in self.__STATUS_BIT_MASK.iteritems()
+                for key, bit_mask in self.__STATUS_BIT_MASK.items()
             )
             
             return status_dict

--- a/instruments/instruments/util_fns.py
+++ b/instruments/instruments/util_fns.py
@@ -215,6 +215,10 @@ def enum_property(name, enum, doc=None, input_decoration=None, output_decoration
     def getter(self):
         return enum[in_decor_fcn(self.query("{}?".format(name)).strip())]
     def setter(self, newval):
+        try:
+            enum[newval]
+        except ValueError:
+            raise ValueError("Enum property new value not in enum.")
         self.sendcmd(set_fmt.format(name, out_decor_fcn(enum[newval].value)))
     
     return rproperty(fget=getter, fset=setter, doc=doc, readonly=readonly, writeonly=writeonly)
@@ -285,7 +289,7 @@ def int_property(name, format_code='{:d}', doc=None, readonly=False, writeonly=F
 
     return rproperty(fget=getter, fset=setter, doc=doc, readonly=readonly, writeonly=writeonly)
 
-def unitful_property(name, units, format_code='{:e}', doc=None, readonly=False, writeonly=False, set_fmt="{} {}", verification_function=None):
+def unitful_property(name, units, format_code='{:e}', doc=None, readonly=False, writeonly=False, set_fmt="{} {}", valid_range=(None,None)):
     """
     Called inside of SCPI classes to instantiate properties with unitful numeric
     values. This function assumes that the instrument only accepts
@@ -308,13 +312,23 @@ def unitful_property(name, units, format_code='{:e}', doc=None, readonly=False, 
         non-query to the instrument. The default is "{} {}" which places a
         space between the SCPI command the associated parameter. By switching
         to "{}={}" an equals sign would instead be used as the separator.
+    :param valid_range: Tuple containing min & max values when setting
+        the property. Index 0 is minimum value, index 1 is maximum value.
+        Setting `None` in either disables bounds checking for that end of the
+        range. The default of `(None, None)` has no min or max constraints.
+        The valid set is inclusive of the values provided.
+    :type valid_range: `tuple` or `list` of `int` or `float`
     """
     def getter(self):
         raw = self.query("{}?".format(name))
         return float(raw) * units
     def setter(self, newval):
-        if verification_function is not None:
-            verification_function(newval)
+        if valid_range[0] is not None and newval < valid_range[0]:
+            raise ValueError("Unitful quantity is too low. Got {}, minimum "
+                             "value is {}".format(newval, valid_range[0]))
+        if valid_range[1] is not None and newval > valid_range[1]:
+            raise ValueError("Unitful quantity  is too high. Got {}, maximum "
+                             "value is {}".format(newval, valid_range[1]))
         # Rescale to the correct unit before printing. This will also catch bad units.
         strval = format_code.format(assume_units(newval, units).rescale(units).item())
         self.sendcmd(set_fmt.format(name, strval))

--- a/instruments/instruments/util_fns.py
+++ b/instruments/instruments/util_fns.py
@@ -54,6 +54,41 @@ def assume_units(value, units):
         value = pq.Quantity(value, units)
     return value
 
+
+def convert_temperature(temperature, base):
+    """
+    convert the temperature to the specified base
+    :param temperature: a quantity with units of Kelvin, Celsius, or Fahrenheit
+    :type temperature: `quantities.Quantity`
+    :param base: a temperature unit to convert to
+    :type base: `unitquantity.UnitTemperature`
+    :return: the converted temperature
+    :rtype: `quantities.Quantity`
+    """
+    # quantities reports equivalence between degC and degK, so a string comparison is needed
+    newval = assume_units(temperature, pq.degC)
+    if newval.units == pq.degF and str(base).split(" ")[1] == 'degC':
+        return ((newval.magnitude-32.0)*5.0/9.0)*base
+    elif str(newval.units).split(" ")[1] == 'K' and str(base).split(" ")[1] == 'degC':
+        return (newval.magnitude-273.15)*base
+    elif str(newval.units).split(" ")[1] == 'K' and base == pq.degF:
+        return (newval.magnitude/1.8-459/57)*base
+    elif str(newval.units).split(" ")[1] == 'degC' and base == pq.degF:
+        return (newval.magnitude*9.0/5.0+32.0)*base
+    elif newval.units == pq.degF and str(base).split(" ")[1] == 'K':
+        return ((newval.magnitude+459.57)*5.0/9.0)*base
+    elif str(newval.units).split(" ")[1] == 'degC' and str(base).split(" ")[1] == 'K':
+        return (newval.magnitude+273.15)*base
+    elif str(newval.units).split(" ")[1] == 'degC' and str(base).split(" ")[1] == 'degC':
+        return newval
+    elif newval.units == pq.degF and base == pq.degF:
+        return newval
+    elif str(newval.units).split(" ")[1] == 'K' and str(base).split(" ")[1] == 'K':
+        return newval
+    else:
+        raise ValueError("Unable to convert "+str(newval.units)+" to "+str(base))
+
+
 def split_unit_str(s, default_units=pq.dimensionless, lookup=None):
     """
     Given a string of the form "12 C" or "14.7 GHz", returns a tuple of the

--- a/instruments/requirements.txt
+++ b/instruments/requirements.txt
@@ -2,4 +2,4 @@ numpy
 pyserial
 quantities
 flufl.enum
-
+future


### PR DESCRIPTION
- Adds support for instruments to respond with an "acknowledgement" string via `_ack_expected` function
- Adds support for instruments to send a "prompt" string (eg `">"`) after finishing with a previous command
- Add Thorlabs TC200
- Refactor Thorlabs SC10 and LCC25
- Adds a little bit of value checking for enum, unitful, and bool property factories
- Includes a few bug fixes


Regarding ack and prompt strings, here is the assumed format:

Sending a command: `CMD=1` returns `[ack][term][prompt][term]`
Sending a query: `CMD?` returns `[ack][term]response term[prompt][term]`