### PR TITLE
pass pylint on agilent classes

### DIFF
--- a/instruments/instruments/abstract_instruments/function_generator.py
+++ b/instruments/instruments/abstract_instruments/function_generator.py
@@ -72,42 +72,42 @@ class FunctionGenerator(with_metaclass(abc.ABCMeta, Instrument)):
     @property
     @abc.abstractmethod
     def frequency(self):
-        raise NotImplementedError
+        pass
 
     @frequency.setter
     @abc.abstractmethod
     def frequency(self, newval):
-        raise NotImplementedError
+        pass
 
     @property
     @abc.abstractmethod
     def function(self):
-        raise NotImplementedError
+        pass
 
     @function.setter
     @abc.abstractmethod
     def function(self, newval):
-        raise NotImplementedError
+        pass
     
     @property
     @abc.abstractmethod
     def offset(self):
-        raise NotImplementedError
+        pass
 
     @offset.setter
     @abc.abstractmethod
     def offset(self, newval):
-        raise NotImplementedError
+        pass
     
     @property
     @abc.abstractmethod
     def phase(self):
-        raise NotImplementedError
+        pass
 
     @phase.setter
     @abc.abstractmethod
     def phase(self, newval):
-        raise NotImplementedError
+        pass
     
     ## CONCRETE PROPERTIES ##
     

--- a/instruments/instruments/abstract_instruments/function_generator.py
+++ b/instruments/instruments/abstract_instruments/function_generator.py
@@ -68,38 +68,46 @@ class FunctionGenerator(with_metaclass(abc.ABCMeta, Instrument)):
         pass
     
     ## ABSTRACT PROPERTIES ##
- 
-    """   
-    def getamplitude(self):
-        raise NotImplementedError('')
-    def setamplitude(self, newval):
-        raise NotImplementedError('')
-    amplitude = abc.abstractproperty(getamplitude, setamplitude)
-    """
+
+    @property
+    @abc.abstractmethod
+    def frequency(self):
+        raise NotImplementedError
+
+    @frequency.setter
+    @abc.abstractmethod
+    def frequency(self, newval):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def function(self):
+        raise NotImplementedError
+
+    @function.setter
+    @abc.abstractmethod
+    def function(self, newval):
+        raise NotImplementedError
     
-    def getfrequency(self):
-        raise NotImplementedError('')
-    def setfrequency(self, newval):
-        raise NotImplementedError('')
-    frequency = abc.abstractproperty(getfrequency, setfrequency)
+    @property
+    @abc.abstractmethod
+    def offset(self):
+        raise NotImplementedError
+
+    @offset.setter
+    @abc.abstractmethod
+    def offset(self, newval):
+        raise NotImplementedError
     
-    def getfunction(self):
-        raise NotImplementedError('')
-    def setfunction(self, newval):
-        raise NotImplementedError('')
-    function = abc.abstractproperty(getfunction, setfunction)
-    
-    def getoffset(self):
-        raise NotImplementedError('')
-    def setoffset(self, newval):
-        raise NotImplementedError('')
-    offset = abc.abstractproperty(getoffset, setoffset)
-    
-    def getphase(self):
-        raise NotImplementedError('')
-    def setphase(self, newval):
-        raise NotImplementedError('')
-    phase = abc.abstractproperty(getphase, setphase)
+    @property
+    @abc.abstractmethod
+    def phase(self):
+        raise NotImplementedError
+
+    @phase.setter
+    @abc.abstractmethod
+    def phase(self, newval):
+        raise NotImplementedError
     
     ## CONCRETE PROPERTIES ##
     
@@ -147,4 +155,3 @@ class FunctionGenerator(with_metaclass(abc.ABCMeta, Instrument)):
             mag = float(assume_units(mag, pq.V).rescale(pq.V).magnitude)
         
         self._set_amplitude_(mag, units)
-        

--- a/instruments/instruments/abstract_instruments/multimeter.py
+++ b/instruments/instruments/abstract_instruments/multimeter.py
@@ -38,57 +38,47 @@ from instruments.abstract_instruments import Instrument
 class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
 
     ## PROPERTIES ##
+
+    @property
+    @abc.abstractmethod
+    def mode(self):
+        raise NotImplementedError
+
+    @mode.setter
+    @abc.abstractmethod
+    def mode(self, newval):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def trigger_mode(self):
+        raise NotImplementedError
+
+    @trigger_mode.setter
+    @abc.abstractmethod
+    def trigger_mode(self, newval):
+        raise NotImplementedError
     
-    def getmode(self):
-        """
-        Read measurement mode the multimeter is currently in.
-        """
+    @property
+    @abc.abstractmethod
+    def relative(self):
         raise NotImplementedError
-    def setmode(self, newval):
-        """
-        Change the mode the multimeter is in.
-        """
+
+    @relative.setter
+    @abc.abstractmethod
+    def relative(self, newval):
         raise NotImplementedError
-    mode = abc.abstractproperty(getmode, setmode)
-    
-    def gettrigger_mode(self):
-        """
-        Get the current trigger mode the multimeter is set to.
-        """
+
+    @property
+    @abc.abstractmethod
+    def input_range(self):
         raise NotImplementedError
-    def settrigger_mode(self, newval):
-        """
-        Set the multimeter triggering mode.
-        """
+
+    @input_range.setter
+    @abc.abstractmethod
+    def input_range(self, newval):
         raise NotImplementedError
-    trigger_mode = abc.abstractproperty(gettrigger_mode, settrigger_mode)
-    
-    def getrelative(self):
-        """
-        Get the status of relative measuring mode (usually on or off).
-        """
-        raise NotImplementedError
-    def setrelative(self, newval):
-        """
-        Set (enable/disable) the relative measuring mode of the multimeter.
-        """
-        raise NotImplementedError
-    relative = abc.abstractproperty(getrelative, setrelative)
-    
-    def getinput_range(self):
-        """
-        Get the current input range setting of the multimeter.
-        """
-        raise NotImplementedError
-    def setinput_range(self, newval):
-        """
-        Set the input range setting of the multimeter.
-        """
-        raise NotImplementedError
-    input_range = abc.abstractproperty(getinput_range, setinput_range)
-    
-    
-    
+
     ## METHODS ##
     
     @abc.abstractmethod

--- a/instruments/instruments/abstract_instruments/multimeter.py
+++ b/instruments/instruments/abstract_instruments/multimeter.py
@@ -42,6 +42,12 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
     @property
     @abc.abstractmethod
     def mode(self):
+        """
+        Gets/sets the measurement mode for the multimeter. This is an
+        abstract method.
+
+        :type: `~enum.Enum`
+        """
         pass
 
     @mode.setter
@@ -52,6 +58,12 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
     @property
     @abc.abstractmethod
     def trigger_mode(self):
+        """
+        Gets/sets the trigger mode for the multimeter. This is an
+        abstract method.
+
+        :type: `~enum.Enum`
+        """
         pass
 
     @trigger_mode.setter
@@ -62,6 +74,12 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
     @property
     @abc.abstractmethod
     def relative(self):
+        """
+        Gets/sets the status of relative measuring mode for the multimeter.
+        This is an abstract method.
+
+        :type: `bool`
+        """
         pass
 
     @relative.setter
@@ -72,6 +90,12 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
     @property
     @abc.abstractmethod
     def input_range(self):
+        """
+        Gets/sets the current input range setting of the multimeter.
+        This is an abstract method.
+
+        :type: `~quantities.quantity.Quantity` or `~enum.Enum`
+        """
         pass
 
     @input_range.setter
@@ -83,8 +107,7 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
     
     @abc.abstractmethod
     def measure(self, mode):
-        '''
+        """
         Perform a measurement as specified by mode parameter.
-        '''
+        """
         pass
-        

--- a/instruments/instruments/abstract_instruments/multimeter.py
+++ b/instruments/instruments/abstract_instruments/multimeter.py
@@ -42,42 +42,42 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
     @property
     @abc.abstractmethod
     def mode(self):
-        raise NotImplementedError
+        pass
 
     @mode.setter
     @abc.abstractmethod
     def mode(self, newval):
-        raise NotImplementedError
+        pass
 
     @property
     @abc.abstractmethod
     def trigger_mode(self):
-        raise NotImplementedError
+        pass
 
     @trigger_mode.setter
     @abc.abstractmethod
     def trigger_mode(self, newval):
-        raise NotImplementedError
+        pass
     
     @property
     @abc.abstractmethod
     def relative(self):
-        raise NotImplementedError
+        pass
 
     @relative.setter
     @abc.abstractmethod
     def relative(self, newval):
-        raise NotImplementedError
+        pass
 
     @property
     @abc.abstractmethod
     def input_range(self):
-        raise NotImplementedError
+        pass
 
     @input_range.setter
     @abc.abstractmethod
     def input_range(self, newval):
-        raise NotImplementedError
+        pass
 
     ## METHODS ##
     
@@ -86,5 +86,5 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
         '''
         Perform a measurement as specified by mode parameter.
         '''
-        raise NotImplementedError
+        pass
         

--- a/instruments/instruments/agilent/__init__.py
+++ b/instruments/instruments/agilent/__init__.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Module containing Agilent instruments
+"""
 
 from __future__ import absolute_import
 

--- a/instruments/instruments/agilent/agilent33220a.py
+++ b/instruments/instruments/agilent/agilent33220a.py
@@ -1,28 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# agilent33220a.py: Driver for the Agilent 33220a function generator.
-##
-# © 2013 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Provides the support for the Agilent 33220a function generator.
+"""
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
@@ -38,16 +20,39 @@ from instruments.util_fns import (
 )
 
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
 
 class Agilent33220a(SCPIFunctionGenerator):
 
+    """
+    The `Agilent/Keysight 33220a`_ is a 20MHz function/arbitrary waveform
+    generator. This model has been replaced by the Keysight 33500 series
+    waveform generators. This class may or may not work with these newer
+    models.
+
+    Example usage:
+
+    >>> import instruments as ik
+    >>> import quantities as pq
+    >>> inst = ik.agilent.Agilent33220a.open_gpibusb('/dev/ttyUSB0', 1)
+    >>> inst.function = inst.Function.sinusoid
+    >>> inst.frequency = 1 * pq.kHz
+    >>> inst.output = True
+
+    .. _Agilent/Keysight 33220a: http://www.keysight.com/en/pd-127539-pn-33220A
+
+    """
+
     def __init__(self, filelike):
         super(Agilent33220a, self).__init__(filelike)
-        
-    ## ENUMS ##
-    
+
+    # ENUMS #
+
     class Function(Enum):
+
+        """
+        Enum containing valid functions for the Agilent/Keysight 33220a
+        """
         sinusoid = "SIN"
         square = "SQU"
         ramp = "RAMP"
@@ -55,100 +60,117 @@ class Agilent33220a(SCPIFunctionGenerator):
         noise = "NOIS"
         dc = "DC"
         user = "USER"
-        
+
     class LoadResistance(Enum):
+
+        """
+        Enum containing valid load resistance for the Agilent/Keysight 33220a
+        """
         minimum = "MIN"
         maximum = "MAX"
         high_impedance = "INF"
-        
+
     class OutputPolarity(Enum):
+
+        """
+        Enum containg valid output polarity modes for the
+        Agilent/Keysight 33220a
+        """
         normal = "NORM"
         inverted = "INV"
-        
-    ## PROPERTIES ##
-    
+
+    # PROPERTIES #
+
+    @property
+    def frequency(self):
+        return super(Agilent33220a, self).frequency
+
+    @frequency.setter
+    def frequency(self, newval):
+        super(Agilent33220a, self).frequency = newval
+
     function = enum_property(
         name="FUNC",
         enum=Function,
         doc="""
         Gets/sets the output function of the function generator
-        
+
         :type: `Agilent33220a.Function`
         """,
         set_fmt="{}:{}"
     )
-    
+
     duty_cycle = int_property(
         name="FUNC:SQU:DCYC",
         doc="""
         Gets/sets the duty cycle of a square wave.
-        
-        Duty cycle represents the amount of time that the square wave is at a 
+
+        Duty cycle represents the amount of time that the square wave is at a
         high level.
-        
+
         :type: `int`
         """,
         valid_set=range(101)
     )
-    
+
     ramp_symmetry = int_property(
         name="FUNC:RAMP:SYMM",
         doc="""
         Gets/sets the ramp symmetry for ramp waves.
-        
-        Symmetry represents the amount of time per cycle that the ramp wave is 
+
+        Symmetry represents the amount of time per cycle that the ramp wave is
         rising (unless polarity is inverted).
-        
+
         :type: `int`
         """,
         valid_set=range(101)
     )
-    
+
     output = bool_property(
         name="OUTP",
         inst_true="ON",
         inst_false="OFF",
         doc="""
         Gets/sets the output enable status of the front panel output connector.
-        
+
         The value `True` corresponds to the output being on, while `False` is
         the output being off.
-        
+
         :type: `bool`
         """
     )
-    
+
     output_sync = bool_property(
         name="OUTP:SYNC",
         inst_true="ON",
         inst_false="OFF",
         doc="""
         Gets/sets the enabled status of the front panel sync connector.
-        
+
         :type: `bool`
-        """ 
+        """
     )
-    
+
     output_polarity = enum_property(
         name="OUTP:POL",
         enum=OutputPolarity,
         doc="""
         Gets/sets the polarity of the waveform relative to the offset voltage.
-        
+
         :type: `~Agilent33220a.OutputPolarity`
         """
     )
-    
+
     @property
     def load_resistance(self):
         """
-        Gets/sets the desired output termination load (ie, the impedance of the 
+        Gets/sets the desired output termination load (ie, the impedance of the
         load attached to the front panel output connector).
-        
-        The instrument has a fixed series output impedance of 50ohms. This 
-        function allows the instrument to compensate of the voltage divider 
+
+        The instrument has a fixed series output impedance of 50ohms. This
+        function allows the instrument to compensate of the voltage divider
         and accurately report the voltage across the attached load.
-        
+
         :units: As specified (if a `~quantities.quantity.Quantity`) or assumed
             to be of units :math:`\\Omega` (ohm).
         :type: `~quantities.quantity.Quantity` or `Agilent33220a.LoadResistance`
@@ -158,15 +180,24 @@ class Agilent33220a(SCPIFunctionGenerator):
             return int(value) * pq.ohm
         except ValueError:
             return self.LoadResistance(value.strip())
+
     @load_resistance.setter
     def load_resistance(self, newval):
         if isinstance(newval, self.LoadResistance):
             newval = newval.value
         elif isinstance(newval, int):
             if (newval < 0) or (newval > 10000):
-                raise ValueError("Load resistance must be between 0 and 10,000")
+                raise ValueError(
+                    "Load resistance must be between 0 and 10,000")
             newval = assume_units(newval, pq.ohm).rescale(pq.ohm).magnitude
         else:
             raise TypeError("Not a valid load resistance type.")
         self.sendcmd("OUTP:LOAD {}".format(newval))
 
+    @property
+    def phase(self):
+        raise NotImplementedError
+
+    @phase.setter
+    def phase(self, newval):
+        raise NotImplementedError

--- a/instruments/instruments/agilent/agilent34410a.py
+++ b/instruments/instruments/agilent/agilent34410a.py
@@ -1,28 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# agilent34410a.py: Implementation of Agilent 34410A-specific functionality.
-##
-# © 2013-2014 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Provides the support for the Agilent 34410a digital multimeter.
+"""
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
@@ -32,77 +14,79 @@ import quantities as pq
 
 from instruments.generic_scpi import SCPIMultimeter
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
 
-class Agilent34410a(SCPIMultimeter):
+
+class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
+
     """
     The Agilent 34410a is a very popular 6.5 digit DMM. This class should also
     cover the Agilent 34401a, 34411a, as well as the backwards compatability
-    mode in the newer Agilent/Keysight 34460a/34461a. You can find the full 
+    mode in the newer Agilent/Keysight 34460a/34461a. You can find the full
     specifications for these instruments on the `Keysight website`_.
-    
+
     Example usage:
-    
+
     >>> import instruments as ik
     >>> import quantities as pq
-    >>> dmm = ik.agilent.Agilent34410a.open_gpib('/dev/ttyUSB0', 1)
-    >>> print dmm.measure(dmm.Mode.resistance)
-    
+    >>> dmm = ik.agilent.Agilent34410a.open_gpibusb('/dev/ttyUSB0', 1)
+    >>> print(dmm.measure(dmm.Mode.resistance))
+
     .. _Keysight website: http://www.keysight.com/
     """
 
     def __init__(self, filelike):
         super(Agilent34410a, self).__init__(filelike)
 
-    ## PROPERTIES ##
-    
+    # PROPERTIES #
+
     @property
     def data_point_count(self):
         """
-        Gets the total number of readings that are located in reading memory 
+        Gets the total number of readings that are located in reading memory
         (RGD_STORE).
-        
+
         :rtype: `int`
         """
         return int(self.query('DATA:POIN?'))
-    
-    ## STATE MANAGEMENT METHODS ##
+
+    # STATE MANAGEMENT METHODS #
 
     def init(self):
         """
         Switch device from "idle" state to "wait-for-trigger state".
-        Measurements will begin when specified triggering conditions are met, 
+        Measurements will begin when specified triggering conditions are met,
         following the receipt of the INIT command.
-        
-        Note that this command will also clear the previous set of readings 
+
+        Note that this command will also clear the previous set of readings
         from memory.
         """
         self.sendcmd('INIT')
-    
+
     def abort(self):
         """
         Abort all measurements currently in progress.
         """
         self.sendcmd('ABOR')
-    
-    ## MEMORY MANAGEMENT METHODS ##
+
+    # MEMORY MANAGEMENT METHODS #
 
     def clear_memory(self):
         """
         Clears the non-volatile memory of the Agilent 34410a.
         """
         self.sendcmd('DATA:DEL NVMEM')
-    
+
     def r(self, count):
         """
-        Have the multimeter perform a specified number of measurements and then 
-        transfer them using a binary transfer method. Data will be cleared from 
+        Have the multimeter perform a specified number of measurements and then
+        transfer them using a binary transfer method. Data will be cleared from
         instrument memory after transfer is complete. Data is transfered
         from the instrument in 64-bit double floating point precision format.
-        
+
         :param int count: Number of samples to take.
-        
-        :rtype: `~quantities.quantity.Quantity` with `numpy.array` 
+
+        :rtype: `~quantities.quantity.Quantity` with `numpy.array`
         """
         mode = self.mode
         units = UNITS[mode]
@@ -116,75 +100,75 @@ class Agilent34410a(SCPIMultimeter):
         self.sendcmd(msg)
         data = self.binblockread(8, fmt=">d")
         return data * units
-        
-    ## DATA READING METHODS ##
-    
+
+    # DATA READING METHODS #
+
     def fetch(self):
         """
-        Transfer readings from instrument memory to the output buffer, and 
+        Transfer readings from instrument memory to the output buffer, and
         thus to the computer.
-        If currently taking a reading, the instrument will wait until it is 
+        If currently taking a reading, the instrument will wait until it is
         complete before executing this command.
-        Readings are NOT erased from memory when using fetch. Use the R? 
+        Readings are NOT erased from memory when using fetch. Use the R?
         command to read and erase data.
-        Note that the data is transfered as ASCII, and thus it is not 
+        Note that the data is transfered as ASCII, and thus it is not
         recommended to transfer a large number of
         data points using this method.
-        
+
         :rtype: `list` of `~quantities.quantity.Quantity` elements
         """
         units = UNITS[self.mode]
         return list(map(float, self.query('FETC?').split(','))) * units
-    
+
     def read_data(self, sample_count):
         """
-        Transfer specified number of data points from reading memory 
+        Transfer specified number of data points from reading memory
         (RGD_STORE) to output buffer.
         First data point sent to output buffer is the oldest.
         Data is erased after being sent to output buffer.
-        
-        :param int sample_count: Number of data points to be transfered to 
-            output buffer. If set to -1, all points in memory will be 
+
+        :param int sample_count: Number of data points to be transfered to
+            output buffer. If set to -1, all points in memory will be
             transfered.
-        
+
         :rtype: `list` of `~quantities.quantity.Quantity` elements
         """
-        if not isinstance(sample_count,int):
+        if not isinstance(sample_count, int):
             raise TypeError('Parameter "sample_count" must be an integer.')
-        
+
         if sample_count == -1:
             sample_count = self.data_point_count
         units = UNITS[self.mode]
         self.sendcmd('FORM:DATA ASC')
         data = self.query('DATA:REM? {}'.format(sample_count)).split(',')
         return list(map(float, data)) * units
-    
-    def read_data_NVMEM(self):
+
+    def read_data_nvmem(self):
         """
         Returns all readings in non-volatile memory (NVMEM).
-        
+
         :rtype: `list` of `~quantities.quantity.Quantity` elements
         """
         units = UNITS[self.mode]
         data = list(map(float, self.query('DATA:DATA? NVMEM').split(',')))
         return data * units
-    
+
     def read_last_data(self):
         """
-        Retrieve the last measurement taken. This can be executed at any time, 
+        Retrieve the last measurement taken. This can be executed at any time,
         including when the instrument is currently taking measurements.
-        If there are no data points available, the value ``9.91000000E+37`` is 
+        If there are no data points available, the value ``9.91000000E+37`` is
         returned.
-        
+
         :units: As specified by the data returned by the instrument.
         :rtype: `~quantities.quantity.Quantity`
         """
         data = self.query('DATA:LAST?')
         unit_map = {
-            "VDC":"V",
-            "VAC":"V",
+            "VDC": "V",
+            "VAC": "V",
         }
-        
+
         if data == '9.91000000E+37':
             return int(data)
         else:
@@ -193,23 +177,23 @@ class Agilent34410a(SCPIMultimeter):
             if data[1] in unit_map:
                 data[1] = unit_map[data[1]]
             return pq.Quantity(*data)
-    
-    def read(self):
+
+    def read_meter(self):
         """
-        Switch device from "idle" state to "wait-for-trigger" state. 
-        Immediately after the trigger conditions are met, the data will be sent 
+        Switch device from "idle" state to "wait-for-trigger" state.
+        Immediately after the trigger conditions are met, the data will be sent
         to the output buffer of the instrument.
-        
-        This is similar to calling `~Agilent34410a.init` and then immediately 
+
+        This is similar to calling `~Agilent34410a.init` and then immediately
         following `~Agilent34410a.fetch`.
-        
+
         :rtype: `~quantities.Quantity`
         """
         mode = self.mode
         units = UNITS[mode]
         return float(self.query('READ?')) * units
-        
-## UNITS #######################################################################
+
+# UNITS #######################################################################
 
 UNITS = {
     Agilent34410a.Mode.capacitance: pq.farad,
@@ -225,4 +209,3 @@ UNITS = {
     Agilent34410a.Mode.temperature: pq.kelvin,
     Agilent34410a.Mode.continuity:  1,
 }
-

--- a/instruments/instruments/generic_scpi/scpi_function_generator.py
+++ b/instruments/instruments/generic_scpi/scpi_function_generator.py
@@ -116,4 +116,3 @@ class SCPIFunctionGenerator(FunctionGenerator, SCPIInstrument):
     @phase.setter
     def phase(self, newval):
         raise NotImplementedError
-    

--- a/instruments/instruments/tests/test_agilent/__init__.py
+++ b/instruments/instruments/tests/test_agilent/__init__.py
@@ -47,7 +47,7 @@ def test_agilent34410a_read():
             "+1.86850000E-03"
         ]
     ) as dmm:
-        unit_eq(dmm.read(), +1.86850000E-03 * pq.volt)
+        unit_eq(dmm.read_meter(), +1.86850000E-03 * pq.volt)
         
 def test_agilent34410a_data_point_count():
     with expected_protocol(
@@ -116,7 +116,7 @@ def test_agilent34410a_read_data_nvmem():
             "+4.27150000E-03,5.27150000E-03"
         ]
     ) as dmm:
-        data = dmm.read_data_NVMEM()
+        data = dmm.read_data_nvmem()
         unit_eq(data[0], 4.27150000E-03 * pq.volt)
         unit_eq(data[1], 5.27150000E-03 * pq.volt)
         


### PR DESCRIPTION
Agilent classes linted, and the corresponding abstract base classes have been changed. These changes to the ABCs technically break Python <= 3.2 's ability to block instantiating a class that has not defined all its abstract methods. This is because in Python 3.3 the `@property` decorator was updated such that it can directly wrap an `@abc.abstractmethod` decorator. According to the docs (https://docs.python.org/3/library/abc.html) the `abc.abstractproperty` method is deprecated.

As we move forward with more test coverage and toward supporting Python 3, I'd rather we do things the most up to date way possible. In this case, if tests pass under Python 2 and 3, then there isn't any issues about abstract methods that haven't been defined for Python <= 3.2