### PR TITLE
Fix read timeout

### DIFF
--- a/instruments/__init__.py
+++ b/instruments/__init__.py
@@ -36,7 +36,7 @@ from .config import load_instruments
 # In keeping with PEP-396, we define a version number of the form
 # {major}.{minor}[.{postrelease}]{prerelease-tag}
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 __title__ = "instrumentkit"
 __description__ = "Test and measurement communication library"

--- a/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/abstract_instruments/comm/serial_communicator.py
@@ -121,7 +121,7 @@ class SerialCommunicator(io.IOBase, AbstractCommunicator):
             c = b''
             while c != self._terminator.encode("utf-8"):
                 c = self._conn.read(1)
-                if c == "":
+                if c == b"":
                     raise IOError("Serial connection timed out before reading "
                                   "a termination character.")
                 if c != self._terminator.encode("utf-8"):

--- a/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/abstract_instruments/comm/serial_communicator.py
@@ -121,6 +121,9 @@ class SerialCommunicator(io.IOBase, AbstractCommunicator):
             c = b''
             while c != self._terminator.encode("utf-8"):
                 c = self._conn.read(1)
+                if c == "":
+                    raise IOError("Serial connection timed out before reading "
+                                  "a termination character.")
                 if c != self._terminator.encode("utf-8"):
                     result += c
             return result

--- a/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/instruments/abstract_instruments/comm/socket_communicator.py
@@ -110,7 +110,7 @@ class SocketCommunicator(io.IOBase, AbstractCommunicator):
             c = b''
             while c != self._terminator.encode("utf-8"):
                 c = self._conn.recv(1)
-                if c == "":
+                if c == b"":
                     raise IOError("Socket connection timed out before reading "
                                   "a termination character.")
                 if c != self._terminator.encode("utf-8"):

--- a/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/instruments/abstract_instruments/comm/socket_communicator.py
@@ -110,6 +110,9 @@ class SocketCommunicator(io.IOBase, AbstractCommunicator):
             c = b''
             while c != self._terminator.encode("utf-8"):
                 c = self._conn.recv(1)
+                if c == "":
+                    raise IOError("Socket connection timed out before reading "
+                                  "a termination character.")
                 if c != self._terminator.encode("utf-8"):
                     result += c
             return result

--- a/instruments/abstract_instruments/comm/visa_communicator.py
+++ b/instruments/abstract_instruments/comm/visa_communicator.py
@@ -124,7 +124,10 @@ class VisaCommunicator(io.IOBase, AbstractCommunicator):
         """
         if size >= 0:
             while len(self._buf) < size:
-                self._buf += self._conn.read()
+                data = self._conn.read()
+                if data == "":
+                    break
+                self._buf += data
             msg = self._buf[:size]
             # Remove the front of the buffer.
             del self._buf[:size]

--- a/instruments/tests/test_comm/test_serial.py
+++ b/instruments/tests/test_comm/test_serial.py
@@ -94,6 +94,15 @@ def test_serialcomm_read_raw():
     comm._conn.read.assert_called_with(10)
 
 
+@raises(IOError)
+def test_serialcomm_read_raw_timeout():
+    comm = SerialCommunicator(serial.Serial())
+    comm._conn = mock.MagicMock()
+    comm._conn.read = mock.MagicMock(side_effect=[b"a", b"b", b""])
+
+    _ = comm.read_raw(-1)
+
+
 def test_serialcomm_write_raw():
     comm = SerialCommunicator(serial.Serial())
     comm._conn = mock.MagicMock()

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -102,6 +102,15 @@ def test_socketcomm_read_raw():
     comm._conn.recv.assert_called_with(10)
 
 
+@raises(IOError)
+def test_serialcomm_read_raw_timeout():
+    comm = SocketCommunicator(socket.socket())
+    comm._conn = mock.MagicMock()
+    comm._conn.recv = mock.MagicMock(side_effect=[b"a", b"b", b""])
+
+    _ = comm.read_raw(-1)
+
+
 def test_socketcomm_write_raw():
     comm = SocketCommunicator(socket.socket())
     comm._conn = mock.MagicMock()


### PR DESCRIPTION
Fixes an inf loop problem that would happen when you specify to read until a termination character is found, but your connection times out. This would cause the read to be re-called, which would in turn timeout, etc.

Problem found by @CatherineH 