### PR TITLE
Fix USBTMC timeout property

### DIFF
--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -15,8 +15,10 @@ import io
 from builtins import str, bytes
 
 import usbtmc
+import quantities as pq
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
+from instruments.util_fns import assume_units
 
 # CLASSES #####################################################################
 
@@ -66,11 +68,12 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
 
     @property
     def timeout(self):
-        raise NotImplementedError
+        return self._filelike.timeout * pq.second
 
     @timeout.setter
     def timeout(self, newval):
-        raise NotImplementedError
+        newval = assume_units(newval, pq.second).rescale(pq.second).magnitude
+        self._filelike.timeout = newval
 
     # FILE-LIKE METHODS #
 

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -11,7 +11,10 @@ from __future__ import absolute_import
 from nose.tools import raises, eq_
 import mock
 
+import quantities as pq
+
 from instruments.abstract_instruments.comm import USBTMCCommunicator
+from instruments.tests import unit_eq
 
 # TEST CASES #################################################################
 
@@ -59,18 +62,21 @@ def test_usbtmccomm_terminator_setter(mock_usbtmc):
     term_char.assert_called_with("*")
 
 
-@raises(NotImplementedError)
 @mock.patch(patch_path)
-def test_usbtmccomm_timeout_getter(mock_usbtmc):
+def test_usbtmccomm_timeout(mock_usbtmc):
     comm = USBTMCCommunicator()
-    _ = comm.timeout
 
+    timeout = mock.PropertyMock(return_value=1)
+    type(comm._filelike).timeout = timeout
 
-@raises(NotImplementedError)
-@mock.patch(patch_path)
-def test_usbtmccomm_timeout_setter(mock_usbtmc):
-    comm = USBTMCCommunicator()
-    comm.timeout = 1
+    unit_eq(comm.timeout, 1 * pq.second)
+    timeout.assert_called_with()
+
+    comm.timeout = 10
+    timeout.assert_called_with(10)
+
+    comm.timeout = 1000 * pq.millisecond
+    timeout.assert_called_with(1)
 
 
 @mock.patch(patch_path)


### PR DESCRIPTION
This adds an implementation for the `USBTMCCommunicator` class, fixing issue #120 