### PR TITLE
Binblockread retries

### DIFF
--- a/instruments/__init__.py
+++ b/instruments/__init__.py
@@ -36,7 +36,7 @@ from .config import load_instruments
 # In keeping with PEP-396, we define a version number of the form
 # {major}.{minor}[.{postrelease}]{prerelease-tag}
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 __title__ = "instrumentkit"
 __description__ = "Test and measurement communication library"

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -293,7 +293,7 @@ class Instrument(object):
                     tries -= 1
                 if tries == 0:
                     raise IOError("Did not read in the required number of bytes"
-                                  "during binblock read. Got {}, expected"
+                                  "during binblock read. Got {}, expected "
                                   "{}".format(len(data), num_of_bytes))
             return np.frombuffer(data, dtype=fmt)
 

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -288,7 +288,7 @@ class Instrument(object):
             data = self._file.read_raw(num_of_bytes)
             while len(data) < num_of_bytes:
                 old_len = len(data)
-                data += self._file.read_raw(num_of_bytes)
+                data += self._file.read_raw(num_of_bytes - old_len)
                 if old_len == len(data):
                     tries -= 1
                 if tries == 0:

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -21,6 +21,8 @@ from instruments.tests import expected_protocol
 
 # TESTS ######################################################################
 
+# pylint: disable=no-member
+
 
 def test_instrument_binblockread():
     with expected_protocol(

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -54,3 +54,11 @@ def test_instrument_binblockread_too_many_reads():
     )
 
     _ = inst.binblockread(2)
+
+
+@raises(IOError)
+def test_instrument_binblockread_bad_block_start():
+    inst = ik.Instrument.open_test()
+    inst._file.read_raw = mock.MagicMock(return_value=b"@")
+
+    _ = inst.binblockread(2)

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -44,6 +44,10 @@ def test_instrument_binblockread_two_reads():
 
     np.testing.assert_array_equal(inst.binblockread(2), [0, 1, 2, 3, 4])
 
+    calls_expected = [1, 1, 2, 10, 4]
+    calls_actual = [call[0][0] for call in inst._file.read_raw.call_args_list]
+    np.testing.assert_array_equal(calls_expected, calls_actual)
+
 
 @raises(IOError)
 def test_instrument_binblockread_too_many_reads():


### PR DESCRIPTION
This adds a reading loop to the `binblockread` function. Over the weekend I discovered that if a transfer takes longer than the specified connection timeout, then the rest of the data just gets stuck in the buffer and passed onto the next query.

The solution here is to keep reading if we haven't read in the specified number of bytes yet. If we are short bytes, and a read does not result in any more bytes, I added a few more retries just in case the instrument is still processing. After two additional retries, there must have been an error and so an `IOError` is raised.