### PR TITLE
Holzworth work

### DIFF
--- a/instruments/instruments/abstract_instruments/signal_generator/channel.py
+++ b/instruments/instruments/abstract_instruments/signal_generator/channel.py
@@ -42,40 +42,63 @@ class SGChannel(with_metaclass(abc.ABCMeta, object)):
     """
     
     ## PROPERTIES ##
+
+    @property
+    @abc.abstractmethod
+    def frequency(self):
+        """
+        Gets/sets the output frequency of the signal generator channel
+
+        :type: `~quantities.quantity.Quantity`
+        """
+        pass
+
+    @frequency.setter
+    @abc.abstractmethod
+    def frequency(self, newval):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def power(self):
+        """
+        Gets/sets the output power of the signal generator channel
+
+        :type: `~quantities.quantity.Quantity`
+        """
+        pass
+
+    @power.setter
+    @abc.abstractmethod
+    def power(self, newval):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def phase(self):
+        """
+        Gets/sets the output phase of the signal generator channel
+
+        :type: `~quantities.quantity.Quantity`
+        """
+        pass
+
+    @phase.setter
+    @abc.abstractmethod
+    def phase(self, newval):
+        pass
     
-    def getfreq(self):
+    @property
+    @abc.abstractmethod
+    def output(self):
         """
-        Gets/sets the output frequency of the SG channel
+        Gets/sets the output status of the signal generator channel
+
+        :type: `bool`
         """
-        raise NotImplementedError
-    def setfreq(self):
-        raise NotImplementedError
-    freq = abc.abstractproperty(getfreq, setfreq)
-    
-    def getpower(self):
-        """
-        Gets/sets the output power of the SG channel
-        """
-        raise NotImplementedError
-    def setpower(self):
-        raise NotImplementedError
-    power = abc.abstractproperty(getpower, setpower)
-    
-    def getphase(self):
-        """
-        Gets/sets the output phase of the SG channel
-        """
-        raise NotImplementedError
-    def setphase(self):
-        raise NotImplementedError
-    phase = abc.abstractproperty(getphase, setphase)
-    
-    def getoutput(self):
-        """
-        Gets/sets the output status of the device. IE enabling output turns on
-        the RF connector.
-        """
-        raise NotImplementedError
-    def setoutput(self):
-        raise NotImplementedError
-    output = abc.abstractproperty(getoutput, setoutput)
+        pass
+
+    @output.setter
+    @abc.abstractmethod
+    def output(self, newval):
+        pass

--- a/instruments/instruments/holzworth/__init__.py
+++ b/instruments/instruments/holzworth/__init__.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Module containing Holzworth instruments
+"""
 
 from __future__ import absolute_import
 
-from instruments.holzworth.holzworth_hs9000 import HolzworthHS9000
+from .holzworth_hs9000 import HS9000

--- a/instruments/instruments/holzworth/holzworth_hs9000.py
+++ b/instruments/instruments/holzworth/holzworth_hs9000.py
@@ -255,7 +255,7 @@ class HS9000(SignalGenerator):
         """
         Gets identification string of the HS9000
 
-        :return: The string as returned by ``*IDN?``
+        :return: The string as usually returned by ``*IDN?`` on SCPI instruments
         :rtype: `str`
         """
         # This is a weird one; the HS-9000 associates the :IDN? command

--- a/instruments/instruments/other/__init__.py
+++ b/instruments/instruments/other/__init__.py
@@ -14,5 +14,5 @@ from instruments.newport import (
     NewportESP301, NewportESP301Axis, NewportError, NewportESP301HomeSearchMode
 )
 from instruments.phasematrix import PhaseMatrixFSW0020
-from instruments.holzworth import HolzworthHS9000
+from instruments.holzworth import HS9000
 

--- a/instruments/instruments/tests/test_holzworth/test_holzworth_hs9000.py
+++ b/instruments/instruments/tests/test_holzworth/test_holzworth_hs9000.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the Holzworth HS9000
+"""
+
+# IMPORTS #####################################################################
+
+from __future__ import absolute_import
+
+import quantities as pq
+import mock
+
+import instruments as ik
+from instruments.tests import expected_protocol, make_name_test, unit_eq
+from instruments.units import dBm
+
+# TEST CLASSES ################################################################
+
+
+def test_channel_idx_list():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+        ],
+        [
+            ":CH1:CH2:FOO"
+        ],
+        sep="\n"
+    ) as hs:
+        assert hs._channel_idxs() == [0, 1, "FOO"]
+
+
+def test_channel_returns_inner_class():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+        ],
+        [
+            ":CH1:CH2:FOO"
+        ],
+        sep="\n"
+    ) as hs:
+        channel = hs.channel[0]
+        assert isinstance(channel, hs.Channel) == True
+        assert channel._ch_name == "CH1"
+
+
+def test_channel_sendcmd():
+    channel = ik.holzworth.HS9000.Channel(mock.MagicMock(), 0)
+
+    channel.sendcmd("FOO")
+
+    channel._hs.sendcmd.assert_called_with(":CH1:FOO")
+
+
+def test_channel_query():
+    channel = ik.holzworth.HS9000.Channel(mock.MagicMock(), 0)
+    channel._hs.query.return_value = "FOO"
+
+    value = channel.query("BAR")
+
+    channel._hs.query.assert_called_with(":CH1:BAR")
+    assert value == "FOO"
+
+
+def test_channel_reset():
+    channel = ik.holzworth.HS9000.Channel(mock.MagicMock(), 0)
+    channel.reset()
+
+    channel._hs.sendcmd.assert_called_with(":CH1:*RST")
+
+
+def test_channel_recall_state():
+    channel = ik.holzworth.HS9000.Channel(mock.MagicMock(), 0)
+    channel.recall_state()
+
+    channel._hs.sendcmd.assert_called_with(":CH1:*RCL")
+
+
+def test_channel_save_state():
+    channel = ik.holzworth.HS9000.Channel(mock.MagicMock(), 0)
+    channel.save_state()
+
+    channel._hs.sendcmd.assert_called_with(":CH1:*SAV")
+
+
+def test_channel_temperature():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+            ":CH1:TEMP?"
+        ],
+        [
+            ":CH1:CH2:FOO",
+            "10 C"
+        ],
+        sep="\n"
+    ) as hs:
+        channel = hs.channel[0]
+        assert channel.temperature == 10 * pq.degC
+
+
+def test_channel_frequency_getter():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+            ":CH1:FREQ?",
+            ":CH1:FREQ:MIN?",
+            ":CH1:FREQ:MAX?"
+        ],
+        [
+            ":CH1:CH2:FOO",
+            "1000 MHz",
+            "100 MHz",
+            "10 GHz"
+        ],
+        sep="\n"
+    ) as hs:
+        channel = hs.channel[0]
+        assert channel.frequency == 1 * pq.GHz
+        assert channel.frequency_min == 100 * pq.MHz
+        assert channel.frequency_max == 10 * pq.GHz
+
+
+def test_channel_frequency_setter():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+            ":CH1:FREQ:MIN?",
+            ":CH1:FREQ:MAX?",
+            ":CH1:FREQ {:e}".format(1)
+        ],
+        [
+            ":CH1:CH2:FOO",
+            "100 MHz",
+            "10 GHz"
+        ],
+        sep="\n"
+    ) as hs:
+        channel = hs.channel[0]
+        channel.frequency = 1 * pq.GHz
+
+
+def test_channel_power_getter():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+            ":CH1:PWR?",
+            ":CH1:PWR:MIN?",
+            ":CH1:PWR:MAX?"
+        ],
+        [
+            ":CH1:CH2:FOO",
+            "0",
+            "-100",
+            "20"
+        ],
+        sep="\n"
+    ) as hs:
+        channel = hs.channel[0]
+        assert channel.power == 0 * dBm
+        assert channel.power_min == -100 * dBm
+        assert channel.power_max == 20 * dBm
+
+
+def test_channel_power_setter():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+            ":CH1:PWR:MIN?",
+            ":CH1:PWR:MAX?",
+            ":CH1:PWR {:e}".format(0)
+        ],
+        [
+            ":CH1:CH2:FOO",
+            "-100",
+            "20"
+        ],
+        sep="\n"
+    ) as hs:
+        channel = hs.channel[0]
+        channel.power = 0 * dBm
+
+
+def test_channel_phase_getter():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+            ":CH1:PHASE?",
+            ":CH1:PHASE:MIN?",
+            ":CH1:PHASE:MAX?"
+        ],
+        [
+            ":CH1:CH2:FOO",
+            "0",
+            "-180",
+            "+180"
+        ],
+        sep="\n"
+    ) as hs:
+        channel = hs.channel[0]
+        assert channel.phase == 0 * pq.degree
+        assert channel.phase_min == -180 * pq.degree
+        assert channel.phase_max == 180 * pq.degree
+
+
+def test_channel_phase_setter():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+            ":CH1:PHASE:MIN?",
+            ":CH1:PHASE:MAX?",
+            ":CH1:PHASE {:e}".format(0)
+        ],
+        [
+            ":CH1:CH2:FOO",
+            "-180",
+            "+180"
+        ],
+        sep="\n"
+    ) as hs:
+        channel = hs.channel[0]
+        channel.phase = 0 * pq.degree
+
+def test_channel_output():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+            ":CH1:PWR:RF?",
+            ":CH1:PWR:RF:ON",
+            ":CH1:PWR:RF:OFF"
+        ],
+        [
+            ":CH1:CH2:FOO",
+            "OFF"
+        ],
+        sep="\n"
+    ) as hs:
+        channel = hs.channel[0]
+        assert channel.output is False
+        channel.output = True
+        channel.output = False
+
+
+def test_hs9000_is_ready():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":COMM:READY?",
+            ":COMM:READY?"
+        ],
+        [
+            "Ready",
+            "DANGER DANGER"
+        ],
+        sep="\n"
+    ) as hs:
+        assert hs.ready is True
+        assert hs.ready is False

--- a/instruments/instruments/tests/test_holzworth/test_holzworth_hs9000.py
+++ b/instruments/instruments/tests/test_holzworth/test_holzworth_hs9000.py
@@ -17,6 +17,20 @@ from instruments.units import dBm
 
 # TEST CLASSES ################################################################
 
+def test_hs9000_name():
+    with expected_protocol(
+        ik.holzworth.HS9000,
+        [
+            ":ATTACH?",
+            ":CH1:IDN?"
+        ],
+        [
+            ":CH1:CH2:FOO",
+            "Foobar name"
+        ],
+        sep="\n"
+    ) as hs:
+        assert hs.name == "Foobar name"
 
 def test_channel_idx_list():
     with expected_protocol(

--- a/instruments/instruments/tests/test_property_factories.py
+++ b/instruments/instruments/tests/test_property_factories.py
@@ -610,6 +610,16 @@ def test_unitful_property_output_decoration():
 
     eq_(mock_instrument.value, 'MOCK:A 1\n')
 
+def test_unitful_property_split_str():
+    class UnitfulMock(MockInstrument):
+        unitful_property = unitful_property('MOCK', pq.hertz, valid_range=(0, 10))
+
+    mock_inst = UnitfulMock({"MOCK?": "1 kHz"})
+
+    value = mock_inst.unitful_property
+    assert value.magnitude == 1000
+    assert value.units == pq.hertz
+
 
 # Bounded Unitful Property #
 

--- a/instruments/instruments/util_fns.py
+++ b/instruments/instruments/util_fns.py
@@ -331,7 +331,7 @@ def unitful_property(name, units, format_code='{:e}', doc=None, input_decoration
         return val if output_decoration is None else output_decoration(val)
     def getter(self):
         raw = in_decor_fcn(self.query("{}?".format(name)))
-        return float(raw) * units
+        return pq.Quantity(*split_unit_str(raw, units)).rescale(units)
     def setter(self, newval):
         min_value, max_value = valid_range
         if min_value is not None:


### PR DESCRIPTION
Holzworth changes:
- Refactors the Holzworth HS9000 a little bit to make sure everything is in line
- Passes all linting on holzworth files
- Adds full coverage for current functionality

Other changes:
- Changes `unitful_property` to use `split_unit_str` on the getter function to handle returns from instruments that also include a unit in the response.