### PR TITLE
Lint accessory files

### DIFF
--- a/instruments/instruments/__init__.py
+++ b/instruments/instruments/__init__.py
@@ -1,100 +1,85 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# __init__.py: Defines globally-available subpackages and symbols for the
-#     instruments package.
-##
-# © 2013 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Defines globally-available subpackages and symbols for the instruments package.
+"""
+
+# IMPORTS ####################################################################
 
 from __future__ import absolute_import
 
-## VERSION METADATA ###########################################################
+from . import abstract_instruments
+from .abstract_instruments import Instrument
+
+from . import agilent
+from . import generic_scpi
+from . import holzworth
+from . import hp
+from . import keithley
+from . import lakeshore
+from . import newport
+from . import oxford
+from . import phasematrix
+from . import picowatt
+from . import qubitekk
+from . import rigol
+from . import srs
+from . import tektronix
+from . import thorlabs
+from . import toptica
+from . import yokogawa
+
+from . import units
+from .config import load_instruments
+
+# Replace instruments.other with a deprecation warning.
+import instruments.other as _other
+
+# VERSION METADATA ###########################################################
 # In keeping with PEP-396, we define a version number of the form
 # {major}.{minor}[.{postrelease}]{prerelease-tag}
 
 __version__ = '1.0a1'
 
-## VERSION CHECKING ###########################################################
+# VERSION CHECKING ###########################################################
 
 # We hide version checking in a function so that imports from here don't
 # "leak" out to the __all__ of this package.
+
+
 def __check_versions():
     from distutils.version import StrictVersion
-    
-    VERSIONS_NEEDED = {
+
+    _versions_needed = {
         # 'flufl.enum': StrictVersion('4.0')
     }
-    
-    for module_name, version in VERSIONS_NEEDED.items():
+
+    for module_name, version in _versions_needed.items():
         module = __import__(module_name, fromlist=['__version__'])
         if StrictVersion(module.__version__) < version:
-            raise ImportError("Module {} is version {}, but we need version {}.".format(module_name, module.__version__, version))
-            
+            raise ImportError("Module {} is version {}, but we need version {}.".format(
+                module_name, module.__version__, version))
+
 __check_versions()
 
-## IMPORTS ####################################################################
-
-from instruments.abstract_instruments import Instrument
-import instruments.abstract_instruments
-
-import instruments.generic_scpi
-import instruments.agilent
-import instruments.holzworth
-import instruments.keithley
-import instruments.lakeshore
-import instruments.oxford
-import instruments.phasematrix
-import instruments.picowatt
-import instruments.rigol
-import instruments.srs
-import instruments.tektronix
-import instruments.toptica
-import instruments.thorlabs
-import instruments.qubitekk
-import instruments.hp
-
-import instruments.units
-
-from instruments.config import load_instruments
-
-# Replace instruments.other with a deprecation warning.
-
-import instruments.other as _other
 
 class _Other(object):
+
     def __getattr__(self, name):
         import warnings
         attr = getattr(_other, name)
-        
+
         msg = (
             "The instruments.other package is deprecated. "
             "Please use the {} package instead.".format(
                 ".".join(attr.__module__.split(".")[:2])
             )
         )
-        
+
         # This really should be a DeprecationWarning, except those are silenced
         # by default. Why?
         warnings.warn(msg, UserWarning)
-        
-        return attr
-        
-other = _Other()
 
+        return attr
+
+other = _Other()

--- a/instruments/instruments/abstract_instruments/comm/file_communicator.py
+++ b/instruments/instruments/abstract_instruments/comm/file_communicator.py
@@ -34,11 +34,9 @@ import time
 from instruments.abstract_instruments.comm import AbstractCommunicator
 import os
 
-from instruments.util_fns import NullHandler
-
 import logging
 logger = logging.getLogger(__name__)
-logger.addHandler(NullHandler())
+logger.addHandler(logging.NullHandler())
 
 ## CLASSES #####################################################################
 

--- a/instruments/instruments/config.py
+++ b/instruments/instruments/config.py
@@ -1,40 +1,23 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# config.py: Support for loading instruments from configuration files.
-##
-# © 2013 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Module containing support for loading instruments from configuration files.
+"""
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
+
+import warnings
 
 try:
     import yaml
 except ImportError:
     yaml = None
 
-import warnings
+# FUNCTIONS ###################################################################
 
-## FUNCTIONS ###################################################################
 
 def walk_dict(d, path):
     """
@@ -42,14 +25,17 @@ def walk_dict(d, path):
     For instance, given ``{'a': {'b': 42, 'c': {'d': ['foo']}}}`,
     the path ``"/"`` returns the whole dictionary, ``"/a"`` returns
     ``{'b': 42, 'c': {'d': ['foo']}}`` and ``/a/c/d"`` returns ``['foo']``.
-    
+
     If ``path`` is a list, it is treated identically to
     ``"/" + "/".join(path)``.
-    
+
+    :param dict d: The dictionary to walk through
+
+    :param path: The walking path through the dictionary
     :type path: `str` or `list`
     """
     # Treat as a base case that the path is empty.
-    if not path: 
+    if not path:
         return d
     if isinstance(path, str):
         path = path.split("/")
@@ -60,6 +46,7 @@ def walk_dict(d, path):
         # Otherwise, resolve that segment and recurse.
         return walk_dict(d[path[0]], path[1:])
 
+
 def load_instruments(conf_file_name, conf_path="/"):
     """
     Given the path to a YAML-formatted configuration file and a path within
@@ -67,66 +54,64 @@ def load_instruments(conf_file_name, conf_path="/"):
     The subsection of the configuration file is expected to look like a map from
     names to YAML nodes giving the class and instrument URI for each instrument.
     For example::
-    
+
         ddg:
             class: !!python/name:instruments.srs.SRSDG645
             uri: gpib+usb://COM7/15
-            
+
     Loading instruments from this configuration will result in a dictionary of
     the form
     ``{'ddg': instruments.srs.SRSDG645.open_from_uri('gpib+usb://COM7/15')}``.
-    
+
     By specifying a path within the configuration file, one can load only a part
     of the given file. For instance, consider the configuration::
-    
+
         instruments:
             ddg:
                 class: !!python/name:instruments.srs.SRSDG645
                 uri: gpib+usb://COM7/15
         prefs:
             ...
-    
+
     Then, specifying ``"/instruments"`` as the configuration path will cause
     this function to load the instruments named in that block, and ignore
     all other keys in the YAML file.
-    
+
     :param str conf_file_name: Name of the configuration file to load
         instruments from.
     :param str conf_path: ``"/"`` separated path to the section in the
         configuration file to load.
-    
+
     :rtype: `dict`
-    
+
     .. warning::
         The configuration file must be trusted, as the class name references
         allow for executing arbitrary code. Do not load instruments from
         configuration files sent over network connections.
-        
+
         Note that keys in sections excluded by the ``conf_path`` argument are
         still processed, such that any side effects that may occur due to
         such processing will occur independently of the value of ``conf_path``.
     """
-    
+
     if yaml is None:
-        raise ImportError("Could not import PyYAML, which is required for this function.")
-    
+        raise ImportError("Could not import PyYAML, which is required "
+                          "for this function.")
+
     with open(conf_file_name, 'r') as f:
         conf_dict = yaml.load(f)
-    
+
     conf_dict = walk_dict(conf_dict, conf_path)
-    
-    
+
     inst_dict = {}
     for name, value in conf_dict.iteritems():
         try:
             inst_dict[name] = value["class"].open_from_uri(value["uri"])
-        except Exception as ex:
+        except IOError as ex:
             # FIXME: need to subclass Warning so that repeated warnings
             #        aren't ignored.
-            warnings.warn("Exception occured loading device URI {}:\n\t{}.".format(
-                value["uri"],
-                ex, RuntimeWarning))
+            warnings.warn("Exception occured loading device URI "
+                          "{}:\n\t{}.".format(value["uri"], ex), RuntimeWarning)
             inst_dict[name] = None
-    
+
     return inst_dict
-    

--- a/instruments/instruments/errors.py
+++ b/instruments/instruments/errors.py
@@ -1,26 +1,8 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# errors.py: Custom exception errors used by various instruments.
-##
-# © 2016 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Module containing custom exception errors used by various instruments.
+"""
 
 # IMPORTS #####################################################################
 
@@ -30,8 +12,18 @@ from __future__ import absolute_import
 
 
 class AcknowledgementError(IOError):
+    """
+    This error is raised when an instrument fails to send the expected
+    acknowledgement string.
+    """
     pass
 
 
 class PromptError(IOError):
+    """
+    This error is raised when an instrument fails to send a "prompt"
+    character when one is expected. Typically most instruments do not send
+    these characters, but some do in a misguided attempt to be more "user
+    friendly".
+    """
     pass

--- a/instruments/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/instruments/thorlabs/thorlabsapt.py
@@ -20,10 +20,8 @@ from instruments.thorlabs import _abstract, _packets, _cmds
 
 # LOGGING #####################################################################
 
-from instruments.util_fns import NullHandler
-
 logger = logging.getLogger(__name__)
-logger.addHandler(NullHandler())
+logger.addHandler(logging.NullHandler())
 
 # CLASSES #####################################################################
 

--- a/instruments/instruments/units.py
+++ b/instruments/instruments/units.py
@@ -1,43 +1,30 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# units.py: Custom units used by various instruments.
-##
-# © 2013 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Module containing custom units used by various instruments.
+"""
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
 
-from quantities import Hz, milli, GHz, UnitQuantity, Quantity
+from quantities import Hz, milli, UnitQuantity
 from quantities.unitquantity import IrreducibleUnit
 
-## UNITS #######################################################################
+# UNITS #######################################################################
 
-## IRREDUCIBLE UNITS ##
+# IRREDUCIBLE UNITS #
+
 
 class UnitLogPower(IrreducibleUnit):
-    _primary_order = 80 # Something large smaller than 99.
+    """
+    Base unit class for log-power units. The primary example of this
+    is `dBm`.
+    """
+    _primary_order = 80  # Something large smaller than 99.
 
-## SPECIFIC UNITS ##
+# SPECIFIC UNITS #
 
 # Define basic unit of log-power, the dBm.
 
@@ -50,12 +37,16 @@ dBm = UnitLogPower('decibel-milliwatt', symbol='dBm')
 
 # TODO: move custom units out to another module.
 
-mHz = UnitQuantity('millihertz', milli * Hz, symbol='mHz', doc="""
-`~quantities.UnitQuantity` representing millihertz, the native unit of the
-Phase Matrix FSW-0020.
-""")
+mHz = UnitQuantity(
+    'millihertz',
+    milli * Hz,
+    symbol='mHz',
+    doc="""
+    `~quantities.UnitQuantity` representing millihertz, the native unit of the
+    Phase Matrix FSW-0020.
+    """
+)
 
 #: Centibel-milliwatts, the native log-power unit supported by the
 #: Phase Matrix FSW-0020.
 cBm = UnitLogPower('centibel-milliwatt', dBm / 10, symbol='cBm')
-

--- a/instruments/instruments/util_fns.py
+++ b/instruments/instruments/util_fns.py
@@ -1,50 +1,34 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-##
-# util_fns.py: Random utility functions.
-##
-# © 2013-2015 Steven Casagrande (scasagrande@galvant.ca).
-#
-# This file is a part of the InstrumentKit project.
-# Licensed under the AGPL version 3.
-##
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
-##
+"""
+Module containing various utility functions
+"""
 
-## IMPORTS #####################################################################
+# IMPORTS #####################################################################
 
 from __future__ import absolute_import
 from __future__ import division
 
-import sys
 import re
 
-import quantities as pq
 from enum import Enum, IntEnum
+import quantities as pq
 
-## FUNCTIONS ###################################################################
+# FUNCTIONS ###################################################################
+
+# pylint: disable=too-many-arguments
+
 
 def assume_units(value, units):
     """
     If units are not provided for ``value`` (that is, if it is a raw
     `float`), then returns a `~quantities.Quantity` with magnitude
     given by ``value`` and units given by ``units``.
-    
+
     :param value: A value that may or may not be unitful.
     :param units: Units to be assumed for ``value`` if it does not already
         have units.
-        
+
     :return: A unitful quantity that has either the units of ``value`` or
         ``units``, depending on if ``value`` is unitful.
     :rtype: `Quantity`
@@ -64,28 +48,31 @@ def convert_temperature(temperature, base):
     :return: the converted temperature
     :rtype: `quantities.Quantity`
     """
-    # quantities reports equivalence between degC and degK, so a string comparison is needed
+    # quantities reports equivalence between degC and degK, so a string
+    # comparison is needed
     newval = assume_units(temperature, pq.degC)
     if newval.units == pq.degF and str(base).split(" ")[1] == 'degC':
-        return ((newval.magnitude-32.0)*5.0/9.0)*base
+        return_val = ((newval.magnitude - 32.0) * 5.0 / 9.0) * base
     elif str(newval.units).split(" ")[1] == 'K' and str(base).split(" ")[1] == 'degC':
-        return (newval.magnitude-273.15)*base
+        return_val = (newval.magnitude - 273.15) * base
     elif str(newval.units).split(" ")[1] == 'K' and base == pq.degF:
-        return (newval.magnitude/1.8-459/57)*base
+        return_val = (newval.magnitude / 1.8 - 459 / 57) * base
     elif str(newval.units).split(" ")[1] == 'degC' and base == pq.degF:
-        return (newval.magnitude*9.0/5.0+32.0)*base
+        return_val = (newval.magnitude * 9.0 / 5.0 + 32.0) * base
     elif newval.units == pq.degF and str(base).split(" ")[1] == 'K':
-        return ((newval.magnitude+459.57)*5.0/9.0)*base
+        return_val = ((newval.magnitude + 459.57) * 5.0 / 9.0) * base
     elif str(newval.units).split(" ")[1] == 'degC' and str(base).split(" ")[1] == 'K':
-        return (newval.magnitude+273.15)*base
+        return_val = (newval.magnitude + 273.15) * base
     elif str(newval.units).split(" ")[1] == 'degC' and str(base).split(" ")[1] == 'degC':
-        return newval
+        return_val = newval
     elif newval.units == pq.degF and base == pq.degF:
-        return newval
+        return_val = newval
     elif str(newval.units).split(" ")[1] == 'K' and str(base).split(" ")[1] == 'K':
-        return newval
+        return_val = newval
     else:
-        raise ValueError("Unable to convert "+str(newval.units)+" to "+str(base))
+        raise ValueError(
+            "Unable to convert " + str(newval.units) + " to " + str(base))
+    return return_val
 
 
 def split_unit_str(s, default_units=pq.dimensionless, lookup=None):
@@ -103,6 +90,7 @@ def split_unit_str(s, default_units=pq.dimensionless, lookup=None):
     For this reason, the second element of the tuple may be a unit or
     a string, depending, since the quantity constructor takes either.
 
+    :param str s: Input string that will be split up
     :param default_units: If no units are specified, this argument is given
         as the units.
     :param callable lookup: If specified, this function is called on the
@@ -126,7 +114,7 @@ def split_unit_str(s, default_units=pq.dimensionless, lookup=None):
         else:
             val = float(match.groups()[0]) * 10**float(match.groups()[1][1:])
             units = match.groups()[2]
-            
+
         if units is None:
             return float(val), default_units
         else:
@@ -138,7 +126,19 @@ def split_unit_str(s, default_units=pq.dimensionless, lookup=None):
             raise ValueError("Could not split '{}' into value "
                              "and units.".format(repr(s)))
 
+
 def rproperty(fget=None, fset=None, doc=None, readonly=False, writeonly=False):
+    """
+    Creates and returns a new property based on the input parameters.
+
+    :param function fget: Function to be called for the new property's getter
+    :param function fset: Function to be called for the new property's setter
+    :param str doc: Docstring for the new property
+    :param bool readonly: If `True`, the returned property does not have a
+        setter.
+    :param bool writeonly: If `True`, the returned property does not have a
+        getter. Both readonly and writeonly cannot both be `True`.
+    """
     if readonly and writeonly:
         raise ValueError("Properties cannot be both read- and write-only.")
     if readonly:
@@ -148,14 +148,16 @@ def rproperty(fget=None, fset=None, doc=None, readonly=False, writeonly=False):
     else:
         return property(fget=fget, fset=fset, doc=doc)
 
-def bool_property(name, inst_true, inst_false, doc=None, readonly=False, writeonly=False, set_fmt="{} {}"):
+
+def bool_property(name, inst_true, inst_false, doc=None, readonly=False,
+                  writeonly=False, set_fmt="{} {}"):
     """
-    Called inside of SCPI classes to instantiate boolean properties 
+    Called inside of SCPI classes to instantiate boolean properties
     of the device cleanly.
     For example:
-    
+
     >>> my_property = bool_property("BEST:PROPERTY", "ON", "OFF") # doctest: +SKIP
-    
+
     :param str name: Name of the SCPI command corresponding to this property.
     :param str inst_true: String returned and accepted by the instrument for
         `True` values.
@@ -166,31 +168,37 @@ def bool_property(name, inst_true, inst_false, doc=None, readonly=False, writeon
         setter.
     :param bool writeonly: If `True`, the returned property does not have a
         getter. Both readonly and writeonly cannot both be `True`.
-    :param str set_fmt: Specify the string format to use when sending a 
+    :param str set_fmt: Specify the string format to use when sending a
         non-query to the instrument. The default is "{} {}" which places a
         space between the SCPI command the associated parameter. By switching
         to "{}={}" an equals sign would instead be used as the separator.
     """
-    def getter(self):
+
+    def _getter(self):
         return self.query(name + "?").strip() == inst_true
-    def setter(self, newval):
+
+    def _setter(self, newval):
         if not isinstance(newval, bool):
             raise TypeError("Bool properties must be specified with a "
                             "boolean value")
         self.sendcmd(set_fmt.format(name, inst_true if newval else inst_false))
-        
-    return rproperty(fget=getter, fset=setter, doc=doc, readonly=readonly, writeonly=writeonly)
-    
-def enum_property(name, enum, doc=None, input_decoration=None, output_decoration=None, readonly=False, writeonly=False, set_fmt="{} {}"):
+
+    return rproperty(fget=_getter, fset=_setter, doc=doc, readonly=readonly,
+                     writeonly=writeonly)
+
+
+def enum_property(name, enum, doc=None, input_decoration=None,
+                  output_decoration=None, readonly=False, writeonly=False,
+                  set_fmt="{} {}"):
     """
-    Called inside of SCPI classes to instantiate Enum properties 
+    Called inside of SCPI classes to instantiate Enum properties
     of the device cleanly.
-    The decorations can be functions which modify the incoming and outgoing 
+    The decorations can be functions which modify the incoming and outgoing
     values for dumb instruments that do stuff like include superfluous quotes
     that you might not want in your enum.
     Example:
     my_property = bool_property("BEST:PROPERTY", enum_class)
-    
+
     :param str name: Name of the SCPI command corresponding to this property.
     :param type enum: Class derived from `Enum` representing valid values.
     :param callable input_decoration: Function called on responses from
@@ -202,18 +210,21 @@ def enum_property(name, enum, doc=None, input_decoration=None, output_decoration
         setter.
     :param bool writeonly: If `True`, the returned property does not have a
         getter. Both readonly and writeonly cannot both be `True`.
-    :param str set_fmt: Specify the string format to use when sending a 
+    :param str set_fmt: Specify the string format to use when sending a
         non-query to the instrument. The default is "{} {}" which places a
         space between the SCPI command the associated parameter. By switching
         to "{}={}" an equals sign would instead be used as the separator.
     """
-    def in_decor_fcn(val):
+    def _in_decor_fcn(val):
         return val if input_decoration is None else input_decoration(val)
-    def out_decor_fcn(val):
+
+    def _out_decor_fcn(val):
         return val if output_decoration is None else output_decoration(val)
-    def getter(self):
-        return enum(in_decor_fcn(self.query("{}?".format(name)).strip()))
-    def setter(self, newval):
+
+    def _getter(self):
+        return enum(_in_decor_fcn(self.query("{}?".format(name)).strip()))
+
+    def _setter(self, newval):
         try:  # First assume newval is Enum.value
             newval = enum[newval]
         except KeyError:  # Check if newval is Enum.name instead
@@ -221,15 +232,18 @@ def enum_property(name, enum, doc=None, input_decoration=None, output_decoration
                 newval = enum(newval)
             except ValueError:
                 raise ValueError("Enum property new value not in enum.")
-        self.sendcmd(set_fmt.format(name, out_decor_fcn(enum(newval).value)))
-    
-    return rproperty(fget=getter, fset=setter, doc=doc, readonly=readonly, writeonly=writeonly)
+        self.sendcmd(set_fmt.format(name, _out_decor_fcn(enum(newval).value)))
 
-def unitless_property(name, format_code='{:e}', doc=None, readonly=False, writeonly=False, set_fmt="{} {}"):
+    return rproperty(fget=_getter, fset=_setter, doc=doc, readonly=readonly,
+                     writeonly=writeonly)
+
+
+def unitless_property(name, format_code='{:e}', doc=None, readonly=False,
+                      writeonly=False, set_fmt="{} {}"):
     """
-    Called inside of SCPI classes to instantiate properties with unitless 
+    Called inside of SCPI classes to instantiate properties with unitless
     numeric values.
-    
+
     :param str name: Name of the SCPI command corresponding to this property.
     :param str format_code: Argument to `str.format` used in sending values
         to the instrument.
@@ -238,25 +252,30 @@ def unitless_property(name, format_code='{:e}', doc=None, readonly=False, writeo
         setter.
     :param bool writeonly: If `True`, the returned property does not have a
         getter. Both readonly and writeonly cannot both be `True`.
-    :param str set_fmt: Specify the string format to use when sending a 
+    :param str set_fmt: Specify the string format to use when sending a
         non-query to the instrument. The default is "{} {}" which places a
         space between the SCPI command the associated parameter. By switching
         to "{}={}" an equals sign would instead be used as the separator.
     """
-    def getter(self):
+
+    def _getter(self):
         raw = self.query("{}?".format(name))
         return float(raw)
-    def setter(self, newval):
+
+    def _setter(self, newval):
         strval = format_code.format(newval)
         self.sendcmd(set_fmt.format(name, strval))
 
-    return rproperty(fget=getter, fset=setter, doc=doc, readonly=readonly, writeonly=writeonly)
+    return rproperty(fget=_getter, fset=_setter, doc=doc, readonly=readonly,
+                     writeonly=writeonly)
 
-def int_property(name, format_code='{:d}', doc=None, readonly=False, writeonly=False, valid_set=None, set_fmt="{} {}"):
+
+def int_property(name, format_code='{:d}', doc=None, readonly=False,
+                 writeonly=False, valid_set=None, set_fmt="{} {}"):
     """
-    Called inside of SCPI classes to instantiate properties with unitless 
+    Called inside of SCPI classes to instantiate properties with unitless
     numeric values.
-    
+
     :param str name: Name of the SCPI command corresponding to this property.
     :param str format_code: Argument to `str.format` used in sending values
         to the instrument.
@@ -267,20 +286,21 @@ def int_property(name, format_code='{:d}', doc=None, readonly=False, writeonly=F
         getter. Both readonly and writeonly cannot both be `True`.
     :param valid_set: Set of valid values for the property, or `None` if all
         `int` values are valid.
-    :param str set_fmt: Specify the string format to use when sending a 
+    :param str set_fmt: Specify the string format to use when sending a
         non-query to the instrument. The default is "{} {}" which places a
         space between the SCPI command the associated parameter. By switching
         to "{}={}" an equals sign would instead be used as the separator.
     """
-    def getter(self):
+
+    def _getter(self):
         raw = self.query("{}?".format(name))
         return int(raw)
     if valid_set is None:
-        def setter(self, newval):
+        def _setter(self, newval):
             strval = format_code.format(newval)
             self.sendcmd(set_fmt.format(name, strval))
     else:
-        def setter(self, newval):
+        def _setter(self, newval):
             if newval not in valid_set:
                 raise ValueError(
                     "{} is not an allowed value for this property; "
@@ -289,9 +309,14 @@ def int_property(name, format_code='{:d}', doc=None, readonly=False, writeonly=F
             strval = format_code.format(newval)
             self.sendcmd(set_fmt.format(name, strval))
 
-    return rproperty(fget=getter, fset=setter, doc=doc, readonly=readonly, writeonly=writeonly)
+    return rproperty(fget=_getter, fset=_setter, doc=doc, readonly=readonly,
+                     writeonly=writeonly)
 
-def unitful_property(name, units, format_code='{:e}', doc=None, input_decoration=None, output_decoration=None, readonly=False, writeonly=False, set_fmt="{} {}", valid_range=(None,None)):
+
+def unitful_property(name, units, format_code='{:e}', doc=None,
+                     input_decoration=None, output_decoration=None,
+                     readonly=False, writeonly=False, set_fmt="{} {}",
+                     valid_range=(None, None)):
     """
     Called inside of SCPI classes to instantiate properties with unitful numeric
     values. This function assumes that the instrument only accepts
@@ -299,7 +324,7 @@ def unitful_property(name, units, format_code='{:e}', doc=None, input_decoration
     information is provided by the ``units`` argument. This is not suitable
     for instruments where the units can change dynamically due to front-panel
     interaction or due to remote commands.
-    
+
     :param str name: Name of the SCPI command corresponding to this property.
     :param units: Units to assume in sending and receiving magnitudes to and
         from the instrument.
@@ -314,7 +339,7 @@ def unitful_property(name, units, format_code='{:e}', doc=None, input_decoration
         setter.
     :param bool writeonly: If `True`, the returned property does not have a
         getter. Both readonly and writeonly cannot both be `True`.
-    :param str set_fmt: Specify the string format to use when sending a 
+    :param str set_fmt: Specify the string format to use when sending a
         non-query to the instrument. The default is "{} {}" which places a
         space between the SCPI command the associated parameter. By switching
         to "{}={}" an equals sign would instead be used as the separator.
@@ -325,14 +350,17 @@ def unitful_property(name, units, format_code='{:e}', doc=None, input_decoration
         The valid set is inclusive of the values provided.
     :type valid_range: `tuple` or `list` of `int` or `float`
     """
-    def in_decor_fcn(val):
+    def _in_decor_fcn(val):
         return val if input_decoration is None else input_decoration(val)
-    def out_decor_fcn(val):
+
+    def _out_decor_fcn(val):
         return val if output_decoration is None else output_decoration(val)
-    def getter(self):
-        raw = in_decor_fcn(self.query("{}?".format(name)))
+
+    def _getter(self):
+        raw = _in_decor_fcn(self.query("{}?".format(name)))
         return pq.Quantity(*split_unit_str(raw, units)).rescale(units)
-    def setter(self, newval):
+
+    def _setter(self, newval):
         min_value, max_value = valid_range
         if min_value is not None:
             if hasattr(min_value, '__call__'):
@@ -348,12 +376,17 @@ def unitful_property(name, units, format_code='{:e}', doc=None, input_decoration
                                  " value is {}".format(newval, max_value))
         # Rescale to the correct unit before printing. This will also
         # catch bad units.
-        strval = format_code.format(assume_units(newval, units).rescale(units).item())
-        self.sendcmd(set_fmt.format(name, out_decor_fcn(strval)))
+        strval = format_code.format(
+            assume_units(newval, units).rescale(units).item())
+        self.sendcmd(set_fmt.format(name, _out_decor_fcn(strval)))
 
-    return rproperty(fget=getter, fset=setter, doc=doc, readonly=readonly, writeonly=writeonly)
+    return rproperty(fget=_getter, fset=_setter, doc=doc, readonly=readonly,
+                     writeonly=writeonly)
 
-def bounded_unitful_property(name, units, min_fmt_str="{}:MIN?", max_fmt_str="{}:MAX?", valid_range=("query", "query"), **kwargs):
+
+def bounded_unitful_property(name, units, min_fmt_str="{}:MIN?",
+                             max_fmt_str="{}:MAX?",
+                             valid_range=("query", "query"), **kwargs):
     """
     Called inside of SCPI classes to instantiate properties with unitful numeric
     values which have upper and lower bounds. This function in turn calls
@@ -389,59 +422,104 @@ def bounded_unitful_property(name, units, min_fmt_str="{}:MIN?", max_fmt_str="{}
         value, and third is a property representing the maximum value
     """
 
-    def min_getter(self):
+    def _min_getter(self):
         if valid_range[0] == "query":
             return pq.Quantity(*split_unit_str(self.query(min_fmt_str.format(name)), units))
         else:
             return assume_units(valid_range[0], units).rescale(units)
 
-    def max_getter(self):
+    def _max_getter(self):
         if valid_range[1] == "query":
             return pq.Quantity(*split_unit_str(self.query(max_fmt_str.format(name)), units))
         else:
             return assume_units(valid_range[1], units).rescale(units)
 
     new_range = (
-        None if valid_range[0] is None else min_getter,
-        None if valid_range[1] is None else max_getter
+        None if valid_range[0] is None else _min_getter,
+        None if valid_range[1] is None else _max_getter
     )
 
     return (
         unitful_property(name, units, valid_range=new_range, **kwargs),
-        property(min_getter) if valid_range[0] is not None else None,
-        property(max_getter) if valid_range[1] is not None else None
+        property(_min_getter) if valid_range[0] is not None else None,
+        property(_max_getter) if valid_range[1] is not None else None
     )
 
-def string_property(name, bookmark_symbol='"', doc=None, readonly=False, writeonly=False, set_fmt="{} {}{}{}"):
+
+def string_property(name, bookmark_symbol='"', doc=None, readonly=False,
+                    writeonly=False, set_fmt="{} {}{}{}"):
     """
     Called inside of SCPI classes to instantiate properties with a string value.
+
+    :param str name: Name of the SCPI command corresponding to this property.
+    :param str doc: Docstring to be associated with the new property.
+    :param bool readonly: If `True`, the returned property does not have a
+        setter.
+    :param bool writeonly: If `True`, the returned property does not have a
+        getter. Both readonly and writeonly cannot both be `True`.
+    :param str set_fmt: Specify the string format to use when sending a
+        non-query to the instrument. The default is "{} {}{}{}" which places a
+        space between the SCPI command the associated parameter, and places
+        the bookmark symbols on either side of the parameter.
+    :param str bookmark_symbol: The symbol that will flank both sides of the
+        parameter to be sent to the instrument. By default this is ``"``.
     """
     bookmark_length = len(bookmark_symbol)
-    def getter(self):
+
+    def _getter(self):
         string = self.query("{}?".format(name))
-        string = string[bookmark_length:-bookmark_length] if bookmark_length>0 else string
+        string = string[
+            bookmark_length:-bookmark_length] if bookmark_length > 0 else string
         return string
-    def setter(self, newval):
-        self.sendcmd(set_fmt.format(name, bookmark_symbol, newval, bookmark_symbol))
 
-    return rproperty(fget=getter, fset=setter, doc=doc, readonly=readonly, writeonly=writeonly)
+    def _setter(self, newval):
+        self.sendcmd(
+            set_fmt.format(name, bookmark_symbol, newval, bookmark_symbol))
 
-## CLASSES #####################################################################
+    return rproperty(fget=_getter, fset=_setter, doc=doc, readonly=readonly,
+                     writeonly=writeonly)
+
+# CLASSES #####################################################################
+
 
 class ProxyList(object):
+    """
+    This is a special class used to generate lists of objects where the valid
+    keys are defined by the `valid_set` init parameter. This allows an
+    instrument to have a single property through which all of its various
+    identical input/ouput channels can be accessed.
+
+    Search the code base of existing examples of how this is used for plenty
+    of different examples.
+
+    :param parent: The "parent" or "owner" of the of the proxy classes. In
+        dev work, this is typically ``self``.
+    :param proxy_cls: The child class that will be returned when the returned
+        object is iterated through. These are usually objects that represent
+        an entire channel/sensor/input/output, of which an instrument might
+        have more than one but each are individually addressed. An example is
+        an oscilloscope channel.
+    :param valid_set: The set of valid keys by which the proxy class objects
+        are accessed. Typically this is something like `range`, but can be
+        any generator, list, enum, etc.
+    """
+
     def __init__(self, parent, proxy_cls, valid_set):
         self._parent = parent
         self._proxy_cls = proxy_cls
         self._valid_set = valid_set
-        
+
         # FIXME: This only checks the next level up the chain!
         if hasattr(valid_set, '__bases__'):
-            self._isenum = (Enum in valid_set.__bases__) or (IntEnum in valid_set.__bases__)
+            self._isenum = (Enum in valid_set.__bases__) or (
+                IntEnum in valid_set.__bases__)
         else:
             self._isenum = False
+
     def __iter__(self):
         for idx in self._valid_set:
             yield self._proxy_cls(self._parent, idx)
+
     def __getitem__(self, idx):
         # If we have an enum, try to normalize by using getitem. This will
         # allow for things like 'x' to be used instead of enum.x.
@@ -461,22 +539,8 @@ class ProxyList(object):
         else:
             if idx not in self._valid_set:
                 raise IndexError("Index out of range. Must be "
-                                    "in {}.".format(self._valid_set))
+                                 "in {}.".format(self._valid_set))
         return self._proxy_cls(self._parent, idx)
+
     def __len__(self):
         return len(self._valid_set)
-
-if sys.version_info[0] == 2 and sys.version_info[1] == 6:  # pragma: no cover
-
-    import logging
-
-    class NullHandler(logging.Handler):
-        """
-        Emulates the Python 2.7 NullHandler when on Python 2.6.
-        """
-        def emit(self, record):
-            pass
-
-else:
-
-    from logging import NullHandler


### PR DESCRIPTION
Lints those extra files, like `util_fns.py`, `units.py`, `config.py`, etc.

While I was at it, I found some code for py26 logging in `util_fns.py` that I've removed. Py27 is the oldest I want to be supporting so I went ahead and removed it and any references.