### PR TITLE
Bounded unitful property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ python:
 # command to install dependencies
 install:
   - "pip install -r instruments/requirements.txt"
+  - "pip install -r instruments/dev-requirements.txt"
   - pip install python-coveralls
   - pip install coverage
-  - pip install nose
-  - pip install pylint
 # command to run tests
 script:
   - nosetests --with-coverage -w instruments

--- a/instruments/dev-requirements.txt
+++ b/instruments/dev-requirements.txt
@@ -1,0 +1,3 @@
+mock
+nose
+pylint

--- a/instruments/instruments/tests/test_property_factories.py
+++ b/instruments/instruments/tests/test_property_factories.py
@@ -30,6 +30,7 @@ import quantities as pq
 from io import BytesIO
 
 from nose.tools import raises, eq_
+import mock
 
 from instruments.util_fns import (
     ProxyList, assume_units,
@@ -609,6 +610,7 @@ def test_unitful_property_output_decoration():
 
     eq_(mock_instrument.value, 'MOCK:A 1\n')
 
+
 # Bounded Unitful Property #
 
 def test_bounded_unitful_property_basics():
@@ -626,6 +628,7 @@ def test_bounded_unitful_property_basics():
 
     mock_inst.property = 1000 * pq.hertz
 
+
 @raises(ValueError)
 def test_bounded_unitful_property_set_outside_max():
     class BoundedUnitfulMock(MockInstrument):
@@ -638,6 +641,7 @@ def test_bounded_unitful_property_set_outside_max():
 
     mock_inst.property = 10000 * pq.hertz  # Should raise ValueError
 
+
 @raises(ValueError)
 def test_bounded_unitful_property_set_outside_min():
     class BoundedUnitfulMock(MockInstrument):
@@ -649,6 +653,7 @@ def test_bounded_unitful_property_set_outside_min():
     mock_inst = BoundedUnitfulMock({'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
 
     mock_inst.property = 1 * pq.hertz  # Should raise ValueError
+
 
 def test_bounded_unitful_property_min_fmt_str():
     class BoundedUnitfulMock(MockInstrument):
@@ -663,6 +668,7 @@ def test_bounded_unitful_property_min_fmt_str():
     eq_(mock_inst.property_min, 10 * pq.Hz)
     eq_(mock_inst.value, 'MOCK MIN?\n')
 
+
 def test_bounded_unitful_property_max_fmt_str():
     class BoundedUnitfulMock(MockInstrument):
         property, property_min, property_max = bounded_unitful_property(
@@ -676,6 +682,7 @@ def test_bounded_unitful_property_max_fmt_str():
     eq_(mock_inst.property_max, 9999 * pq.Hz)
     eq_(mock_inst.value, 'MOCK MAX?\n')
 
+
 def test_bounded_unitful_property_static_range():
     class BoundedUnitfulMock(MockInstrument):
         property, property_min, property_max = bounded_unitful_property(
@@ -688,6 +695,50 @@ def test_bounded_unitful_property_static_range():
 
     eq_(mock_inst.property_min, 10 * pq.Hz)
     eq_(mock_inst.property_max, 9999 * pq.Hz)
+
+
+@mock.patch("instruments.util_fns.unitful_property")
+def test_bounded_unitful_property_passes_kwargs(mock_unitful_property):
+    bounded_unitful_property(
+        name='MOCK',
+        units=pq.Hz,
+        derp="foobar"
+    )
+    mock_unitful_property.assert_called_with(
+        'MOCK',
+        pq.Hz,
+        derp="foobar",
+        valid_range=(mock.ANY, mock.ANY)
+    )
+
+
+@mock.patch("instruments.util_fns.unitful_property")
+def test_bounded_unitful_property_valid_range_none(mock_unitful_property):
+    bounded_unitful_property(
+        name='MOCK',
+        units=pq.Hz,
+        valid_range=(None, None)
+    )
+    mock_unitful_property.assert_called_with(
+        'MOCK',
+        pq.Hz,
+        valid_range=(None, None)
+    )
+
+
+def test_bounded_unitful_property_returns_none():
+    class BoundedUnitfulMock(MockInstrument):
+        property, property_min, property_max = bounded_unitful_property(
+            'MOCK',
+            units=pq.hertz,
+            valid_range=(None, None)
+        )
+
+    mock_inst = BoundedUnitfulMock()
+
+    eq_(mock_inst.property_min, None)
+    eq_(mock_inst.property_max, None)
+
 
 ## String Property ##
 

--- a/instruments/instruments/tests/test_property_factories.py
+++ b/instruments/instruments/tests/test_property_factories.py
@@ -34,7 +34,7 @@ from nose.tools import raises, eq_
 from instruments.util_fns import (
     ProxyList, assume_units,
     rproperty, bool_property, enum_property, int_property, string_property,
-    unitful_property, unitless_property
+    unitful_property, unitless_property, bounded_unitful_property
 )
 
 from enum import Enum
@@ -551,6 +551,24 @@ def test_unitful_property_valid_range():
 
     eq_(mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0, 10))
 
+def test_unitful_property_valid_range_functions():
+    class UnitfulMock(MockInstrument):
+
+        def min_value(self):
+            return 0
+
+        def max_value(self):
+            return 10
+
+        unitful_property = unitful_property('MOCK', pq.hertz, valid_range=(min_value, max_value))
+
+    mock_inst = UnitfulMock()
+
+    mock_inst.unitful_property = 0
+    mock_inst.unitful_property = 10
+
+    eq_(mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0, 10))
+
 @raises(ValueError)
 def test_unitful_property_minimum_value():
     class UnitfulMock(MockInstrument):
@@ -590,6 +608,86 @@ def test_unitful_property_output_decoration():
     mock_instrument.a = 345 * pq.hertz
 
     eq_(mock_instrument.value, 'MOCK:A 1\n')
+
+# Bounded Unitful Property #
+
+def test_bounded_unitful_property_basics():
+    class BoundedUnitfulMock(MockInstrument):
+        property, property_min, property_max = bounded_unitful_property(
+            'MOCK',
+            units=pq.hertz
+        )
+
+    mock_inst = BoundedUnitfulMock({'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
+
+    eq_(mock_inst.property, 1000 * pq.hertz)
+    eq_(mock_inst.property_min, 10 * pq.hertz)
+    eq_(mock_inst.property_max, 9999 * pq.hertz)
+
+    mock_inst.property = 1000 * pq.hertz
+
+@raises(ValueError)
+def test_bounded_unitful_property_set_outside_max():
+    class BoundedUnitfulMock(MockInstrument):
+        property, property_min, property_max = bounded_unitful_property(
+            'MOCK',
+            units=pq.hertz
+        )
+
+    mock_inst = BoundedUnitfulMock({'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
+
+    mock_inst.property = 10000 * pq.hertz  # Should raise ValueError
+
+@raises(ValueError)
+def test_bounded_unitful_property_set_outside_min():
+    class BoundedUnitfulMock(MockInstrument):
+        property, property_min, property_max = bounded_unitful_property(
+            'MOCK',
+            units=pq.hertz
+        )
+
+    mock_inst = BoundedUnitfulMock({'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
+
+    mock_inst.property = 1 * pq.hertz  # Should raise ValueError
+
+def test_bounded_unitful_property_min_fmt_str():
+    class BoundedUnitfulMock(MockInstrument):
+        property, property_min, property_max = bounded_unitful_property(
+            'MOCK',
+            units=pq.hertz,
+            min_fmt_str="{} MIN?"
+        )
+
+    mock_inst = BoundedUnitfulMock({'MOCK MIN?': '10'})
+
+    eq_(mock_inst.property_min, 10 * pq.Hz)
+    eq_(mock_inst.value, 'MOCK MIN?\n')
+
+def test_bounded_unitful_property_max_fmt_str():
+    class BoundedUnitfulMock(MockInstrument):
+        property, property_min, property_max = bounded_unitful_property(
+            'MOCK',
+            units=pq.hertz,
+            max_fmt_str="{} MAX?"
+        )
+
+    mock_inst = BoundedUnitfulMock({'MOCK MAX?': '9999'})
+
+    eq_(mock_inst.property_max, 9999 * pq.Hz)
+    eq_(mock_inst.value, 'MOCK MAX?\n')
+
+def test_bounded_unitful_property_static_range():
+    class BoundedUnitfulMock(MockInstrument):
+        property, property_min, property_max = bounded_unitful_property(
+            'MOCK',
+            units=pq.hertz,
+            valid_range=(10, 9999)
+        )
+
+    mock_inst = BoundedUnitfulMock()
+
+    eq_(mock_inst.property_min, 10 * pq.Hz)
+    eq_(mock_inst.property_max, 9999 * pq.Hz)
 
 ## String Property ##
 

--- a/instruments/instruments/util_fns.py
+++ b/instruments/instruments/util_fns.py
@@ -384,7 +384,9 @@ def bounded_unitful_property(name, units, min_fmt_str="{}:MIN?", max_fmt_str="{}
         string ``"query"``.
     :param kwargs: All other keyword arguments are passed onto
         `unitful_property`
-    :return:
+    :return: Returns a `tuple` of 3 properties: first is as returned by
+        `unitful_property`, second is a property representing the minimum
+        value, and third is a property representing the maximum value
     """
 
     def min_getter(self):


### PR DESCRIPTION
Adds `bounded_unitful_property` to `util_fns.py`. This builds on `unitful_property` by easily allowing for devs to assign dynamic bounds to unitful properties. By default it will query the instrument for min and max values, but this can be overridden to use static boundary values. These can also be done directly though `unitful_property` now, but `bounded_unitful_property` is a much cleaner way which also returns properties for direct access to the min and max values.