### PR TITLE
Add support for multiple ACKs

### DIFF
--- a/instruments/__init__.py
+++ b/instruments/__init__.py
@@ -36,7 +36,7 @@ from .config import load_instruments
 # In keeping with PEP-396, we define a version number of the form
 # {major}.{minor}[.{postrelease}]{prerelease-tag}
 
-__version__ = "0.0.5"
+__version__ = "0.1.0"
 
 __title__ = "instrumentkit"
 __description__ = "Test and measurement communication library"

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -231,28 +231,28 @@ def test_laser_correction():
     with expected_protocol(
         ik.toptica.TopMode,
         [
-            "(param-ref 'laser1:charm:correction-status)",
+            "(param-ref 'laser1:charm:correction-status)",  # 1st
             "(exec 'laser1:charm:start-correction-initial)",
-            "(param-ref 'laser1:charm:correction-status)",
+            "(param-ref 'laser1:charm:correction-status)",  # 2nd
             "(exec 'laser1:charm:start-correction)",
-            "(param - ref 'laser1:charm:correction-status)",
+            "(param-ref 'laser1:charm:correction-status)",  # 3rd
+            "(param-ref 'laser1:charm:correction-status)",  # 4th
             "(exec 'laser1:charm:start-correction)"
         ],
         [
-            "(param-ref 'laser1:charm:correction-status)\r",
+            "(param-ref 'laser1:charm:correction-status)\r",  # 1st
             "0",
             "> (exec 'laser1:charm:start-correction-initial)\r",
             "()\r",
-            "> (param-ref 'laser1:charm:correction-status)\r",
+            "> (param-ref 'laser1:charm:correction-status)\r",  # 3nd
             "1",
             "> (exec 'laser1:charm:start-correction)\r",
             "()\r",
-            "> ",
-            "(param-ref 'laser1:charm:correction-status)\r",
+            "> (param-ref 'laser1:charm:correction-status)\r",  # 3rd
             "3",
-            "> ",
+            "> (param-ref 'laser1:charm:correction-status)\r",  # 4th
+            "2",
             "> (exec 'laser1:charm:start-correction)\r",
-            "()\r",
             "()\r",
             "> ",
         ],

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -234,6 +234,8 @@ def test_laser_correction():
             "(param-ref 'laser1:charm:correction-status)",
             "(exec 'laser1:charm:start-correction-initial)",
             "(param-ref 'laser1:charm:correction-status)",
+            "(exec 'laser1:charm:start-correction)",
+            "(param - ref 'laser1:charm:correction-status)",
             "(exec 'laser1:charm:start-correction)"
         ],
         [
@@ -245,11 +247,20 @@ def test_laser_correction():
             "1",
             "> (exec 'laser1:charm:start-correction)\r",
             "()\r",
-            "> "
+            "> ",
+            "(param-ref 'laser1:charm:correction-status)\r",
+            "3",
+            "> ",
+            "> (exec 'laser1:charm:start-correction)\r",
+            "()\r",
+            "()\r",
+            "> ",
         ],
         sep="\n"
     ) as tm:
         tm.laser[0].correction()
+        tm.laser[0].correction()
+        _ = tm.laser[0].correction_status
         tm.laser[0].correction()
 
 
@@ -261,7 +272,7 @@ def test_reboot_system():
         ],
         [
             "(exec 'reboot-system)\r",
-            "reboot process started.\r"
+            "reboot process started.\r",
             "> "
         ],
         sep="\n"

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -240,9 +240,11 @@ def test_laser_correction():
             "(param-ref 'laser1:charm:correction-status)\r",
             "0",
             "> (exec 'laser1:charm:start-correction-initial)\r",
+            "()\r",
             "> (param-ref 'laser1:charm:correction-status)\r",
             "1",
             "> (exec 'laser1:charm:start-correction)\r",
+            "()\r",
             "> "
         ],
         sep="\n"
@@ -259,6 +261,7 @@ def test_reboot_system():
         ],
         [
             "(exec 'reboot-system)\r",
+            "reboot process started.\r"
             "> "
         ],
         sep="\n"

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -43,11 +43,15 @@ class TopMode(Instrument):
     def __init__(self, filelike):
         super(TopMode, self).__init__(filelike)
         self.prompt = "> "
-        self._ack_expected = self._return_msg
         self.terminator = "\n"
 
-    def _return_msg(self, msg=""): # pylint: disable=no-self-use
-        return msg+"\r"
+    def _ack_expected(self, msg=""):
+        if "reboot" in msg:
+            return [msg+"\r", "reboot process started.\r"]
+        elif "start-correction" in msg:
+            return [msg + "\r", "()\r"]
+        else:
+            return msg + "\r"
 
     # ENUMS #
 
@@ -251,8 +255,7 @@ class TopMode(Instrument):
             :return: The correction status of the specified laser
             :type: `~TopMode.CharmStatus`
             """
-            value = self.parent.reference(
-                self.name + ":charm:correction-status")
+            value = self.parent.reference(self.name + ":charm:correction-status")
             return TopMode.CharmStatus(int(value))
 
         # METHODS #


### PR DESCRIPTION
Looks like the Toptica Topmode laser will send more than one ACK message for some commands. This PR adds support for `_ack_expected` returning a list of messages that must be read in.