### PR TITLE
Convert project from flufl to enum34

### DIFF
--- a/instruments/doc/source/devguide/code_style.rst
+++ b/instruments/doc/source/devguide/code_style.rst
@@ -27,8 +27,8 @@ the `if` statement.
 
 If a property has more than two permissible values, or the two allowable
 values are not naturally interpreted as a Boolean (e.g.: positive/negative,
-AC/DC coupling, etc.), then consider using an `~flufl.enum.Enum` or `~flufl.enum.IntEnum` as
-provided by `flufl.enum`. The latter is useful in Python 2.6 and 2.7 for
+AC/DC coupling, etc.), then consider using an `~enum.Enum` or `~enum.IntEnum` as
+provided by `enum`. The latter is useful in Python 2.6 and 2.7 for
 wrapping integer values that are meaningful to the device.
 For example, if an instrument can operate in AC or DC mode, use an enumeration
 like the following::

--- a/instruments/doc/source/intro.rst
+++ b/instruments/doc/source/intro.rst
@@ -31,7 +31,7 @@ $ pip install -r requirements.txt
 - NumPy
 - `PySerial`_
 - `quantities`_
-- `flufl.enum`_ version 4.0 or later
+- `enum34`_
 
 Optional Dependencies
 ~~~~~~~~~~~~~~~~~~~~~
@@ -42,7 +42,7 @@ Optional Dependencies
 
 .. _PySerial: http://pyserial.sourceforge.net/
 .. _quantities: http://pythonhosted.org/quantities/
-.. _flufl.enum: http://pythonhosted.org/flufl.enum/
+.. _enum34: https://pypi.python.org/pypi/enum34
 .. _PyYAML: https://bitbucket.org/xi/pyyaml
 .. _PyUSB: http://sourceforge.net/apps/trac/pyusb/
 .. _PyVISA: http://pyvisa.sourceforge.net/

--- a/instruments/instruments/__init__.py
+++ b/instruments/instruments/__init__.py
@@ -39,7 +39,7 @@ def __check_versions():
     from distutils.version import StrictVersion
     
     VERSIONS_NEEDED = {
-        'flufl.enum': StrictVersion('4.0')
+        # 'flufl.enum': StrictVersion('4.0')
     }
     
     for module_name, version in VERSIONS_NEEDED.items():

--- a/instruments/instruments/abstract_instruments/function_generator.py
+++ b/instruments/instruments/abstract_instruments/function_generator.py
@@ -37,7 +37,7 @@ from instruments.util_fns import assume_units
 
 import quantities as pq
 
-from flufl.enum import Enum
+from enum import Enum
 
 ## CLASSES #####################################################################
 

--- a/instruments/instruments/agilent/agilent33220a.py
+++ b/instruments/instruments/agilent/agilent33220a.py
@@ -28,8 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range
 
-from flufl.enum import Enum
-from flufl.enum._enum import EnumValue
+from enum import Enum
 
 import quantities as pq
 
@@ -157,12 +156,11 @@ class Agilent33220a(SCPIFunctionGenerator):
         value = self.query("OUTP:LOAD?")
         try:
             return int(value) * pq.ohm
-        except:
-            return self.LoadResistance[value.strip()]
+        except ValueError:
+            return self.LoadResistance(value.strip())
     @load_resistance.setter
     def load_resistance(self, newval):
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                        self.LoadResistance):
+        if isinstance(newval, self.LoadResistance):
             newval = newval.value
         elif isinstance(newval, int):
             if (newval < 0) or (newval > 10000):

--- a/instruments/instruments/generic_scpi/scpi_function_generator.py
+++ b/instruments/instruments/generic_scpi/scpi_function_generator.py
@@ -27,7 +27,7 @@
 from __future__ import absolute_import
 from __future__ import division
 
-from flufl.enum import Enum
+from enum import Enum
 
 import quantities as pq
 import numpy as np

--- a/instruments/instruments/generic_scpi/scpi_instrument.py
+++ b/instruments/instruments/generic_scpi/scpi_instrument.py
@@ -31,7 +31,7 @@ from builtins import map
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import assume_units
 
-from flufl.enum import IntEnum
+from enum import IntEnum
 import quantities as pq
 
 ## CLASSES #####################################################################
@@ -51,12 +51,12 @@ class SCPIInstrument(Instrument):
     >>> inst = ik.generic_scpi.SCPIInstrument.open_tcpip('192.168.0.2', 8888)
     >>> print inst.name
     '''
-    
+
     def __init__(self, filelike):
         super(SCPIInstrument, self).__init__(filelike)
-    
+
     ## PROPERTIES ##
-    
+
     @property
     def name(self):
         """
@@ -66,7 +66,7 @@ class SCPIInstrument(Instrument):
         :rtype: `str`
         """
         return self.query('*IDN?')
-        
+
     @property
     def scpi_version(self):
         """
@@ -75,7 +75,7 @@ class SCPIInstrument(Instrument):
         of the SCPI 1999 standard.
         """
         return self.query("SYST:VERS?")
-        
+
     @property
     def op_complete(self):
         '''
@@ -85,7 +85,7 @@ class SCPIInstrument(Instrument):
         '''
         result = self.query('*OPC?')
         return bool(int(result))
-    
+
     @property
     def power_on_status(self):
         '''
@@ -107,7 +107,7 @@ class SCPIInstrument(Instrument):
             self.sendcmd('*PSC 0')
         else:
             raise ValueError
-    
+
     @property
     def self_test_ok(self):
         '''
@@ -122,23 +122,23 @@ class SCPIInstrument(Instrument):
             return result == 0
         except:
             return False
-    
+
     ## BASIC SCPI COMMANDS ##
-    
+
     def reset(self):
         '''
         Reset instrument. On many instruments this is a factory reset and will 
         revert all settings to default.
         '''
         self.sendcmd('*RST')
-        
+
     def clear(self):
         '''
         Clear instrument. Consult manual for specifics related to that 
         instrument.
         '''
         self.sendcmd('*CLS')
-    
+
     def trigger(self):
         '''
         Send a software trigger event to the instrument. On most instruments 
@@ -149,28 +149,28 @@ class SCPIInstrument(Instrument):
         trigger to your instrument.
         '''
         self.sendcmd('*TRG')
-    
+
     def wait_to_continue(self):
         '''
         Instruct the instrument to wait until it has completed all received 
         commands before continuing.
         '''
         self.sendcmd('*WAI')
-    
+
     ## SYSTEM COMMANDS ##
-    
+
     @property
     def line_frequency(self):
         return pq.Quantity(
-            float(self.query("SYST:LFR?")),
-            "Hz"
+                float(self.query("SYST:LFR?")),
+                "Hz"
         )
     @line_frequency.setter
     def line_frequency(self, newval):
         self.sendcmd("SYST:LFR {}".format(
-            assume_units(newval, "Hz").rescale("Hz").magnitude
+                assume_units(newval, "Hz").rescale("Hz").magnitude
         ))
-    
+
     ## ERROR QUEUE HANDLING ##
     # NOTE: This functionality is still quite incomplete, and could be fleshed
     #       out significantly still. One good thing would be to add handling
@@ -179,6 +179,9 @@ class SCPIInstrument(Instrument):
     #       Another good use of this functionality would be to allow users to
     #       automatically check errors after each command or query.
     class ErrorCodes(IntEnum):
+        pass
+
+    def check_error_queue(self):
         """
         Enumeration describing error codes as defined by SCPI 1999.0.
         Error codes that are equal to 0 mod 100 are defined to be *generic*.
@@ -189,7 +192,7 @@ class SCPIInstrument(Instrument):
         #       error codes from the SCPI base, they can be added in a natural
         #       way.
         no_error = 0
-        
+
         ## -100 BLOCK: COMMAND ERRORS ##
         command_error = -100
         invalid_character = -101
@@ -232,29 +235,27 @@ class SCPIInstrument(Instrument):
         invalid_outside_macro_definition = -181
         invalid_inside_macro_definition = -183
         macro_parameter_error = -184
-        
+
         # TODO: copy over other blocks.
         ## -200 BLOCK: EXECUTION ERRORS ##
         ## -300 BLOCK: DEVICE-SPECIFIC ERRORS ##
         # Note that device-specific errors also include all positive numbers.
         ## -400 BLOCK: QUERY ERRORS ##
-        
+
         ## OTHER ERRORS ##
-        
+
         #: Raised when the instrument detects that it has been turned from
         #: off to on.
         power_on = -500 # Yes, SCPI 1999 defines the instrument turning on as
-                        # an error. Yes, this makes my brain hurt.
+        # an error. Yes, this makes my brain hurt.
         user_request_event = -600
         request_control_event = -700
         operation_complete = -800
-        
-    def check_error_queue(self):
         """
-        Checks and clears the error queue for this device, returning a list of
-        :class:`SCPIInstrument.ErrorCodes` or `int` elements for each error
-        reported by the connected instrument.
-        """
+            Checks and clears the error queue for this device, returning a list of
+            :class:`SCPIInstrument.ErrorCodes` or `int` elements for each error
+            reported by the connected instrument.
+            """
         # TODO: use SYST:ERR:ALL instead of SYST:ERR:CODE:ALL to get
         #       messages as well. Should be just a bit more parsing, but the
         #       SCPI standard isn't clear on how the pairs are represented,
@@ -264,10 +265,10 @@ class SCPIInstrument(Instrument):
             self.ErrorCodes[err] if err in self.ErrorCodes else err
             for err in err_list
             if err != self.ErrorCodes.no_error
-        ]
-        
+            ]
+
     ## DISPLAY COMMANDS ##
-    
+
     @property
     def display_brightness(self):
         """
@@ -281,9 +282,9 @@ class SCPIInstrument(Instrument):
     def display_brightness(self, newval):
         if newval < 0 or newval > 1:
             raise ValueError("Display brightness must be a number between 0"
-                " and 1.")
+                             " and 1.")
         self.sendcmd("DISP:BRIG {}".format(newval))
-        
+
     @property
     def display_contrast(self):
         """
@@ -297,6 +298,6 @@ class SCPIInstrument(Instrument):
     def display_brightness(self, newval):
         if newval < 0 or newval > 1:
             raise ValueError("Display brightness must be a number between 0"
-                " and 1.")
+                             " and 1.")
         self.sendcmd("DISP:CONT {}".format(newval))
             

--- a/instruments/instruments/generic_scpi/scpi_multimeter.py
+++ b/instruments/instruments/generic_scpi/scpi_multimeter.py
@@ -27,8 +27,7 @@
 from __future__ import absolute_import
 from __future__ import division
 
-from flufl.enum import Enum
-from flufl.enum._enum import EnumValue
+from enum import Enum
 
 import quantities as pq
 import numpy as np
@@ -181,18 +180,18 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
         :type: `~quantities.Quantity`, or `~SCPIMultimeter.InputRange`
         """
         value = self.query('CONF?')
-        mode = self.Mode[self._mode_parse(value)]
-        value = value.split(" ")[1].split(",")[0] # Extract device range
+        mode = self.Mode(self._mode_parse(value))
+        value = value.split(" ")[1].split(",")[0]  # Extract device range
         try:
             return float(value) * UNITS[mode]
-        except:
-            return self.InputRange[value.strip()]
+        except ValueError:
+            return self.InputRange(value.strip())
     @input_range.setter
     def input_range(self, newval):
         current = self.query("CONF?")
-        mode = self.Mode[self._mode_parse(current)]
+        mode = self.Mode(self._mode_parse(current))
         units = UNITS[mode]
-        if isinstance(newval, EnumValue) and (newval.enum is self.InputRange):
+        if isinstance(newval, self.InputRange):
             newval = newval.value
         else:
             newval = assume_units(newval, units).rescale(units).magnitude
@@ -213,17 +212,17 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
         :type: `int`, `float` or `~SCPIMultimeter.Resolution`
         """
         value = self.query('CONF?')
-        value = value.split(" ")[1].split(",")[1] # Extract resolution
+        value = value.split(" ")[1].split(",")[1]  # Extract resolution
         try:
             return float(value)
         except:
-            return self.Resolution[value.strip()]
+            return self.Resolution(value.strip())
     @resolution.setter
     def resolution(self, newval):
         current = self.query("CONF?")
-        mode = self.Mode[self._mode_parse(current)]
+        mode = self.Mode(self._mode_parse(current))
         input_range = current.split(" ")[1].split(",")[0]
-        if isinstance(newval, EnumValue) and (newval.enum is self.Resolution):
+        if isinstance(newval, self.Resolution):
             newval = newval.value
         elif not isinstance(newval, float) and not isinstance(newval, int):
             raise TypeError("Resolution must be specified as an int, float, "
@@ -258,11 +257,11 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
         value = self.query('TRIG:COUN?')
         try:
             return int(value)
-        except:
-            return self.TriggerCount[value.strip()]
+        except ValueError:
+            return self.TriggerCount(value.strip())
     @trigger_count.setter
     def trigger_count(self, newval):
-        if isinstance(newval, EnumValue) and (newval.enum is self.TriggerCount):
+        if isinstance(newval, self.TriggerCount):
             newval = newval.value
         elif not isinstance(newval, int):
             raise TypeError("Trigger count must be specified as an int "
@@ -298,11 +297,11 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
         value = self.query('SAMP:COUN?')
         try:
             return int(value)
-        except:
-            return self.SampleCount[value.strip()]
+        except ValueError:
+            return self.SampleCount(value.strip())
     @sample_count.setter
     def sample_count(self, newval):
-        if isinstance(newval, EnumValue) and (newval.enum is self.SampleCount):
+        if isinstance(newval, self.SampleCount):
             newval = newval.value
         elif not isinstance(newval, int):
             raise TypeError("Sample count must be specified as an int "
@@ -379,9 +378,9 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
         """
         if mode is None:
             mode = self.mode
-        if mode.enum is not SCPIMultimeter.Mode:
+        if not isinstance(mode, SCPIMultimeter.Mode):
             raise TypeError("Mode must be specified as a SCPIMultimeter.Mode "
-                            "value, got {} instead.".format(type(newval)))
+                            "value, got {} instead.".format(type(mode)))
         value = float(self.query('MEAS:{}?'.format(mode.value)))
         return value * UNITS[mode]
         

--- a/instruments/instruments/hp/hp3456a.py
+++ b/instruments/instruments/hp/hp3456a.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 import time
-from flufl.enum import Enum, IntEnum
+from enum import Enum, IntEnum
 
 import quantities as pq
 
@@ -562,7 +562,7 @@ class HP3456a(Multimeter):
         """
         if isinstance(name, str):
             name = HP3456a.Register[name]
-        if name not in HP3456a.Register:
+        if not isinstance(name, HP3456a.Register):
             raise TypeError('register must be specified as a '
                             'HP3456a.Register, got {} '
                             'instead.'.format(name))
@@ -578,8 +578,8 @@ class HP3456a(Multimeter):
         :type value: `float`
         """
         if isinstance(name, str):
-            r = HP3456a.Register[name]
-        if name not in HP3456a.Register:
+            name = HP3456a.Register[name]
+        if not isinstance(name, HP3456a.Register):
             raise TypeError('register must be specified as a '
                             'HP3456a.Register, got {} '
                             'instead.'.format(name))

--- a/instruments/instruments/hp/hp6632b.py
+++ b/instruments/instruments/hp/hp6632b.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range
 
-from flufl.enum import Enum, IntEnum
+from enum import Enum, IntEnum
 import quantities as pq
 
 from instruments.generic_scpi.scpi_instrument import SCPIInstrument
@@ -87,7 +87,68 @@ class HP6632b(SCPIInstrument, HP6652a):
         request_service_bit = 'RQS'
         off = 'OFF'
 
-    class ErrorCodes(SCPIInstrument.ErrorCodes):
+    class ErrorCodes(IntEnum):
+        no_error = 0
+
+        ## -100 BLOCK: COMMAND ERRORS ##
+        command_error = -100
+        invalid_character = -101
+        syntax_error = -102
+        invalid_separator = -103
+        data_type_error = -104
+        get_not_allowed = -105
+        # -106 and -107 not specified.
+        parameter_not_allowed = -108
+        missing_parameter = -109
+        command_header_error = -110
+        header_separator_error = -111
+        program_mnemonic_too_long = -112
+        undefined_header = -113
+        header_suffix_out_of_range = -114
+        unexpected_number_of_parameters = -115
+        numeric_data_error = -120
+        invalid_character_in_number = -121
+        exponent_too_large = -123
+        too_many_digits = -124
+        numeric_data_not_allowed = -128
+        suffix_error = -130
+        invalid_suffix = -131
+        suffix_too_long = -134
+        suffix_not_allowed = -138
+        character_data_error = -140
+        invalid_character_data = -141
+        character_data_too_long = -144
+        character_data_not_allowed = -148
+        string_data_error = -150
+        invalid_string_data = -151
+        string_data_not_allowed = -158
+        block_data_error = -160
+        invalid_block_data = -161
+        block_data_not_allowed = -168
+        expression_error = -170
+        invalid_expression = -171
+        expression_not_allowed = -178
+        macro_error = -180
+        invalid_outside_macro_definition = -181
+        invalid_inside_macro_definition = -183
+        macro_parameter_error = -184
+
+        # TODO: copy over other blocks.
+        ## -200 BLOCK: EXECUTION ERRORS ##
+        ## -300 BLOCK: DEVICE-SPECIFIC ERRORS ##
+        # Note that device-specific errors also include all positive numbers.
+        ## -400 BLOCK: QUERY ERRORS ##
+
+        ## OTHER ERRORS ##
+
+        #: Raised when the instrument detects that it has been turned from
+        #: off to on.
+        power_on = -500 # Yes, SCPI 1999 defines the instrument turning on as
+        # an error. Yes, this makes my brain hurt.
+        user_request_event = -600
+        request_control_event = -700
+        operation_complete = -800
+
         # -200 BLOCK: EXECUTION ERRORS
         execution_error = -200
         data_out_of_range = -222
@@ -367,6 +428,6 @@ class HP6632b(SCPIInstrument, HP6652a):
             if err == self.ErrorCodes.no_error:
                 done = True
             else:
-                result.append(self.ErrorCodes[err] if err in self.ErrorCodes else err)
+                result.append(self.ErrorCodes(err) if err in self.ErrorCodes else err)
 
         return result

--- a/instruments/instruments/keithley/keithley195.py
+++ b/instruments/instruments/keithley/keithley195.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 import time
-from flufl.enum import Enum, IntEnum
+from enum import Enum, IntEnum
 import struct
 
 import quantities as pq
@@ -107,7 +107,7 @@ class Keithley195(Multimeter):
     def mode(self, newval):
         if isinstance(newval, str):
             newval = self.Mode[newval]
-        if newval not in Keithley195.Mode:
+        if not isinstance(newval, Keithley195.Mode):
             raise TypeError("Mode must be specified as a Keithley195.Mode "
                             "value, got {} instead.".format(newval))
         self.sendcmd('F{}DX'.format(newval.value))
@@ -142,7 +142,7 @@ class Keithley195(Multimeter):
     def trigger_mode(self, newval):
         if isinstance(newval, str):
             newval = Keithley195.TriggerMode[newval]
-        if newval not in Keithley195.TriggerMode:
+        if not isinstance(newval, Keithley195.TriggerMode):
             raise TypeError('Drive must be specified as a ' 
                             'Keithley195.TriggerMode, got {} '
                             'instead.'.format(newval))
@@ -219,7 +219,7 @@ class Keithley195(Multimeter):
             
         mode = self.mode
         valid = Keithley195.ValidRange[mode.name].value
-        if isinstance(newval, float) or isinstance(newval, int):
+        if isinstance(newval, (float, int)):
             if newval in valid:
                 newval = valid.index(newval) + 1
             else:
@@ -307,8 +307,8 @@ class Keithley195(Multimeter):
          delay, multiplex, selftest, data_fmt, data_ctrl, filter_mode, \
          terminator) = struct.unpack('@4c2s3c2s5c2s', statusword[4:])
         
-        return { 'trigger': Keithley195.TriggerMode[int(trigger)],
-                 'mode': Keithley195.Mode[int(function)],
+        return { 'trigger': Keithley195.TriggerMode(int(trigger)),
+                 'mode': Keithley195.Mode(int(function)),
                  'range': int(input_range),
                  'eoi': (eoi == '1'),
                  'buffer': buf,

--- a/instruments/instruments/keithley/keithley2182.py
+++ b/instruments/instruments/keithley/keithley2182.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range, map
 
-from flufl.enum import Enum
+from enum import Enum
 import quantities as pq
 
 from instruments.generic_scpi import SCPIMultimeter
@@ -216,7 +216,7 @@ class Keithley2182(SCPIMultimeter):
         :return: Measurement readings from the instrument output buffer.
         :rtype: `list` of `~quantities.quantity.Quantity` elements
         """
-        return map(float, self.query('FETC?').split(',')) * self.units
+        return list(map(float, self.query('FETC?').split(','))) * self.units
     
     def measure(self, mode=None):
         """
@@ -232,9 +232,9 @@ class Keithley2182(SCPIMultimeter):
         """
         if mode is None:
             mode = self.mode
-        if mode not in Keithley2182.Mode:
+        if not isinstance(mode, Keithley2182.Mode):
             raise TypeError("Mode must be specified as a Keithley2182.Mode "
-                            "value, got {} instead.".format(newval))
+                            "value, got {} instead.".format(mode))
         value = float(self.query('MEAS:{}?'.format(mode)))
         unit = self.units
         return value * unit

--- a/instruments/instruments/keithley/keithley580.py
+++ b/instruments/instruments/keithley/keithley580.py
@@ -31,7 +31,7 @@ from builtins import range, map
 
 import time
 import struct
-from flufl.enum import IntEnum
+from enum import IntEnum
 
 import quantities as pq
 
@@ -102,7 +102,7 @@ class Keithley580(Instrument):
     def polarity(self, newval):
         if isinstance(newval, str):
             newval = Keithley580.Polarity[newval]
-        if newval not in Keithley580.Polarity:
+        if not isinstance(newval, Keithley580.Polarity):
             raise TypeError('Polarity must be specified as a '
                             'Keithley580.Polarity, got {} '
                             'instead.'.format(newval))
@@ -126,9 +126,9 @@ class Keithley580(Instrument):
         return Keithley580.Drive[value]
     @drive.setter
     def drive(self, newval):
-        if  isinstance(newval, str):
+        if isinstance(newval, str):
             newval = Keithley580.Drive[newval]
-        if newval not in Keithley580.Drive:
+        if not isinstance(newval, Keithley580.Drive):
             raise TypeError('Drive must be specified as a '
                             'Keithley580.Drive, got {} '
                             'instead.'.format(newval))
@@ -246,7 +246,7 @@ class Keithley580(Instrument):
     @input_range.setter
     def input_range(self, newval):
         valid = ('auto', 2e-1, 2e0, 2e1, 2e2, 2e3, 2e4, 2e5)
-        if isisntance(newval, str):
+        if isinstance(newval, str):
             newval = newval.lower()
             if newval == 'auto':
                 self.sendcmd('R0X')
@@ -257,7 +257,7 @@ class Keithley580(Instrument):
         if isinstance(newval, pq.quantity.Quantity):
             newval = float(newval)
 
-        if isinstance(newval, float) or isinstance(newval, int):
+        if isinstance(newval, (float, int)):
             if newval in valid:
                 newval = valid.index(newval)
             else:

--- a/instruments/instruments/keithley/keithley6514.py
+++ b/instruments/instruments/keithley/keithley6514.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import map
 
-from flufl.enum import Enum
+from enum import Enum
 
 import quantities as pq
 

--- a/instruments/instruments/lakeshore/lakeshore475.py
+++ b/instruments/instruments/lakeshore/lakeshore475.py
@@ -30,7 +30,7 @@ from __future__ import division
 from builtins import range
 
 import quantities as pq
-from flufl.enum import IntEnum
+from enum import IntEnum
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import assume_units, bool_property
@@ -302,28 +302,24 @@ class Lakeshore475(SCPIInstrument):
             used.
         :type peak_disp: `Lakeshore475.PeakDisplay`
         """
-        if not isinstance(mode, EnumValue) or \
-                (mode.enum is not Lakeshore475.Mode):
+        if not isinstance(mode, Lakeshore475.Mode):
             raise TypeError("Mode setting must be a "
-                              "`Lakeshore475.Mode` value, got {} "
-                              "instead.".format(type(mode)))
+                            "`Lakeshore475.Mode` value, got {} "
+                            "instead.".format(type(mode)))
         if not isinstance(resolution, int):
             raise TypeError('Parameter "resolution" must be an integer.')
-        if not isinstance(filter_type, EnumValue) or \
-                (filter_type.enum is not Lakeshore475.Filter):
+        if not isinstance(filter_type, Lakeshore475.Filter):
             raise TypeError("Filter type setting must be a "
-                              "`Lakeshore475.Filter` value, got {} "
-                              "instead.".format(type(filter_type)))
-        if not isinstance(peak_mode, EnumValue) or \
-                (peak_mode.enum is not Lakeshore475.PeakMode):
+                            "`Lakeshore475.Filter` value, got {} "
+                            "instead.".format(type(filter_type)))
+        if not isinstance(peak_mode, Lakeshore475.PeakMode):
             raise TypeError("Filter type setting must be a "
-                              "`Lakeshore475.PeakMode` value, got {} "
-                              "instead.".format(type(peak_mode)))
-        if not isinstance(peak_disp, EnumValue) or \
-                (peak_disp.enum is not Lakeshore475.PeakDisplay):
+                            "`Lakeshore475.PeakMode` value, got {} "
+                            "instead.".format(type(peak_mode)))
+        if not isinstance(peak_disp, Lakeshore475.PeakDisplay):
             raise TypeError("Filter type setting must be a "
-                              "`Lakeshore475.PeakDisplay` value, got {} "
-                              "instead.".format(type(peak_disp)))      
+                            "`Lakeshore475.PeakDisplay` value, got {} "
+                            "instead.".format(type(peak_disp)))
 
         mode = mode.value
         filter_type = filter_type.value

--- a/instruments/instruments/newport/newportesp301.py
+++ b/instruments/instruments/newport/newportesp301.py
@@ -33,7 +33,7 @@ from time import time, sleep
 
 import datetime
 
-from flufl.enum import IntEnum
+from enum import IntEnum
 
 from contextlib import contextmanager
 

--- a/instruments/instruments/picowatt/picowattavs47.py
+++ b/instruments/instruments/picowatt/picowattavs47.py
@@ -29,7 +29,7 @@ from __future__ import division
 from builtins import range, map
 
 import quantities as pq
-from flufl.enum import IntEnum
+from enum import IntEnum
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import (enum_property, bool_property, int_property,
@@ -80,7 +80,7 @@ class PicowattAVS47(SCPIInstrument):
             if not self._parent.mux_channel == self._idx:
                 self._parent.input_source = self._parent.InputSource.ground
                 self._parent.mux_channel = self._idx
-                self_.parent.input_source = self._parent.InputSource.actual
+                self._parent.input_source = self._parent.InputSource.actual
             # Next, prep a measurement with the ADC command
             self._parent.sendcmd("ADC")
             return float(self._parent.query("RES?")) * pq.ohm 

--- a/instruments/instruments/rigol/rigolds1000.py
+++ b/instruments/instruments/rigol/rigolds1000.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range, map
 
-from flufl.enum import Enum
+from enum import Enum
 
 from instruments.abstract_instruments import (
     Oscilloscope, OscilloscopeChannel, OscilloscopeDataSource

--- a/instruments/instruments/srs/srs345.py
+++ b/instruments/instruments/srs/srs345.py
@@ -28,8 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range, map
 
-from flufl.enum import IntEnum
-from flufl.enum._enum import EnumValue
+from enum import IntEnum
 
 import quantities as pq
 

--- a/instruments/instruments/srs/srs830.py
+++ b/instruments/instruments/srs/srs830.py
@@ -33,9 +33,7 @@ import time
 
 import numpy as np
 
-from flufl.enum import Enum
-from flufl.enum import IntEnum
-from flufl.enum._enum import EnumValue
+from enum import Enum, IntEnum
 import quantities as pq
 
 from instruments.generic_scpi import SCPIInstrument
@@ -141,11 +139,10 @@ class SRS830(SCPIInstrument):
         return self.FreqSource[int(self.query('FMOD?'))]
     @frequency_source.setter
     def frequency_source(self, newval):
-        if not isinstance(newval, EnumValue) or \
-                (newval.enum is not SRS830.FreqSource):
+        if not isinstance(newval, SRS830.FreqSource):
             raise TypeError("Frequency source setting must be a "
-                              "`SRS830.FreqSource` value, got {} "
-                              "instead.".format(type(newval)))
+                            "`SRS830.FreqSource` value, got {} "
+                            "instead.".format(type(newval)))
         self.sendcmd('FMOD {}'.format(newval.value))
         
     @property
@@ -222,14 +219,13 @@ class SRS830(SCPIInstrument):
         
         :type: `SRS830.Coupling`
         '''
-        return SRS830.Coupling[int(self.query('ICPL?'))]
+        return SRS830.Coupling(int(self.query('ICPL?')))
     @coupling.setter
     def coupling(self, newval):
-        if not isinstance(newval, EnumValue) or \
-                (newval.enum is not SRS830.Coupling):
+        if not isinstance(newval, SRS830.Coupling):
             raise TypeError("Input coupling setting must be a "
-                              "`SRS830.Coupling` value, got {} "
-                              "instead.".format(type(newval)))
+                            "`SRS830.Coupling` value, got {} "
+                            "instead.".format(type(newval)))
         self.sendcmd('ICPL {}'.format(newval.value))
         
     @property
@@ -269,14 +265,13 @@ class SRS830(SCPIInstrument):
         
         :type: `SRS830.BufferMode`
         '''
-        return SRS830.BufferMode[int(self.query('SEND?'))]
+        return SRS830.BufferMode(int(self.query('SEND?')))
     @buffer_mode.setter
     def buffer_mode(self, newval):
-        if not isinstance(newval, EnumValue) or \
-                (newval.enum is not SRS830.BufferMode):
+        if not isinstance(newval, SRS830.BufferMode):
             raise TypeError("Input coupling setting must be a "
-                              "`SRS830.BufferMode` value, got {} "
-                              "instead.".format(type(newval)))
+                            "`SRS830.BufferMode` value, got {} "
+                            "instead.".format(type(newval)))
         self.sendcmd('SEND {}'.format(newval.value))     
     
     @property
@@ -616,8 +611,3 @@ class SRS830(SCPIInstrument):
         ratio = self._valid_channel_ratio[channel-1][display]
         
         self.sendcmd('DDEF {},{},{}'.format(channel,display,ratio))        
-            
-            
-            
-            
-            

--- a/instruments/instruments/srs/srsctc100.py
+++ b/instruments/instruments/srs/srsctc100.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range, map
 
-from flufl.enum import Enum
+from enum import Enum
 
 import quantities as pq
 
@@ -37,9 +37,6 @@ from contextlib import contextmanager
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import assume_units, ProxyList
 import sys
-## ENUMS #######################################################################
-
-
 
 ## CLASSES #####################################################################
 

--- a/instruments/instruments/srs/srsdg645.py
+++ b/instruments/instruments/srs/srsdg645.py
@@ -30,8 +30,7 @@ from builtins import range, map
 
 from time import time, sleep
 
-from flufl.enum import IntEnum
-from flufl.enum._enum import EnumValue
+from enum import IntEnum, Enum
 
 from contextlib import contextmanager
 
@@ -40,10 +39,6 @@ import quantities as pq
 from instruments.generic_scpi import SCPIInstrument
 from instruments.abstract_instruments.comm import GPIBCommunicator
 from instruments.util_fns import assume_units, ProxyList
-
-## ENUMS #######################################################################
-
-
 
 ## CLASSES #####################################################################
 
@@ -58,7 +53,7 @@ class _SRSDG645Channel(object):
         if not isinstance(ddg, SRSDG645):
             raise TypeError("Don't do that.")
 
-        if isinstance(chan, EnumValue):
+        if isinstance(chan, SRSDG645.Channels):
             self._chan = chan.value
         else:
             self._chan = chan
@@ -192,13 +187,17 @@ class SRSDG645(SCPIInstrument):
             
             :type: :class:`SRSDG645.LevelPolarity`
             """
-            return self._parent.LevelPolarity[
+            return self._parent.LevelPolarity(
                 int(self._parent.query("LPOL? {}".format(self._idx)))
-            ]
+            )
         @polarity.setter
         def polarity(self, newval):
+            if not isinstance(newval, self._parent.LevelPolarity):
+                raise TypeError("Mode must be specified as a "
+                                "SRSDG645.LevelPolarity value, got {} "
+                                "instead.".format(type(newval)))
             self._parent.sendcmd("LPOL {},{}".format(
-                self._idx, int(self._parent.LevelPolarity[newval])
+                self._idx, int(newval.value)
             ))
             
         @property

--- a/instruments/instruments/tektronix/tekawg2000.py
+++ b/instruments/instruments/tektronix/tekawg2000.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range, map
 
-from flufl.enum import Enum
+from enum import Enum
 
 import numpy as np
 import quantities as pq
@@ -132,7 +132,7 @@ class TekAWG2000Channel(object):
                                                 self._name)).strip()]
     @polarity.setter
     def polarity(self, newval):
-        if newval.enum is not TekAWG2000.Polarity:
+        if not isinstance(newval, TekAWG2000.Polarity):
             raise TypeError('Polarity settings must be a `TekAWG2000.Polarity` '
                 'value, got {} instead.'.format(type(newval)))
         
@@ -150,7 +150,7 @@ class TekAWG2000Channel(object):
                                             self._name)).strip().split(',')[0]]
     @shape.setter
     def shape(self, newval):
-        if newval.enum is not TekAWG2000.Shape:
+        if not isinstance(newval, TekAWG2000.Shape):
             raise TypeError('Shape settings must be a `TekAWG2000.Shape` '
                 'value, got {} instead.'.format(type(newval)))
         self._tek.sendcmd('FG:{}:SHAP {}'.format(self._name, newval.value))

--- a/instruments/instruments/tektronix/tekdpo4104.py
+++ b/instruments/instruments/tektronix/tekdpo4104.py
@@ -30,8 +30,7 @@ from builtins import range, map
 
 from time import time, sleep
 
-from flufl.enum import Enum
-from flufl.enum._enum import EnumValue
+from enum import Enum
 
 from contextlib import contextmanager
 
@@ -190,13 +189,12 @@ class _TekDPO4104Channel(_TekDPO4104DataSource, OscilloscopeChannel):
 
         :type: `TekDPO4104.Coupling`
         """
-        return TekDPO4104.Coupling[self._tek.query("CH{}:COUPL?".format(
+        return TekDPO4104.Coupling(self._tek.query("CH{}:COUPL?".format(
                                                                 self._idx)
-                                                                )]
+                                                                ))
     @coupling.setter
     def coupling(self, newval):
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                           TekDPO4104.Coupling):
+        if not isinstance(newval, TekDPO4104.Coupling):
             raise TypeError("Coupling setting must be a `TekDPO4104.Coupling`"
                 " value, got {} instead.".format(type(newval)))
 
@@ -353,4 +351,3 @@ class TekDPO4104(SCPIInstrument, Oscilloscope):
         Note that this is distinct from the standard SCPI "\*TRG" functionality.
         """
         self.sendcmd('TRIG FORCE')
-    

--- a/instruments/instruments/tektronix/tekdpo70000.py
+++ b/instruments/instruments/tektronix/tekdpo70000.py
@@ -31,7 +31,7 @@ from builtins import range, map
 import abc
 import time
 
-from flufl.enum import Enum
+from enum import Enum
 
 from instruments.abstract_instruments import (
     Oscilloscope, OscilloscopeChannel, OscilloscopeDataSource
@@ -94,6 +94,13 @@ class TekDPO70000Series(SCPIInstrument, Oscilloscope):
     class ByteOrder(Enum):
         little_endian = "LSB"
         big_endian = "MSB"
+
+    class TriggerState(Enum):
+        armed = "ARMED"
+        auto = "AUTO"
+        dpo = "DPO"
+        partial = "PARTIAL"
+        ready = "READY"
         
     ## STATIC METHODS ##
     
@@ -107,14 +114,6 @@ class TekDPO70000Series(SCPIInstrument, Oscilloscope):
             TekDPO70000Series.BinaryFormat.uint: "u",
             TekDPO70000Series.BinaryFormat.float: "f"
         }[binary_format], n_bytes)
-
-
-    class TriggerState(Enum):
-        armed = "ARMED"
-        auto = "AUTO"
-        dpo = "DPO"
-        partial = "PARTIAL"
-        ready = "READY"
 
     ## CLASSES ##
 

--- a/instruments/instruments/tektronix/tektds224.py
+++ b/instruments/instruments/tektronix/tektds224.py
@@ -31,8 +31,7 @@ from builtins import range, map
 import time
 import numpy as np
 import quantities as pq
-from flufl.enum import Enum
-from flufl.enum._enum import EnumValue
+from enum import Enum
 
 from instruments.abstract_instruments import (
     OscilloscopeChannel,
@@ -157,16 +156,14 @@ class _TekTDS224Channel(_TekTDS224DataSource, OscilloscopeChannel):
 
         :type: `TekTDS224.Coupling`
         """
-        return TekTDS224.Coupling[self._tek.query("CH{}:COUPL?".format(
-                                                                self._idx)
-                                                                )]
+        return TekTDS224.Coupling(self._tek.query(
+                "CH{}:COUPL?".format(self._idx)
+        ))
     @coupling.setter
     def coupling(self, newval):
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                           TekTDS224.Coupling):
+        if not isinstance(newval, TekTDS224.Coupling):
             raise TypeError("Coupling setting must be a `TekTDS224.Coupling`"
-                " value, got {} instead.".format(type(newval)))
-
+                            " value, got {} instead.".format(type(newval)))
         self._tek.sendcmd("CH{}:COUPL {}".format(self._idx, newval.value))
         
 class TekTDS224(SCPIInstrument, Oscilloscope):
@@ -209,7 +206,7 @@ class TekTDS224(SCPIInstrument, Oscilloscope):
         :rtype: `_TekTDS224DataSource`
         '''
         return ProxyList(self,
-            lambda s, idx: _TekTDS224DataSource(s, "REF{}".format(idx  + 1)),
+            lambda s, idx: _TekTDS224DataSource(s, "REF{}".format(idx + 1)),
             range(4))
         
     @property
@@ -255,5 +252,3 @@ class TekTDS224(SCPIInstrument, Oscilloscope):
     @property
     def force_trigger(self):
         raise NotImplementedError
-    
-        

--- a/instruments/instruments/tektronix/tektds5xx.py
+++ b/instruments/instruments/tektronix/tektds5xx.py
@@ -34,8 +34,7 @@ from functools import reduce
 
 import time
 import numpy as np
-from flufl.enum import Enum
-from flufl.enum._enum import EnumValue
+from enum import Enum
 
 from time import sleep
 from datetime import datetime
@@ -201,13 +200,12 @@ class _TekTDS5xxChannel(_TekTDS5xxDataSource, OscilloscopeChannel):
 
         :type: `TekTDS5xx.Coupling`
         """
-        return TekTDS5xx.Coupling[self._tek.query("CH{}:COUPL?".format(
+        return TekTDS5xx.Coupling(self._tek.query("CH{}:COUPL?".format(
                                                                 self._idx)
-                                                                )]
+                                                                ))
     @coupling.setter
     def coupling(self, newval):
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                           TekTDS5xx.Coupling):
+        if not isinstance(newval, TekTDS5xx.Coupling):
             raise TypeError("Coupling setting must be a `TekTDS5xx.Coupling`"
                 " value, got {} instead.".format(type(newval)))
 
@@ -220,13 +218,12 @@ class _TekTDS5xxChannel(_TekTDS5xxDataSource, OscilloscopeChannel):
 
         :type: `TekTDS5xx.Bandwidth`
         """
-        return TekTDS5xx.Bandwidth[self._tek.query("CH{}:BAND?".format(
+        return TekTDS5xx.Bandwidth(self._tek.query("CH{}:BAND?".format(
                                                                 self._idx)
-                                                                )]
+                                                                ))
     @bandwidth.setter
     def bandwidth(self, newval):
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                           TekTDS5xx.Bandwidth):
+        if not isinstance(newval, TekTDS5xx.Bandwidth):
             raise TypeError("Bandwidth setting must be a `TekTDS5xx.Bandwidth`"
                 " value, got {} instead.".format(type(newval)))
 
@@ -239,13 +236,12 @@ class _TekTDS5xxChannel(_TekTDS5xxDataSource, OscilloscopeChannel):
 
         :type: `TekTDS5xx.Impedance`
         """
-        return TekTDS5xx.Impedance[self._tek.query("CH{}:IMP?".format(
+        return TekTDS5xx.Impedance(self._tek.query("CH{}:IMP?".format(
                                                                 self._idx)
-                                                                )]
+                                                                ))
     @impedance.setter
     def impedance(self, newval):
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                           TekTDS5xx.Impedance):
+        if not isinstance(newval, TekTDS5xx.Impedance):
             raise TypeError("Impedance setting must be a `TekTDS5xx.Impedance`"
                 " value, got {} instead.".format(type(newval)))
 
@@ -443,8 +439,7 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
     def data_source(self, newval):
         if isinstance(newval, _TekTDS5xxDataSource):
             newval = TekTDS5xx.Source[newval.name]
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                            TekTDS5xx.Source):
+        if not isinstance(newval, TekTDS5xx.Source):
             raise TypeError("Source setting must be a `TekTDS5xx.Source`"
                 " value, got {} instead.".format(type(newval)))
 
@@ -514,8 +509,7 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
     
     @trigger_coupling.setter
     def trigger_coupling(self, newval):
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                   TekTDS5xx.Coupling):
+        if not isinstance(newval, TekTDS5xx.Coupling):
             raise TypeError("Coupling setting must be a `TekTDS5xx.Coupling`"
                 " value, got {} instead.".format(type(newval)))
 
@@ -528,12 +522,11 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
         
         :type: `TekTDS5xx.Edge`
         """
-        return TekTDS5xx.Edge[self.query("TRIG:MAI:EDGE:SLO?")]
+        return TekTDS5xx.Edge(self.query("TRIG:MAI:EDGE:SLO?"))
     
     @trigger_slope.setter
     def trigger_slope(self, newval):
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                   TekTDS5xx.Edge):
+        if not isinstance(newval, TekTDS5xx.Edge):
             raise TypeError("Edge setting must be a `TekTDS5xx.Edge`"
                 " value, got {} instead.".format(type(newval)))
 
@@ -546,12 +539,11 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
         
         :type: `TekTDS5xx.Trigger`
         """
-        return TekTDS5xx.Trigger[self.query("TRIG:MAI:EDGE:SOU?")]
+        return TekTDS5xx.Trigger(self.query("TRIG:MAI:EDGE:SOU?"))
     
     @trigger_source.setter
     def trigger_source(self, newval):
-        if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                   TekTDS5xx.Trigger):
+        if not isinstance(newval, TekTDS5xx.Trigger):
             raise TypeError("Trigger source setting must be a"
                 "`TekTDS5xx.source` value, got {} instead.".format(type(newval)))
 

--- a/instruments/instruments/tests/test_property_factories.py
+++ b/instruments/instruments/tests/test_property_factories.py
@@ -37,7 +37,7 @@ from instruments.util_fns import (
     unitful_property, unitless_property
 )
 
-from flufl.enum import Enum
+from enum import Enum
 
 ## CLASSES ####################################################################
 

--- a/instruments/instruments/tests/test_thorlabs/__init__.py
+++ b/instruments/instruments/tests/test_thorlabs/__init__.py
@@ -26,7 +26,7 @@
 
 from __future__ import absolute_import
 
-from flufl.enum import IntEnum
+from enum import IntEnum
 from nose.tools import raises
 import quantities as pq
 
@@ -143,7 +143,7 @@ def test_lcc25_mode_invalid2():
         []
     ) as lcc:
         blo = IntEnum("blo", "beep boop bop")
-        lcc.mode = blo[0]
+        lcc.mode = blo(0)
 
 
 def test_lcc25_enable():
@@ -614,7 +614,7 @@ def test_sc10_mode_invalid2():
         sep="\r"
     ) as sc:
         blo = IntEnum("blo", "beep boop bop")
-        sc.mode = blo[0]
+        sc.mode = blo(0)
 
 
 def test_sc10_trigger():

--- a/instruments/instruments/tests/test_util_fns.py
+++ b/instruments/instruments/tests/test_util_fns.py
@@ -36,7 +36,7 @@ from instruments.util_fns import (
     assume_units, convert_temperature
 )
 
-from flufl.enum import Enum
+from enum import Enum
 
 ## TEST CASES #################################################################
 
@@ -67,9 +67,9 @@ def test_ProxyList_valid_range_is_enum():
     parent = object()
     
     proxy_list = ProxyList(parent, ProxyChild, MockEnum)
-    assert proxy_list['aa']._name == MockEnum.a
-    assert proxy_list['b']._name  == MockEnum.b
-    assert proxy_list[MockEnum.a]._name == MockEnum.a
+    assert proxy_list['aa']._name == MockEnum.a.value
+    assert proxy_list['b']._name  == MockEnum.b.value
+    assert proxy_list[MockEnum.a]._name == MockEnum.a.value
     
 def test_ProxyList_length():
     class ProxyChild(object):

--- a/instruments/instruments/thorlabs/_cmds.py
+++ b/instruments/instruments/thorlabs/_cmds.py
@@ -26,7 +26,7 @@
 
 from __future__ import absolute_import
 from __future__ import division
-from flufl.enum import IntEnum
+from enum import IntEnum
 
 # CLASSES #####################################################################
 

--- a/instruments/instruments/thorlabs/lcc25.py
+++ b/instruments/instruments/thorlabs/lcc25.py
@@ -36,7 +36,7 @@ from __future__ import division
 from builtins import range
 
 import quantities as pq
-from flufl.enum import IntEnum
+from enum import IntEnum
 
 from instruments.thorlabs.thorlabs_utils import check_cmd
 

--- a/instruments/instruments/thorlabs/pm100usb.py
+++ b/instruments/instruments/thorlabs/pm100usb.py
@@ -30,7 +30,7 @@ from __future__ import division
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import enum_property
 
-from flufl.enum import Enum, IntEnum
+from enum import Enum, IntEnum
 from collections import defaultdict
 
 import quantities as pq

--- a/instruments/instruments/thorlabs/sc10.py
+++ b/instruments/instruments/thorlabs/sc10.py
@@ -35,7 +35,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range
 
-from flufl.enum import IntEnum
+from enum import IntEnum
 import quantities as pq
 
 from instruments.abstract_instruments import Instrument

--- a/instruments/instruments/thorlabs/tc200.py
+++ b/instruments/instruments/thorlabs/tc200.py
@@ -36,7 +36,7 @@ from __future__ import division
 from builtins import range, map
 
 import quantities as pq
-from flufl.enum import IntEnum, Enum
+from enum import IntEnum, Enum
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import convert_temperature
@@ -105,14 +105,11 @@ class TC200(Instrument):
         """
         response = self.query("stat?")
         response_code = (int(response) >> 1) % 2
-        return TC200.Mode[response_code]
+        return TC200.Mode(response_code)
 
     @mode.setter
     def mode(self, newval):
-        if not hasattr(newval, 'enum'):
-            raise TypeError("Mode setting must be a `TC200.Mode` value, "
-                            "got {} instead.".format(type(newval)))
-        if newval.enum is not TC200.Mode:
+        if not isinstance(newval, TC200.Mode):
             raise TypeError("Mode setting must be a `TC200.Mode` value, "
                             "got {} instead.".format(type(newval)))
         out_query = "mode={}".format(newval.name)

--- a/instruments/instruments/toptica/topmode.py
+++ b/instruments/instruments/toptica/topmode.py
@@ -13,7 +13,7 @@ from __future__ import division
 from builtins import range
 
 import quantities as pq
-from flufl.enum import IntEnum
+from enum import IntEnum
 
 from instruments.toptica.toptica_utils import convert_toptica_boolean as ctbool
 from instruments.toptica.toptica_utils import convert_toptica_datetime as ctdate
@@ -251,7 +251,7 @@ class TopMode(Instrument):
             """
             value = self.parent.reference(
                 self.name + ":charm:correction-status")
-            return TopMode.CharmStatus[int(value)]
+            return TopMode.CharmStatus(int(value))
 
         # METHODS #
 

--- a/instruments/instruments/yokogawa/yokogawa7651.py
+++ b/instruments/instruments/yokogawa/yokogawa7651.py
@@ -28,8 +28,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 import quantities as pq
-from flufl.enum import Enum, IntEnum
-from flufl.enum._enum import EnumValue
+from enum import Enum, IntEnum
 
 from instruments.abstract_instruments import (
     PowerSupply,
@@ -77,8 +76,7 @@ class Yokogawa7651(PowerSupply, Instrument):
                                       'querying the operation mode.')
         @mode.setter
         def mode(self, newval):
-            if (not isinstance(newval, EnumValue)) or (newval.enum is not 
-                                                            Yokogawa7651.Mode):
+            if not isinstance(newval, Yokogawa7651.Mode):
                 raise TypeError("Mode setting must be a `Yokogawa7651.Mode` "
                                 "value, got {} instead.".format(type(newval)))
             self._parent.sendcmd('F{};'.format(newval.value))

--- a/instruments/requirements.txt
+++ b/instruments/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 pyserial
 quantities
-flufl.enum
 future
+enum34


### PR DESCRIPTION
- Switches from using `flufl.enum` to `enum` obtained from package `enum34`
- Updates access behaviour, such as using `[]` for keys and `()` for values
- Removes calls to `.enum` and `EnumValue` as they are not supported. Replaces them with `isinstance` checks

Tests pass, but not all classes changed have tests. I checked over all classes that had `flufl` removed and hopefully I caught everything. During that I did catch 1 or 2 old typos. Not sure how long they were around for...(eg `picowattavs47`)