### PR TITLE
Fixes for USBTMCCommunicator

### DIFF
--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -78,7 +78,8 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, pq.second).rescale(pq.second).magnitude
+        newval = assume_units(newval, pq.second)\
+            .rescale(pq.millisecond).magnitude
         self._filelike.timeout = newval
 
     # FILE-LIKE METHODS #

--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -78,8 +78,7 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, pq.second)\
-            .rescale(pq.millisecond).magnitude
+        newval = assume_units(newval, pq.second).rescale(pq.ms).magnitude
         self._filelike.timeout = newval
 
     # FILE-LIKE METHODS #

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -12,6 +12,7 @@ from nose.tools import raises, eq_
 import mock
 
 import quantities as pq
+from numpy import array
 
 from instruments.abstract_instruments.comm import USBTMCCommunicator
 from instruments.tests import unit_eq
@@ -73,10 +74,10 @@ def test_usbtmccomm_timeout(mock_usbtmc):
     timeout.assert_called_with()
 
     comm.timeout = 10
-    timeout.assert_called_with(10)
+    timeout.assert_called_with(array(10000.0))
 
     comm.timeout = 1000 * pq.millisecond
-    timeout.assert_called_with(1)
+    timeout.assert_called_with(array(1000.0))
 
 
 @mock.patch(patch_path)


### PR DESCRIPTION
This PR pulls in the changes made to fix the following issues: #120 #121 #122 #127

Work was mainly done in PRs #124 #125 #126

After this, `v0.1.1` can be made ready.