### PR TITLE
Fix USBTMC flush_input, and add a missing docstring

### DIFF
--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -68,6 +68,12 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
 
     @property
     def timeout(self):
+        """
+        Gets/sets the communication timeout of the usbtmc comm channel.
+
+        :type: `~quantities.Quantity`
+        :units: As specified or assumed to be of units ``seconds``
+        """
         return self._filelike.timeout * pq.second
 
     @timeout.setter
@@ -140,7 +146,11 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
         raise NotImplementedError
 
     def flush_input(self):
-        raise NotImplementedError
+        """
+        For a USBTMC connection, this function does not actually do anything
+        and simply returns.
+        """
+        pass
 
     # METHODS #
 

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -144,7 +144,6 @@ def test_usbtmccomm_tell(mock_usbtmc):
     comm.tell()
 
 
-@raises(NotImplementedError)
 @mock.patch(patch_path)
 def test_usbtmccomm_flush_input(mock_usbtmc):
     comm = USBTMCCommunicator()


### PR DESCRIPTION
Changes the `USBTMCCommunicator.flush_input()` implementation to `pass` instead of raising an exception. Flushing doesn't make much sense for these types of connected instruments, but some code does call this function. So for now this will just pass unless this causes other magical instrument problems.

Addresses issue #122 