### PR TITLE
Add tox.ini file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py33,py34,py35
+[testenv]
+deps = -rdev-requirements.txt
+commands = nosetests


### PR DESCRIPTION
Let's devs use `tox` to quickly run the unit tests against all supported versions Python.