### PR TITLE
Lint keithley

### DIFF
--- a/instruments/.pylintrc
+++ b/instruments/.pylintrc
@@ -177,7 +177,7 @@ expected-line-ending-format=
 [SIMILARITIES]
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=6
 
 # Ignore comments when computing similarities.
 ignore-comments=yes

--- a/instruments/doc/source/apiref/keithley.rst
+++ b/instruments/doc/source/apiref/keithley.rst
@@ -34,3 +34,11 @@ Keithley
 .. autoclass:: Keithley6220
     :members:
     :undoc-members:
+
+:class:`Keithley6514`
+=====================
+
+.. autoclass:: Keithley6514
+    :members:
+    :undoc-members:
+.. _Keithley 6514: http://www.tunl.duke.edu/documents/public/electronics/Keithley/keithley-6514-electrometer-manual.pdf

--- a/instruments/doc/source/apiref/keithley.rst
+++ b/instruments/doc/source/apiref/keithley.rst
@@ -27,6 +27,7 @@ Keithley
 .. autoclass:: Keithley2182
     :members:
     :undoc-members:
+.. _user's guide: http://www.keithley.com/products/dcac/sensitive/lowvoltage/?mn=2182A
 
 :class:`Keithley6220`
 =====================

--- a/instruments/instruments/abstract_instruments/electrometer.py
+++ b/instruments/instruments/abstract_instruments/electrometer.py
@@ -38,92 +38,111 @@ from instruments.abstract_instruments import Instrument
 class Electrometer(with_metaclass(abc.ABCMeta, Instrument)):
 
     ## PROPERTIES ##
-    
-    def _getmode(self):
-        """
-        Read measurement mode the electrometer is currently in.
-        """
-        raise NotImplementedError
-    def _setmode(self, newval):
-        """
-        Change the mode the electrometer is in.
-        """
-        raise NotImplementedError
-    mode = abc.abstractproperty(_getmode, _setmode)
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
+    def mode(self):
+        """
+        Gets/sets the measurement mode for the electrometer. This is an
+        abstract method.
+
+        :type: `~enum.Enum`
+        """
+        pass
+
+    @mode.setter
+    @abc.abstractmethod
+    def mode(self, newval):
+        pass
+
+    @property
+    @abc.abstractmethod
     def unit(self):
         """
-        Returns the unit corresponding to the current mode.
-        """
-        raise NotImplementedError
-    
-    def _gettrigger_mode(self):
-        """
-        Get the current trigger mode the electrometer is set to.
-        """
-        raise NotImplementedError
-    def _settrigger_mode(self, newval):
-        """
-        Set the electrometer triggering mode.
-        """
-        raise NotImplementedError
-    trigger_mode = abc.abstractproperty(_gettrigger_mode, _settrigger_mode)
-    
-   
-    def _getinput_range(self):
-        """
-        Get the current input range setting of the electrometer.
-        """
-        raise NotImplementedError
-    def _setinput_range(self, newval):
-        """
-        Set the input range setting of the electrometer.
-        """
-        raise NotImplementedError
-    input_range = abc.abstractproperty(_getinput_range, _setinput_range)
+        Gets/sets the measurement mode for the multimeter. This is an
+        abstract method.
 
-    
-    def _getzero_check(self):
+        :type: `~quantities.UnitQuantity`
         """
-        Get the current zero check status.
-        """
-        raise NotImplementedError
-    def _setzero_check(self, newval):
-        """
-        Set the current zero check status.
-        """
-        raise NotImplementedError
-    zero_check = abc.abstractproperty(_getzero_check, _setzero_check)
+        pass
 
-    def _getzero_correct(self):
+    @property
+    @abc.abstractmethod
+    def trigger_mode(self):
         """
-        Get the current zero correct status.
+        Gets/sets the trigger mode for the electrometer. This is an
+        abstract method.
+
+        :type: `~enum.Enum`
         """
-        raise NotImplementedError
-    def _setzero_correct(self, newval):
+        pass
+
+    @trigger_mode.setter
+    @abc.abstractmethod
+    def trigger_mode(self, newval):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def input_range(self):
         """
-        Set the current zero correct status.
+        Gets/sets the input range setting for the electrometer. This is an
+        abstract method.
+
+        :type: `~enum.Enum`
         """
-        raise NotImplementedError
-    zero_correct = abc.abstractproperty(_getzero_correct, _setzero_correct)
-    
-    
+        pass
+
+    @input_range.setter
+    @abc.abstractmethod
+    def input_range(self, newval):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def zero_check(self):
+        """
+        Gets/sets the zero check status for the electrometer. This is an
+        abstract method.
+
+        :type: `bool`
+        """
+        pass
+
+    @zero_check.setter
+    @abc.abstractmethod
+    def zero_check(self, newval):
+        pass
+
+    @property
+    @abc.abstractmethod
+    def zero_correct(self):
+        """
+        Gets/sets the zero correct status for the electrometer. This is an
+        abstract method.
+
+        :type: `bool`
+        """
+        pass
+
+    @zero_correct.setter
+    @abc.abstractmethod
+    def zero_correct(self, newval):
+        pass
+
     ## METHODS ##
 
     @abc.abstractmethod
     def fetch(self):
-        '''
+        """
         Request the latest post-processed readings using the current mode. 
         (So does not issue a trigger)
-        '''
+        """
         raise NotImplementedError
 
     @abc.abstractmethod
     def read(self):
-        '''
+        """
         Trigger and acquire readings using the current mode.
-        '''
+        """
         raise NotImplementedError
-        
-        

--- a/instruments/instruments/hp/__init__.py
+++ b/instruments/instruments/hp/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 Module containing HP instruments

--- a/instruments/instruments/keithley/__init__.py
+++ b/instruments/instruments/keithley/__init__.py
@@ -1,10 +1,13 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+Module containing Keithley instruments
+"""
 
 from __future__ import absolute_import
 
-from instruments.keithley.keithley195 import Keithley195
-from instruments.keithley.keithley580 import Keithley580
-from instruments.keithley.keithley2182 import Keithley2182
-from instruments.keithley.keithley6220 import Keithley6220
-from instruments.keithley.keithley6514 import Keithley6514
+from .keithley195 import Keithley195
+from .keithley580 import Keithley580
+from .keithley2182 import Keithley2182
+from .keithley6220 import Keithley6220
+from .keithley6514 import Keithley6514

--- a/instruments/instruments/keithley/keithley195.py
+++ b/instruments/instruments/keithley/keithley195.py
@@ -1,73 +1,62 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# keithley195.py: Driver for the Keithley 195 multimeter.
-##
-# © 2013-2014 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Driver for the Keithley 195 digital multimeter
+"""
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
 
 import time
-from enum import Enum, IntEnum
 import struct
+from enum import Enum, IntEnum
 
 import quantities as pq
 
 from instruments.abstract_instruments import Multimeter
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
+
 
 class Keithley195(Multimeter):
+
     """
-    The Keithley 195 is a 5 1/2 digit auto-ranging digital multimeter. You can 
+    The Keithley 195 is a 5 1/2 digit auto-ranging digital multimeter. You can
     find the full specifications list in the `Keithley 195 user's guide`_.
-    
+
     Example usage:
-    
+
     >>> import instruments as ik
     >>> import quantities as pq
     >>> dmm = ik.keithley.Keithley195.open_gpibusb('/dev/ttyUSB0', 12)
     >>> print dmm.measure(dmm.Mode.resistance)
-    
+
     .. _Keithley 195 user's guide: http://www.keithley.com/data?asset=803
     """
 
     def __init__(self, filelike):
         super(Keithley195, self).__init__(filelike)
-        self.sendcmd('YX') # Removes the termination CRLF 
-                           # characters from the instrument
-        self.sendcmd('G1DX') # Disable returning prefix and suffix
+        self.sendcmd('YX')  # Removes the termination CRLF
+        self.sendcmd('G1DX')  # Disable returning prefix and suffix
 
-    ## ENUMS ##
-    
+    # ENUMS ##
+
     class Mode(IntEnum):
+        """
+        Enum containing valid measurement modes for the Keithley 195
+        """
         voltage_dc = 0
         voltage_ac = 1
         resistance = 2
         current_dc = 3
         current_ac = 4
-        
+
     class TriggerMode(IntEnum):
+        """
+        Enum containing valid trigger modes for the Keithley 195
+        """
         talk_continuous = 0
         talk_one_shot = 1
         get_continuous = 2
@@ -76,33 +65,37 @@ class Keithley195(Multimeter):
         x_one_shot = 5
         ext_continuous = 6
         ext_one_shot = 7
-        
+
     class ValidRange(Enum):
+        """
+        Enum containing valid range settings for the Keithley 195
+        """
         voltage_dc = (20e-3, 200e-3, 2, 20, 200, 1000)
         voltage_ac = (20e-3, 200e-3, 2, 20, 200, 700)
         current_dc = (20e-6, 200e-6, 2e-3, 20e-3, 200e-3, 2)
         current_ac = (20e-6, 200e-6, 2e-3, 20e-3, 200e-3, 2, 2)
         resistance = (20, 200, 2000, 20e3, 200e3, 2e6, 20e6)
-        
-    ## PROPERTIES ##    
-        
+
+    # PROPERTIES ##
+
     @property
     def mode(self):
         """
         Gets/sets the measurement mode for the Keithley 195. The base model
         only has DC voltage and resistance measurements. In order to use AC
-        voltage, DC current, and AC current measurements your unit must be 
+        voltage, DC current, and AC current measurements your unit must be
         equiped with option 1950.
-        
+
         Example use:
-        
+
         >>> import instruments as ik
         >>> dmm = ik.keithley.Keithley195.open_gpibusb('/dev/ttyUSB0', 12)
         >>> dmm.mode = dmm.Mode.resistance
-        
+
         :type: `Keithley195.Mode`
         """
         return self.parse_status_word(self.get_status_word())['mode']
+
     @mode.setter
     def mode(self, newval):
         if isinstance(newval, str):
@@ -111,90 +104,92 @@ class Keithley195(Multimeter):
             raise TypeError("Mode must be specified as a Keithley195.Mode "
                             "value, got {} instead.".format(newval))
         self.sendcmd('F{}DX'.format(newval.value))
-        
+
     @property
     def trigger_mode(self):
         """
         Gets/sets the trigger mode of the Keithley 195.
-        
+
         There are two different trigger settings for four different sources.
         This means there are eight different settings for the trigger mode.
-        
+
         The two types are continuous and one-shot. Continuous has the instrument
         continuously sample the resistance. One-shot performs a single
         resistance measurement.
-        
-        The three trigger sources are on talk, on GET, and on "X". On talk 
+
+        The three trigger sources are on talk, on GET, and on "X". On talk
         refers to addressing the instrument to talk over GPIB. On GET is when
-        the instrument receives the GPIB command byte for "group execute 
-        trigger". On "X" is when one sends the ASCII character "X" to the 
-        instrument. This character is used as a general execute to confirm 
+        the instrument receives the GPIB command byte for "group execute
+        trigger". On "X" is when one sends the ASCII character "X" to the
+        instrument. This character is used as a general execute to confirm
         commands send to the instrument. In InstrumentKit, "X" is sent after
         each command so it is not suggested that one uses on "X" triggering.
-        Last, is external triggering. This is the port on the rear of the 
+        Last, is external triggering. This is the port on the rear of the
         instrument. Refer to the manual for electrical characteristics of this
         port.
-        
+
         :type: `Keithley195.TriggerMode`
         """
         return self.parse_status_word(self.get_status_word())['trigger']
+
     @trigger_mode.setter
     def trigger_mode(self, newval):
         if isinstance(newval, str):
             newval = Keithley195.TriggerMode[newval]
         if not isinstance(newval, Keithley195.TriggerMode):
-            raise TypeError('Drive must be specified as a ' 
+            raise TypeError('Drive must be specified as a '
                             'Keithley195.TriggerMode, got {} '
                             'instead.'.format(newval))
         self.sendcmd('T{}X'.format(newval.value))
-    
+
     @property
     def relative(self):
         """
-        Gets/sets the zero command (relative measurement) mode of the 
+        Gets/sets the zero command (relative measurement) mode of the
         Keithley 195.
-        
+
         As stated in the manual: The zero mode serves as a means for a baseline
-        suppression. When the correct zero command is send over the bus, the 
+        suppression. When the correct zero command is send over the bus, the
         instrument will enter the zero mode, as indicated by the front panel
         ZERO indicator light. All reading displayed or send over the bus while
-        zero is enabled are the difference between the stored baseline adn the 
+        zero is enabled are the difference between the stored baseline adn the
         actual voltage level. For example, if a 100mV baseline is stored, 100mV
         will be subtracted from all subsequent readings as long as the zero mode
-        is enabled. The value of the stored baseline can be as little as a few 
+        is enabled. The value of the stored baseline can be as little as a few
         microvolts or as large as the selected range will permit.
-        
+
         See the manual for more information.
-        
+
         :type: `bool`
         """
         return self.parse_status_word(self.get_status_word())['relative']
+
     @relative.setter
     def relative(self, newval):
         if not isinstance(newval, bool):
             raise TypeError('Relative mode must be a boolean.')
         self.sendcmd('Z{}DX'.format(int(newval)))
-        
+
     @property
     def input_range(self):
         """
         Gets/sets the range of the Keithley 195 input terminals. The valid range
         settings depends on the current mode of the instrument. They are listed
         as follows:
-        
+
         #) voltage_dc = ``(20e-3, 200e-3, 2, 20, 200, 1000)``
-        
+
         #) voltage_ac = ``(20e-3, 200e-3, 2, 20, 200, 700)``
-        
+
         #) current_dc = ``(20e-6, 200e-6, 2e-3, 20e-3, 200e-3, 2)``
-        
+
         #) current_ac = ``(20e-6, 200e-6, 2e-3, 20e-3, 200e-3, 2)``
-        
+
         #) resistance = ``(20, 200, 2000, 20e3, 200e3, 2e6, 20e6)``
-        
+
         All modes will also accept the string ``auto`` which will set the 195
         into auto ranging mode.
-        
+
         :rtype: `~quantities.quantity.Quantity` or `str`
         """
         index = self.parse_status_word(self.get_status_word())['range']
@@ -202,9 +197,10 @@ class Keithley195(Multimeter):
             return 'auto'
         else:
             mode = self.mode
-            value = Keithley195.ValidRange[mode.name].value[index-1]
+            value = Keithley195.ValidRange[mode.name].value[index - 1]
             units = UNITS2[mode]
             return value * units
+
     @input_range.setter
     def input_range(self, newval):
         if isinstance(newval, str):
@@ -216,7 +212,7 @@ class Keithley195(Multimeter):
                                  'the input range as a string.')
         if isinstance(newval, pq.quantity.Quantity):
             newval = float(newval)
-            
+
         mode = self.mode
         valid = Keithley195.ValidRange[mode.name].value
         if isinstance(newval, (float, int)):
@@ -229,35 +225,35 @@ class Keithley195(Multimeter):
             raise TypeError('Range setting must be specified as a float, int, '
                             'or the string "auto", got {}'.format(type(newval)))
         self.sendcmd('R{}DX'.format(newval))
-        
-    ## METHODS ##
-    
+
+    # METHODS ##
+
     def measure(self, mode=None):
         """
-        Instruct the Keithley 195 to perform a one time measurement. The 
+        Instruct the Keithley 195 to perform a one time measurement. The
         instrument will use default parameters for the requested measurement.
-        The measurement will immediately take place, and the results are 
+        The measurement will immediately take place, and the results are
         directly sent to the instrument's output buffer.
-        
+
         Method returns a Python quantity consisting of a numpy array with the
         instrument value and appropriate units.
-        
-        With the 195, it is HIGHLY recommended that you seperately set the 
+
+        With the 195, it is HIGHLY recommended that you seperately set the
         mode and let the instrument settle into the new mode. This can sometimes
         take longer than the 2 second delay added in this method. In our testing
         the 2 seconds seems to be sufficient but we offer no guarentee.
-        
+
         Example usage:
-    
+
         >>> import instruments as ik
         >>> import quantities as pq
         >>> dmm = ik.keithley.Keithley195.open_gpibusb('/dev/ttyUSB0', 12)
-        >>> print dmm.measure(dmm.Mode.resistance)
-        
+        >>> print(dmm.measure(dmm.Mode.resistance))
+
         :param mode: Desired measurement mode. This must always be specified
             in order to provide the correct return units.
         :type mode: `Keithley195.Mode`
-        
+
         :return: A measurement from the multimeter.
         :rtype: `~quantities.quantity.Quantity`
         """
@@ -265,82 +261,84 @@ class Keithley195(Multimeter):
             current_mode = self.mode
             if mode != current_mode:
                 self.mode = mode
-                time.sleep(2) # Gives the instrument a moment to settle
+                if not self._testing:
+                    time.sleep(2)  # Gives the instrument a moment to settle
         else:
             mode = self.mode
         value = self.query('')
         return float(value) * UNITS2[mode]
-        
+
     def get_status_word(self):
         """
         Retreive the status word from the instrument. This contains information
         regarding the various settings of the instrument.
-        
+
         The function `~Keithley195.parse_status_word` is designed to parse
         the return string from this function.
-        
-        :return: String containing setting information of the instrument 
+
+        :return: String containing setting information of the instrument
         :rtype: `str`
         """
         return self.query('U0DX')
-        
-    def parse_status_word(self, statusword):
+
+    @staticmethod
+    def parse_status_word(statusword):  # pylint: disable=too-many-locals
         """
         Parse the status word returned by the function
         `~Keithley195.get_status_word`.
-        
+
         Returns a `dict` with the following keys:
         ``{trigger,mode,range,eoi,buffer,rate,srqmode,relative,delay,multiplex,
         selftest,dataformat,datacontrol,filter,terminator}``
-        
+
         :param statusword: Byte string to be unpacked and parsed
         :type: `str`
-        
+
         :return: A parsed version of the status word as a Python dictionary
         :rtype: `dict`
         """
         if statusword[:3] != '195':
             raise ValueError('Status word starts with wrong prefix, expected '
                              '195, got {}'.format(statusword))
-        
-        (trigger, function, input_range, eoi, buf, rate, srqmode, relative, \
-         delay, multiplex, selftest, data_fmt, data_ctrl, filter_mode, \
+
+        (trigger, function, input_range, eoi, buf, rate, srqmode, relative,
+         delay, multiplex, selftest, data_fmt, data_ctrl, filter_mode,
          terminator) = struct.unpack('@4c2s3c2s5c2s', statusword[4:])
-        
-        return { 'trigger': Keithley195.TriggerMode(int(trigger)),
-                 'mode': Keithley195.Mode(int(function)),
-                 'range': int(input_range),
-                 'eoi': (eoi == '1'),
-                 'buffer': buf,
-                 'rate': rate,
-                 'srqmode': srqmode,
-                 'relative': (relative == '1'),
-                 'delay': delay,
-                 'multiplex': (multiplex == '1'),
-                 'selftest': selftest,
-                 'dataformat': data_fmt,
-                 'datacontrol': data_ctrl,
-                 'filter': filter_mode,
-                 'terminator': terminator }
-    
+
+        return {'trigger': Keithley195.TriggerMode(int(trigger)),
+                'mode': Keithley195.Mode(int(function)),
+                'range': int(input_range),
+                'eoi': (eoi == '1'),
+                'buffer': buf,
+                'rate': rate,
+                'srqmode': srqmode,
+                'relative': (relative == '1'),
+                'delay': delay,
+                'multiplex': (multiplex == '1'),
+                'selftest': selftest,
+                'dataformat': data_fmt,
+                'datacontrol': data_ctrl,
+                'filter': filter_mode,
+                'terminator': terminator}
+
     def trigger(self):
         """
         Tell the Keithley 195 to execute all commands that it has received.
-        
-        Do note that this is different from the standard SCPI \*TRG command
+
+        Do note that this is different from the standard SCPI ``*TRG`` command
         (which is not supported by the 195 anyways).
         """
         self.sendcmd('X')
-                    
+
     def auto_range(self):
         """
-        Turn on auto range for the Keithley 195. 
-        
+        Turn on auto range for the Keithley 195.
+
         This is the same as calling ``Keithley195.input_range = 'auto'``
         """
         self.input_range = 'auto'
-            
-## UNITS #######################################################################
+
+# UNITS #######################################################################
 
 UNITS = {
     'DCV':  pq.volt,
@@ -348,8 +346,8 @@ UNITS = {
     'ACA':  pq.amp,
     'DCA':  pq.amp,
     'OHM':  pq.ohm,
-}            
-        
+}
+
 UNITS2 = {
     Keithley195.Mode.voltage_dc:  pq.volt,
     Keithley195.Mode.voltage_ac:  pq.volt,
@@ -357,4 +355,3 @@ UNITS2 = {
     Keithley195.Mode.current_ac:  pq.amp,
     Keithley195.Mode.resistance:  pq.ohm,
 }
-

--- a/instruments/instruments/keithley/keithley195.py
+++ b/instruments/instruments/keithley/keithley195.py
@@ -76,7 +76,7 @@ class Keithley195(Multimeter):
         current_ac = (20e-6, 200e-6, 2e-3, 20e-3, 200e-3, 2, 2)
         resistance = (20, 200, 2000, 20e3, 200e3, 2e6, 20e6)
 
-    # PROPERTIES ##
+    # PROPERTIES #
 
     @property
     def mode(self):
@@ -226,7 +226,7 @@ class Keithley195(Multimeter):
                             'or the string "auto", got {}'.format(type(newval)))
         self.sendcmd('R{}DX'.format(newval))
 
-    # METHODS ##
+    # METHODS #
 
     def measure(self, mode=None):
         """

--- a/instruments/instruments/keithley/keithley2182.py
+++ b/instruments/instruments/keithley/keithley2182.py
@@ -100,7 +100,8 @@ class Keithley2182(SCPIMultimeter):
             :rtype: `~quantities.quantity.Quantity`
             """
             if mode is not None:
-                self.mode = mode
+                # self.mode = mode
+                raise NotImplementedError
             self._parent.sendcmd('SENS:CHAN {}'.format(self._idx))
             value = float(self._parent.query('SENS:DATA:FRES?'))
             unit = self._parent.units
@@ -160,14 +161,14 @@ class Keithley2182(SCPIMultimeter):
 
         :type: `bool`
         """
-        mode = self.mode
+        mode = self.channel[0].mode
         return self.query("SENS:{}:CHAN1:REF:STAT?".format(mode.value)) == "ON"
 
     @relative.setter
     def relative(self, newval):
         if not isinstance(newval, bool):
             raise TypeError("Relative mode must be a boolean.")
-        mode = self.mode
+        mode = self.channel[0].mode
         if self.relative:
             self.sendcmd("SENS:{}:CHAN1:REF:ACQ".format(mode.value))
         else:

--- a/instruments/instruments/keithley/keithley2182.py
+++ b/instruments/instruments/keithley/keithley2182.py
@@ -1,28 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# keithley2182.py: Driver for the Keithley 2182 nano-voltmeter.
-##
-# © 2013-2014 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Driver for the Keithley 2182 digital multimeter
+"""
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
@@ -35,197 +17,219 @@ from instruments.generic_scpi import SCPIMultimeter
 from instruments.abstract_instruments import Multimeter
 from instruments.util_fns import ProxyList
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
 
-class _Keithley2182Channel(Multimeter):
-    """
-    Class representing a channel on the Keithley 2182 nano-voltmeter.
-    
-    .. warning:: This class should NOT be manually created by the user. It is 
-        designed to be initialized by the `Keithley2182` class.
-    """
-    
-    def __init__(self, parent, idx):
-        self._parent = parent
-        self._idx = idx + 1
-        
-    ## PROPERTIES ##
-    
-    @property
-    def mode(self):
-        return Keithley2182.Mode[self._parent.query('SENS:FUNC?')]
-    @mode.setter
-    def mode(self, newval):
-        raise NotImplementedError
-    
-    @property
-    def trigger_mode(self):
-        raise NotImplementedError
-    @trigger_mode.setter
-    def trigger_mode(self, newval):
-        raise NotImplementedError
-        
-    @property
-    def relative(self):
-        raise NotImplementedError
-    @relative.setter
-    def relative(self, newval):
-        raise NotImplementedError
-    
-    @property
-    def input_range(self):
-        raise NotImplementedError
-    @input_range.setter
-    def input_range(self, newval):
-        raise NotImplementedError
-        
-    ## METHODS ##
-    
-    def measure(self, mode=None):
-        """
-        #TODO docstring
-        """
-        if mode is not None:
-            self.mode = mode
-        self._parent.sendcmd('SENS:CHAN {}'.format(idx))
-        value = float(self._parent.query('SENS:DATA:FRES?'))
-        unit = self._parent.units
-        return value * unit
-        
 
 class Keithley2182(SCPIMultimeter):
+
     """
     The Keithley 2182 is a nano-voltmeter. You can find the full specifications
     list in the `user's guide`_.
-    
+
     Example usage:
-    
+
     >>> import instruments as ik
-    >>> import quantities as pq
-    >>> meter = ik.keithley.Keithley2182.open_gpibusb('/dev/ttyUSB0', 10)
+    >>> meter = ik.keithley.Keithley2182.open_gpibusb("/dev/ttyUSB0", 10)
     >>> print meter.measure(meter.Mode.voltage_dc)
-    
+
     .. _user's guide: http://www.keithley.com/products/dcac/sensitive/lowvoltage/?mn=2182A
     """
-    
+
     def __init__(self, filelike):
         super(Keithley2182, self).__init__(filelike)
-        
-    ## ENUMS ##
-    
+
+    # INNER CLASSES #
+
+    class Channel(Multimeter):
+        """
+        Class representing a channel on the Keithley 2182 nano-voltmeter.
+
+        .. warning:: This class should NOT be manually created by the user. It
+            is designed to be initialized by the `Keithley2182` class.
+        """
+
+        def __init__(self, parent, idx):
+            super(Keithley2182.Channel, self).__init__(None)
+            self._parent = parent
+            self._idx = idx + 1
+
+        # PROPERTIES #
+
+        @property
+        def mode(self):
+            return Keithley2182.Mode[self._parent.query('SENS:FUNC?')]
+
+        @mode.setter
+        def mode(self, newval):
+            raise NotImplementedError
+
+        @property
+        def trigger_mode(self):
+            raise NotImplementedError
+
+        @trigger_mode.setter
+        def trigger_mode(self, newval):
+            raise NotImplementedError
+
+        @property
+        def relative(self):
+            raise NotImplementedError
+
+        @relative.setter
+        def relative(self, newval):
+            raise NotImplementedError
+
+        @property
+        def input_range(self):
+            raise NotImplementedError
+
+        @input_range.setter
+        def input_range(self, newval):
+            raise NotImplementedError
+
+        # METHODS #
+
+        def measure(self, mode=None):
+            """
+            Performs a measurement of the specified channel. If no mode
+            parameter is specified then the current mode is used.
+
+            :param mode: Mode that the measurement will be performed in
+            :type mode: Keithley2182.Mode
+            :return: The value of the measurement
+            :rtype: `~quantities.quantity.Quantity`
+            """
+            if mode is not None:
+                self.mode = mode
+            self._parent.sendcmd('SENS:CHAN {}'.format(self._idx))
+            value = float(self._parent.query('SENS:DATA:FRES?'))
+            unit = self._parent.units
+            return value * unit
+
+    # ENUMS #
+
     class Mode(Enum):
+        """
+        Enum containing valid measurement modes for the Keithley 2182
+        """
         voltage_dc = 'VOLT'
         temperature = 'TEMP'
-        
+
     class TriggerMode(Enum):
+        """
+        Enum containing valid trigger modes for the Keithley 2182
+        """
         immediate = 'IMM'
         external = 'EXT'
         bus = 'BUS'
         timer = 'TIM'
         manual = 'MAN'
-        
-    ## PROPERTIES ##
-    
+
+    # PROPERTIES #
+
     @property
     def channel(self):
         """
         Gets a specific Keithley 2182 channel object. The desired channel is
         specified like one would access a list.
-        
+
         Although not default, the 2182 has up to two channels.
-        
+
         For example, the following would print the measurement from channel 1:
-        
-        >>> meter = ik.keithley.Keithley2182.open_gpibusb('/dev/ttyUSB0', 10)
+
+        >>> meter = ik.keithley.Keithley2182.open_gpibusb("/dev/ttyUSB0", 10)
         >>> print meter.channel[0].measure()
-        
-        :rtype: `_Keithley2182Channel`
+
+        :rtype: `Keithley2182.Channel`
         """
-        return ProxyList(self, _Keithley2182Channel, range(2))
-        
+        return ProxyList(self, Keithley2182.Channel, range(2))
+
     @property
     def relative(self):
         """
         Gets/sets the relative measurement function of the Keithley 2182.
-        
-        This is used to enable or disable the relative function for the 
-        currently set mode. When enabling, the current reading is used as a 
-        baseline which is subtracted from future measurements. 
-        
-        If relative is already on, the stored value is refreshed with the 
+
+        This is used to enable or disable the relative function for the
+        currently set mode. When enabling, the current reading is used as a
+        baseline which is subtracted from future measurements.
+
+        If relative is already on, the stored value is refreshed with the
         currently read value.
-        
+
         See the manual for more information.
-        
+
         :type: `bool`
         """
         mode = self.mode
-        return self.query('SENS:{}:CHAN1:REF:STAT?'.format(mode.value)) == 'ON'
+        return self.query("SENS:{}:CHAN1:REF:STAT?".format(mode.value)) == "ON"
+
     @relative.setter
     def relative(self, newval):
         if not isinstance(newval, bool):
-            raise TypeError('Relative mode must be a boolean.')
+            raise TypeError("Relative mode must be a boolean.")
         mode = self.mode
-        if (self.relative):
-            self.sendcmd('SENS:{}:CHAN1:REF:ACQ'.format(mode.value))
+        if self.relative:
+            self.sendcmd("SENS:{}:CHAN1:REF:ACQ".format(mode.value))
         else:
-            newval = ('ON' if newval is True else 'OFF')
-            self.sendcmd('SENS:{}:CHAN1:REF:STAT {}'.format(mode.value, newval))
+            newval = ("ON" if newval is True else "OFF")
+            self.sendcmd(
+                "SENS:{}:CHAN1:REF:STAT {}".format(mode.value, newval))
 
     @property
     def input_range(self):
         raise NotImplementedError
+
     @input_range.setter
     def input_range(self, newval):
         raise NotImplementedError
-        
+
     @property
     def units(self):
         """
         Gets the current measurement units of the instrument.
-        
+
         :rtype: `~quantities.unitquantity.UnitQuantity`
         """
         mode = self.mode
         if mode == Keithley2182.Mode.voltage_dc:
             return pq.ohm
-        unit = self.query('UNIT:TEMP?')
-        if unit == 'C':
+        unit = self.query("UNIT:TEMP?")
+        if unit == "C":
             unit = pq.celsius
-        elif unit == 'K':
+        elif unit == "K":
             unit = pq.kelvin
-        elif unit == 'F':
+        elif unit == "F":
             unit = pq.fahrenheit
         else:
-            raise ValueError('Unknown temperature units.') 
+            raise ValueError("Unknown temperature units.")
         return unit
-        
-    ## METHODS ##
-        
+
+    # METHODS #
+
     def fetch(self):
         """
-        Transfer readings from instrument memory to the output buffer, and thus 
+        Transfer readings from instrument memory to the output buffer, and thus
         to the computer.
-        If currently taking a reading, the instrument will wait until it is 
+        If currently taking a reading, the instrument will wait until it is
         complete before executing this command.
-        Readings are NOT erased from memory when using fetch. Use the R? command 
+        Readings are NOT erased from memory when using fetch. Use the R? command
         to read and erase data.
-        Note that the data is transfered as ASCII, and thus it is not 
+        Note that the data is transfered as ASCII, and thus it is not
         recommended to transfer a large number of data points using GPIB.
-        
+
         :return: Measurement readings from the instrument output buffer.
         :rtype: `list` of `~quantities.quantity.Quantity` elements
         """
-        return list(map(float, self.query('FETC?').split(','))) * self.units
-    
+        return list(map(float, self.query("FETC?").split(","))) * self.units
+
     def measure(self, mode=None):
         """
         Perform and transfer a measurement of the desired type.
-        
-        :param mode: Desired measurement mode. If left at default the 
+
+        :param mode: Desired measurement mode. If left at default the
             measurement will occur with the current mode.
         :type: `Keithley2182.Mode`
-        
+
         :return: Returns a single shot measurement of the specified mode.
         :rtype: `~quantities.quantity.Quantity`
         :units: Volts, Celsius, Kelvin, or Fahrenheit
@@ -235,7 +239,6 @@ class Keithley2182(SCPIMultimeter):
         if not isinstance(mode, Keithley2182.Mode):
             raise TypeError("Mode must be specified as a Keithley2182.Mode "
                             "value, got {} instead.".format(mode))
-        value = float(self.query('MEAS:{}?'.format(mode)))
+        value = float(self.query("MEAS:{}?".format(mode)))
         unit = self.units
         return value * unit
-

--- a/instruments/instruments/keithley/keithley6220.py
+++ b/instruments/instruments/keithley/keithley6220.py
@@ -51,7 +51,7 @@ class Keithley6220(SCPIInstrument, PowerSupply):
         >>> ccs.channel[0].current = 0.01
         >>> ccs.current = 0.01
         """
-        return tuple(self)
+        return self,
 
     @property
     def voltage(self):

--- a/instruments/instruments/keithley/keithley6220.py
+++ b/instruments/instruments/keithley/keithley6220.py
@@ -1,28 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# keithley6220.py: Driver for the Keithley 6220 current source.
-##
-# © 2014 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Provides support for the Keithley 6220 constant current supply
+"""
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
@@ -31,28 +13,30 @@ import quantities as pq
 
 from instruments.abstract_instruments import PowerSupply
 from instruments.generic_scpi import SCPIInstrument
-from instruments.util_fns import assume_units
+from instruments.util_fns import bounded_unitful_property
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
+
 
 class Keithley6220(SCPIInstrument, PowerSupply):
+
     """
     The Keithley 6220 is a single channel constant current supply.
-    
+
     Because this is a constant current supply, most features that a regular
     power supply have are not present on the 6220.
-    
+
     Example usage:
-    
+
     >>> import quantities as pq
     >>> import instruments as ik
-    >>> ccs = ik.keithley.Keithley6220.open_gpibusb('/dev/ttyUSB0', 10)
+    >>> ccs = ik.keithley.Keithley6220.open_gpibusb("/dev/ttyUSB0", 10)
     >>> ccs.current = 10 * pq.milliamp # Sets current to 10mA
     >>> ccs.disable() # Turns off the output and sets the current to 0A
     """
-    
-    ## PROPERTIES ##
-    
+
+    # PROPERTIES ##
+
     @property
     def channel(self):
         """
@@ -60,51 +44,45 @@ class Keithley6220(SCPIInstrument, PowerSupply):
         However, the 6220 only has a single channel, so this function simply
         returns a tuple containing itself. This is for compatibility reasons
         if a multichannel supply is replaced with the single-channel 6220.
-        
-        For example, the following commands are the same and both set the 
+
+        For example, the following commands are the same and both set the
         current to 10mA:
-        
+
         >>> ccs.channel[0].current = 0.01
         >>> ccs.current = 0.01
         """
         return tuple(self)
-        
+
     @property
     def voltage(self):
         """
         This property is not supported by the Keithley 6220.
         """
-        raise NotImplementedError('The Keithley 6220 does not support voltage '
-                                  'settings.')
+        raise NotImplementedError("The Keithley 6220 does not support voltage "
+                                  "settings.")
+
     @voltage.setter
     def voltage(self, newval):
-        raise NotImplementedError('The Keithley 6220 does not support voltage '
-                                  'settings.')
-    
-    @property
-    def current(self):
-        """
+        raise NotImplementedError("The Keithley 6220 does not support voltage "
+                                  "settings.")
+
+    current, current_min, current_max = bounded_unitful_property(
+        "SOUR:CURR",
+        pq.amp,
+        valid_range=(-105 * pq.milliamp, +105 * pq.milliamp),
+        doc="""
         Gets/sets the output current of the source. Value must be between
         -105mA and +105mA.
-        
-        
+
         :units: As specified, or assumed to be :math:`\\text{A}` otherwise.
         :type: `float` or `~quantities.Quantity`
         """
-        return pq.Quantity(float(self.query(
-                        'SOUR:CURR? {}'.format(self._idx)).strip()[:-1]), pq.amp)
-    @current.setter
-    def current(self, newval):
-        newval = assume_units(newval, pq.amp).rescale(pq.amp)
-        
-        if (newval < -105e-3) or (newval > 105e-3):
-            raise ValueError('Current must be betwen -105e-3 and 105e-3') 
-        self.sendcmd('SOUR:CURR {}'.format(newval.magnitude))
-    
-    ## METHODS ##
-    
+    )
+
+    # METHODS #
+
     def disable(self):
-        '''
+        """
         Set the output current to zero and disable the output.
-        '''
-        self.sendcmd('SOUR:CLE:IMM')
+        """
+        self.sendcmd("SOUR:CLE:IMM")

--- a/instruments/instruments/keithley/keithley6514.py
+++ b/instruments/instruments/keithley/keithley6514.py
@@ -100,7 +100,7 @@ class Keithley6514(SCPIInstrument, Electrometer):
 
     def _parse_measurement(self, ascii):
         # TODO: don't assume ASCII data format # pylint: disable=fixme
-        vals = map(float, ascii.split(','))
+        vals = list(map(float, ascii.split(',')))
         reading = vals[0] * self.unit
         timestamp = vals[1]
         status = vals[2]
@@ -188,7 +188,7 @@ class Keithley6514(SCPIInstrument, Electrometer):
     def input_range(self, newval):
         mode = self.mode
         val = newval.rescale(self._MODE_UNITS[mode]).item()
-        if val not in self._valid_range(mode):
+        if val not in self._valid_range(mode).value:
             raise ValueError(
                 'Unexpected range limit for currently selected mode.')
         self.sendcmd('{}:RANGE:UPPER {:e}'.format(mode.value, val))

--- a/instruments/instruments/keithley/keithley6514.py
+++ b/instruments/instruments/keithley/keithley6514.py
@@ -1,28 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# keithley6514.py: Driver for the Keithley 6514 electrometer.
-##
-# © 2013-2014 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Provides support for the Keithley 6514 electrometer
+"""
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
@@ -36,35 +18,44 @@ from instruments.abstract_instruments import Electrometer
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import bool_property, enum_property
 
-## CLASSES #####################################################################
+# CLASSES #####################################################################
+
 
 class Keithley6514(SCPIInstrument, Electrometer):
+
     """
-    The Keithley 6514 is an electrometer capable of doing sensitive current, 
+    The `Keithley 6514`_ is an electrometer capable of doing sensitive current,
     charge, voltage and resistance measurements.
-    
+
     Example usage:
-    
+
     >>> import instruments as ik
     >>> import quantities as pq
     >>> dmm = ik.keithley.Keithley6514.open_gpibusb('/dev/ttyUSB0', 12)
-    
-    .. _Keithley 6514 user's guide: http://www.tunl.duke.edu/documents/public/electronics/Keithley/keithley-6514-electrometer-manual.pdf
     """
 
-    ## ENUMS ##
-    
+    # ENUMS #
+
     class Mode(Enum):
+        """
+        Enum containing valid measurement modes for the Keithley 6514
+        """
         voltage = 'VOLT:DC'
         current = 'CURR:DC'
         resistance = 'RES'
         charge = 'CHAR'
-       
+
     class TriggerMode(Enum):
+        """
+        Enum containing valid trigger modes for the Keithley 6514
+        """
         immediate = 'IMM'
         tlink = 'TLINK'
 
     class ArmSource(Enum):
+        """
+        Enum containing valid trigger arming sources for the Keithley 6514
+        """
         immediate = 'IMM'
         timer = 'TIM'
         bus = 'BUS'
@@ -73,14 +64,18 @@ class Keithley6514(SCPIInstrument, Electrometer):
         pstest = 'PST'
         nstest = 'NST'
         manual = 'MAN'
-        
+
     class ValidRange(Enum):
+        """
+        Enum containing valid measurement ranges for the Keithley 6514
+        """
         voltage = (2, 20, 200)
-        current = (20e-12, 200e-12, 2e-9, 20e-9, 200e-9, 2e-6, 20e-6, 200e-6, 2e-3,20e-3)
+        current = (20e-12, 200e-12, 2e-9, 20e-9,
+                   200e-9, 2e-6, 20e-6, 200e-6, 2e-3, 20e-3)
         resistance = (2e3, 20e3, 200e3, 2e6, 20e6, 200e6, 2e9, 20e9, 200e9)
         charge = (20e-9, 200e-9, 2e-6, 20e-6)
 
-    ## CONSTANTS ##
+    # CONSTANTS #
 
     _MODE_UNITS = {
         Mode.voltage: pq.volt,
@@ -88,107 +83,120 @@ class Keithley6514(SCPIInstrument, Electrometer):
         Mode.resistance: pq.ohm,
         Mode.charge: pq.coulomb
     }
-        
-    ## PRIVATE METHODS ##    
-    
-    def _get_auto_range(self, mode):
-        out = self.query('{}:RANGE:AUTO?'.format(mode.value))
-        return out.strip() == '1'
-    def _set_auto_range(self, mode, value):
-        self.sendcmd('{}:RANGE:AUTO {}'.format(mode.value, '1' if value else '0'))
 
-    def _get_range(self, mode):
-        out = self.query('{}:RANGE:UPPER?'.format(mode.value)).strip()
-        return float(out) * self._MODE_UNITS[mode]
-    def _set_range(self, mode, value):
-        val = value.rescale(self._MODE_UNITS[mode]).item()
-        if val not in self._valid_range(mode):
-            raise ValueError('Unexpected range limit for currently selected mode.')
-        self.sendcmd('{}:RANGE:UPPER {:e}'.format(mode.value, val))
+    # PRIVATE METHODS #
 
     def _valid_range(self, mode):
         if mode == self.Mode.voltage:
-            vrange = self.ValidRange.voltage
+            return self.ValidRange.voltage
         elif mode == self.Mode.current:
-            vrange = self.ValidRange.current
+            return self.ValidRange.current
         elif mode == self.Mode.resistance:
-            vrange = self.ValidRange.resistance
+            return self.ValidRange.resistance
         elif mode == self.Mode.charge:
-            vrange = self.ValidRange.charge
+            return self.ValidRange.charge
         else:
             raise ValueError('Invalid mode.')
-        return vrange
-        
+
     def _parse_measurement(self, ascii):
-        # TODO: don't assume ASCII data format
+        # TODO: don't assume ASCII data format # pylint: disable=fixme
         vals = map(float, ascii.split(','))
         reading = vals[0] * self.unit
         timestamp = vals[1]
         status = vals[2]
         return reading, timestamp, status
-    
-    ## PROPERTIES ##  
+
+    # PROPERTIES #
 
     # The mode values have quotes around them for some annoying reason.
-    mode = enum_property('FUNCTION', 
-        Mode, 
-        doc='Gets/sets the measurement mode of the Keithley 6514.',
+    mode = enum_property(
+        'FUNCTION',
+        Mode,
         input_decoration=lambda val: val[1:-1],
-        output_decoration=lambda val: '"{}"'.format(val)
+        # output_decoration=lambda val: '"{}"'.format(val),
+        set_fmt='{} "{}"',
+        doc="""
+        Gets/sets the measurement mode of the Keithley 6514.
+        """
     )
 
-    trigger_mode = enum_property('TRIGGER:SOURCE', 
-        TriggerMode, 
-        'Gets/sets the trigger mode of the Keithley 6514.'
+    trigger_mode = enum_property(
+        'TRIGGER:SOURCE',
+        TriggerMode,
+        doc="""
+        Gets/sets the trigger mode of the Keithley 6514.
+        """
     )
 
-    arm_source = enum_property('ARM:SOURCE', 
-        ArmSource, 
-        'Gets/sets the arm source of the Keithley 6514.'
+    arm_source = enum_property(
+        'ARM:SOURCE',
+        ArmSource,
+        doc="""
+        Gets/sets the arm source of the Keithley 6514.
+        """
     )
 
-    zero_check = bool_property('SYST:ZCH', 
-        'ON', 'OFF',
-        'Gets/sets the zero checking status of the Keithley 6514.'
+    zero_check = bool_property(
+        'SYST:ZCH',
+        inst_true='ON',
+        inst_false='OFF',
+        doc="""
+        Gets/sets the zero checking status of the Keithley 6514.
+        """
     )
-    zero_correct = bool_property('SYST:ZCOR', 
-        'ON', 'OFF',
-        'Gets/sets the zero correcting status of the Keithley 6514.'
+
+    zero_correct = bool_property(
+        'SYST:ZCOR',
+        inst_true='ON',
+        inst_false='OFF',
+        doc="""
+        Gets/sets the zero correcting status of the Keithley 6514.
+        """
     )
 
     @property
     def unit(self):
         return self._MODE_UNITS[self.mode]
-  
+
     @property
     def auto_range(self):
         """
         Gets/sets the auto range setting
-               
-        :type: `Keithley6514.TriggerMode`
+
+        :type: `bool`
         """
-        return self._get_auto_range(self.mode)
+        out = self.query('{}:RANGE:AUTO?'.format(self.mode.value))
+        return True if out == '1' else False
+
     @auto_range.setter
     def auto_range(self, newval):
-        self._set_auto_range(self.mode, newval)
+        self.sendcmd('{}:RANGE:AUTO {}'.format(
+            self.mode.value, '1' if newval else '0'))
 
     @property
     def input_range(self):
         """
         Gets/sets the upper limit of the current range.
-               
-        :type: `Keithley6514.TriggerMode`
+
+        :type: `~quantities.Quantity`
         """
-        return self._get_range(self.mode)
+        mode = self.mode
+        out = self.query('{}:RANGE:UPPER?'.format(mode.value))
+        return float(out) * self._MODE_UNITS[mode]
+
     @input_range.setter
     def input_range(self, newval):
-        self._set_range(self.mode, newval)
-        
-        
-    ## METHODS ##
+        mode = self.mode
+        val = newval.rescale(self._MODE_UNITS[mode]).item()
+        if val not in self._valid_range(mode):
+            raise ValueError(
+                'Unexpected range limit for currently selected mode.')
+        self.sendcmd('{}:RANGE:UPPER {:e}'.format(mode.value, val))
+
+    # METHODS ##
 
     def auto_config(self, mode):
-        '''
+        """
         This command causes the device to do the following:
             - Switch to the specified mode
             - Reset all related controls to default values
@@ -199,31 +207,24 @@ class Keithley6514(SCPIInstrument, Electrometer):
             - Disable all math calculations
             - Disable buffer operation
             - Enable autozero
-        '''
+        """
         self.sendcmd('CONF:{}'.format(mode.value))
-    
+
     def fetch(self):
-        '''
-        Request the latest post-processed readings using the current mode. 
+        """
+        Request the latest post-processed readings using the current mode.
         (So does not issue a trigger)
         Returns a tuple of the form (reading, timestamp)
-        '''
-        # TODO: figure out what to do with the status info
+        """
         raw = self.query('FETC?')
-        reading, timestamp, status = self._parse_measurement(raw)
+        reading, timestamp, _ = self._parse_measurement(raw)
         return reading, timestamp
-
 
     def read(self):
-        '''
+        """
         Trigger and acquire readings using the current mode.
         Returns a tuple of the form (reading, timestamp)
-        '''
-        # TODO: figure out what to do with the status info
+        """
         raw = self.query('READ?')
-        reading, timestamp, status = self._parse_measurement(raw)
+        reading, timestamp, _ = self._parse_measurement(raw)
         return reading, timestamp
-
-        
-
-

--- a/instruments/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/instruments/tests/test_keithley/test_keithley2182.py
@@ -163,3 +163,74 @@ def test_measure():
         ]
     ) as inst:
         assert inst.measure() == 1.234 * pq.volt
+
+
+@raises(TypeError)
+def test_measure_invalid_mode():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [],
+        []
+    ) as inst:
+        inst.measure("derp")
+
+
+def test_relative_get():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "SENS:FUNC?",
+            "SENS:VOLT:CHAN1:REF:STAT?"
+        ],
+        [
+            "VOLT",
+            "ON"
+        ]
+    ) as inst:
+        assert inst.relative is True
+
+
+def test_relative_set_already_enabled():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "SENS:FUNC?",
+            "SENS:FUNC?",
+            "SENS:VOLT:CHAN1:REF:STAT?",
+            "SENS:VOLT:CHAN1:REF:ACQ"
+        ],
+        [
+            "VOLT",
+            "VOLT",
+            "ON",
+        ]
+    ) as inst:
+        inst.relative = True
+
+
+def test_relative_set_start_disabled():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "SENS:FUNC?",
+            "SENS:FUNC?",
+            "SENS:VOLT:CHAN1:REF:STAT?",
+            "SENS:VOLT:CHAN1:REF:STAT ON"
+        ],
+        [
+            "VOLT",
+            "VOLT",
+            "OFF",
+        ]
+    ) as inst:
+        inst.relative = True
+
+
+@raises(TypeError)
+def test_relative_set_wrong_type():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [],
+        []
+    ) as inst:
+        inst.relative = "derp"

--- a/instruments/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/instruments/tests/test_keithley/test_keithley2182.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the Keithley 2182 nano-voltmeter
+"""
+
+# IMPORTS #####################################################################
+
+from __future__ import absolute_import
+
+import quantities as pq
+import numpy as np
+from nose.tools import raises
+
+import instruments as ik
+from instruments.tests import expected_protocol, make_name_test, unit_eq
+
+# TESTS #######################################################################
+
+
+def test_channel():
+    inst = ik.keithley.Keithley2182.open_test()
+    assert isinstance(inst.channel[0], inst.Channel) is True
+
+
+def test_channel_mode():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "SENS:FUNC?",
+        ],
+        [
+            "VOLT",
+        ]
+    ) as inst:
+        channel = inst.channel[0]
+        assert channel.mode == inst.Mode.voltage_dc
+
+def test_channel_measure_voltage():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "SENS:CHAN 1",
+            "SENS:DATA:FRES?",
+            "SENS:FUNC?"
+        ],
+        [
+            "1.234",
+            "VOLT",
+        ]
+    ) as inst:
+        channel = inst.channel[0]
+        assert channel.measure() == 1.234 * pq.volt
+
+
+def test_channel_measure_temperature():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "SENS:CHAN 1",
+            "SENS:DATA:FRES?",
+            "SENS:FUNC?",
+            "UNIT:TEMP?"
+        ],
+        [
+            "1.234",
+            "TEMP",
+            "C"
+        ]
+    ) as inst:
+        channel = inst.channel[0]
+        assert channel.measure() == 1.234 * pq.celsius
+
+
+@raises(ValueError)
+def test_channel_measure_unknown_temperature_units():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "SENS:CHAN 1",
+            "SENS:DATA:FRES?",
+            "SENS:FUNC?",
+            "UNIT:TEMP?"
+        ],
+        [
+            "1.234",
+            "TEMP",
+            "Z"
+        ]
+    ) as inst:
+        inst.channel[0].measure()
+
+
+def test_units():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "SENS:FUNC?",
+            "UNIT:TEMP?",
+
+            "SENS:FUNC?",
+            "UNIT:TEMP?",
+
+            "SENS:FUNC?",
+            "UNIT:TEMP?",
+
+            "SENS:FUNC?"
+        ],
+        [
+            "TEMP",
+            "C",
+
+            "TEMP",
+            "F",
+
+            "TEMP",
+            "K",
+
+            "VOLT"
+        ]
+    ) as inst:
+        units = str(inst.units.units).split()[1]
+        assert units == "degC"
+
+        units = str(inst.units.units).split()[1]
+        assert units == "degF"
+
+        units = str(inst.units.units).split()[1]
+        assert units == "K"
+
+        assert inst.units == pq.volt
+
+
+def test_fetch():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "FETC?",
+            "SENS:FUNC?"
+        ],
+        [
+            "1.234,1,5.678",
+            "VOLT",
+        ]
+    ) as inst:
+        np.testing.assert_array_equal(
+            inst.fetch(), [1.234, 1, 5.678] * pq.volt
+        )
+
+
+def test_measure():
+    with expected_protocol(
+        ik.keithley.Keithley2182,
+        [
+            "SENS:FUNC?",
+            "MEAS:VOLT?",
+            "SENS:FUNC?",
+        ],
+        [
+            "VOLT",
+            "1.234",
+            "VOLT"
+        ]
+    ) as inst:
+        assert inst.measure() == 1.234 * pq.volt

--- a/instruments/instruments/tests/test_keithley/test_keithley6220.py
+++ b/instruments/instruments/tests/test_keithley/test_keithley6220.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the Keithley 6220 constant current supply
+"""
+
+# IMPORTS #####################################################################
+
+from __future__ import absolute_import
+
+import quantities as pq
+
+import instruments as ik
+from instruments.tests import expected_protocol, make_name_test, unit_eq
+
+# TESTS #######################################################################
+
+
+def test_channel():
+    inst = ik.keithley.Keithley6220.open_test()
+    assert inst.channel[0] == inst
+
+
+def test_current():
+    with expected_protocol(
+        ik.keithley.Keithley6220,
+        [
+            "SOUR:CURR?",
+            "SOUR:CURR {:e}".format(0.05)
+        ],
+        [
+            "0.1",
+        ]
+    ) as inst:
+        assert inst.current == 100 * pq.milliamp
+        assert inst.current_min == -105 * pq.milliamp
+        assert inst.current_max == +105 * pq.milliamp
+        inst.current = 50 * pq.milliamp
+
+
+def test_disable():
+    with expected_protocol(
+        ik.keithley.Keithley6220,
+        [
+            "SOUR:CLE:IMM"
+        ],
+        []
+    ) as inst:
+        inst.disable()

--- a/instruments/instruments/tests/test_keithley/test_keithley6514.py
+++ b/instruments/instruments/tests/test_keithley/test_keithley6514.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the Keithley 6514 electrometer
+"""
+
+# IMPORTS #####################################################################
+
+from __future__ import absolute_import
+
+import quantities as pq
+import numpy as np
+from nose.tools import raises
+import mock
+
+import instruments as ik
+from instruments.tests import expected_protocol, make_name_test, unit_eq
+
+# TESTS #######################################################################
+
+
+def test_valid_range():
+    inst = ik.keithley.Keithley6514.open_test()
+    assert inst._valid_range(inst.Mode.voltage) == inst.ValidRange.voltage
+    assert inst._valid_range(inst.Mode.current) == inst.ValidRange.current
+    assert inst._valid_range(inst.Mode.resistance) == inst.ValidRange.resistance
+    assert inst._valid_range(inst.Mode.charge) == inst.ValidRange.charge
+
+
+@raises(ValueError)
+def test_valid_range_invalid():
+    inst = ik.keithley.Keithley6514.open_test()
+    inst._valid_range(inst.TriggerMode.immediate)
+
+
+def test_parse_measurement():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "FUNCTION?",
+        ],
+        [
+            '"VOLT:DC"'
+        ]
+    ) as inst:
+        reading, timestamp, status = inst._parse_measurement("1.0,1234,5678")
+        assert reading == 1.0 * pq.volt
+        assert timestamp == 1234
+        assert status == 5678
+
+
+def test_mode():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "FUNCTION?",
+            'FUNCTION "VOLT:DC"'
+        ],
+        [
+            '"VOLT:DC"'
+        ]
+    ) as inst:
+        assert inst.mode == inst.Mode.voltage
+        inst.mode = inst.Mode.voltage
+
+
+def test_trigger_source():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "TRIGGER:SOURCE?",
+            "TRIGGER:SOURCE IMM"
+        ],
+        [
+            "TLINK"
+        ]
+    ) as inst:
+        assert inst.trigger_mode == inst.TriggerMode.tlink
+        inst.trigger_mode = inst.TriggerMode.immediate
+
+
+def test_arm_source():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "ARM:SOURCE?",
+            "ARM:SOURCE IMM"
+        ],
+        [
+            "TIM"
+        ]
+    ) as inst:
+        assert inst.arm_source == inst.ArmSource.timer
+        inst.arm_source = inst.ArmSource.immediate
+
+
+def test_zero_check():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "SYST:ZCH?",
+            "SYST:ZCH ON"
+        ],
+        [
+            "OFF"
+        ]
+    ) as inst:
+        assert inst.zero_check is False
+        inst.zero_check = True
+
+
+def test_zero_correct():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "SYST:ZCOR?",
+            "SYST:ZCOR ON"
+        ],
+        [
+            "OFF"
+        ]
+    ) as inst:
+        assert inst.zero_correct is False
+        inst.zero_correct = True
+
+
+def test_unit():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "FUNCTION?",
+        ],
+        [
+            '"VOLT:DC"'
+        ]
+    ) as inst:
+        assert inst.unit == pq.volt
+
+
+def test_auto_range():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "FUNCTION?",
+            "VOLT:DC:RANGE:AUTO?",
+            "FUNCTION?",
+            "VOLT:DC:RANGE:AUTO 1"
+        ],
+        [
+            '"VOLT:DC"',
+            "0",
+            '"VOLT:DC"'
+        ]
+    ) as inst:
+        assert inst.auto_range is False
+        inst.auto_range = True
+
+
+def test_input_range():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "FUNCTION?",
+            "VOLT:DC:RANGE:UPPER?",
+            "FUNCTION?",
+            "VOLT:DC:RANGE:UPPER {:e}".format(20)
+        ],
+        [
+            '"VOLT:DC"',
+            "10",
+            '"VOLT:DC"'
+        ]
+    ) as inst:
+        assert inst.input_range == 10 * pq.volt
+        inst.input_range = 20 * pq.volt
+
+
+@raises(ValueError)
+def test_input_range_invalid():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "FUNCTION?"
+        ],
+        [
+            '"VOLT:DC"'
+        ]
+    ) as inst:
+        inst.input_range = 10 * pq.volt
+
+
+def test_auto_config():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "CONF:VOLT:DC",
+        ],
+        []
+    ) as inst:
+        inst.auto_config(inst.Mode.voltage)
+
+
+def test_fetch():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "FETC?",
+            "FUNCTION?",
+        ],
+        [
+            "1.0,1234,5678",
+            '"VOLT:DC"'
+        ]
+    ) as inst:
+        reading, timestamp = inst.fetch()
+        assert reading == 1.0 * pq.volt
+        assert timestamp == 1234
+
+
+def test_read():
+    with expected_protocol(
+        ik.keithley.Keithley6514,
+        [
+            "READ?",
+            "FUNCTION?",
+        ],
+        [
+            "1.0,1234,5678",
+            '"VOLT:DC"'
+        ]
+    ) as inst:
+        reading, timestamp = inst.read()
+        assert reading == 1.0 * pq.volt
+        assert timestamp == 1234

--- a/instruments/instruments/tests/test_property_factories.py
+++ b/instruments/instruments/tests/test_property_factories.py
@@ -707,6 +707,20 @@ def test_bounded_unitful_property_static_range():
     eq_(mock_inst.property_max, 9999 * pq.Hz)
 
 
+def test_bounded_unitful_property_static_range_with_units():
+    class BoundedUnitfulMock(MockInstrument):
+        property, property_min, property_max = bounded_unitful_property(
+            'MOCK',
+            units=pq.hertz,
+            valid_range=(10 * pq.kilohertz, 9999 * pq.kilohertz)
+        )
+
+    mock_inst = BoundedUnitfulMock()
+
+    eq_(mock_inst.property_min, 10 * 1000 * pq.Hz)
+    eq_(mock_inst.property_max, 9999 * 1000 * pq.Hz)
+
+
 @mock.patch("instruments.util_fns.unitful_property")
 def test_bounded_unitful_property_passes_kwargs(mock_unitful_property):
     bounded_unitful_property(

--- a/instruments/instruments/util_fns.py
+++ b/instruments/instruments/util_fns.py
@@ -393,13 +393,13 @@ def bounded_unitful_property(name, units, min_fmt_str="{}:MIN?", max_fmt_str="{}
         if valid_range[0] == "query":
             return pq.Quantity(*split_unit_str(self.query(min_fmt_str.format(name)), units))
         else:
-            return valid_range[0] * units
+            return assume_units(valid_range[0], units).rescale(units)
 
     def max_getter(self):
         if valid_range[1] == "query":
             return pq.Quantity(*split_unit_str(self.query(max_fmt_str.format(name)), units))
         else:
-            return valid_range[1] * units
+            return assume_units(valid_range[1], units).rescale(units)
 
     new_range = (
         None if valid_range[0] is None else min_getter,


### PR DESCRIPTION
Includes the following:

- lints keithley instrument files
- adds unit tests for 2182, 6220, 6514
- improves `bounded_unitful_property` to use `assume_units` for the boundary checker

No tests for the 195 and 580. Those are a pain in the bum and are going to take some time to write tests for. I'd rather get this in and move on for now.