### PR TITLE
Fix USBTMC terminator char problems

### DIFF
--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -64,7 +64,7 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
             raise TypeError("Terminator for loopback communicator must be "
                             "specified as a single character string.")
         self._terminator = newval
-        self._filelike.term_char = newval
+        self._filelike.term_char = ord(newval)
 
     @property
     def timeout(self):
@@ -153,7 +153,7 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
 
         :param str msg: The command message to send to the instrument
         """
-        self._filelike.write("{}{}".format(msg, self.terminator))
+        self.write(msg)
 
     def _query(self, msg, size=-1):
         """

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -55,11 +55,11 @@ def test_usbtmccomm_terminator_setter(mock_usbtmc):
 
     comm.terminator = "*"
     eq_(comm._terminator, "*")
-    term_char.assert_called_with("*")
+    term_char.assert_called_with(42)
 
     comm.terminator = b"*"  # pylint: disable=redefined-variable-type
     eq_(comm._terminator, "*")
-    term_char.assert_called_with("*")
+    term_char.assert_called_with(42)
 
 
 @mock.patch(patch_path)
@@ -112,10 +112,10 @@ def test_usbtmccomm_write_raw(mock_usbtmc):
 @mock.patch(patch_path)
 def test_usbtmccomm_sendcmd(mock_usbtmc):
     comm = USBTMCCommunicator()
-    comm.terminator = "\n"  # included due to mocking
+    comm.write = mock.MagicMock()
 
     comm._sendcmd("mock")
-    comm._filelike.write.assert_called_with("mock\n")
+    comm.write.assert_called_with("mock")
 
 
 @mock.patch(patch_path)


### PR DESCRIPTION
Fixes a problem with `USBTMCCommunicator` where termination characters were being appended once in the class, and then again in the downstream `usbtmc` package. In addition, it also fixes setting the termination character in the `usbtmc` package by sending an `int` instead of a `str`.

Address issue #121 