### PR TITLE
Feature/multichar termination

### DIFF
--- a/instruments/abstract_instruments/comm/loopback_communicator.py
+++ b/instruments/abstract_instruments/comm/loopback_communicator.py
@@ -67,9 +67,9 @@ class LoopbackCommunicator(io.IOBase, AbstractCommunicator):
     def terminator(self, newval):
         if isinstance(newval, bytes):
             newval = newval.decode("utf-8")
-        if not isinstance(newval, str) or len(newval) > 1:
+        if not isinstance(newval, str):
             raise TypeError("Terminator for loopback communicator must be "
-                            "specified as a single character string.")
+                            "specified as a byte or unicode string.")
         self._terminator = newval
 
     @property
@@ -113,12 +113,12 @@ class LoopbackCommunicator(io.IOBase, AbstractCommunicator):
                 return bytes(input_var)
             elif size == -1:
                 result = bytes()
-                c = b''
-                while c != self._terminator.encode("utf-8"):
+                while result.endswith(self._terminator.encode("utf-8")) is False:
                     c = self._stdin.read(1)
-                    if c != self._terminator.encode("utf-8"):
-                        result += c
-                return result
+                    if c == b'':
+                        break
+                    result += c
+                return result[:-len(self._terminator)]
             else:
                 raise ValueError("Must read a positive value of characters.")
         else:

--- a/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/abstract_instruments/comm/serial_communicator.py
@@ -75,9 +75,9 @@ class SerialCommunicator(io.IOBase, AbstractCommunicator):
     def terminator(self, newval):
         if isinstance(newval, bytes):
             newval = newval.decode("utf-8")
-        if not isinstance(newval, str) or len(newval) > 1:
+        if not isinstance(newval, str):
             raise TypeError("Terminator for serial communicator must be "
-                            "specified as a single character string.")
+                            "specified as a byte or unicode string.")
         self._terminator = newval
 
     @property
@@ -118,15 +118,13 @@ class SerialCommunicator(io.IOBase, AbstractCommunicator):
             return resp
         elif size == -1:
             result = bytes()
-            c = b''
-            while c != self._terminator.encode("utf-8"):
+            while result.endswith(self._terminator.encode("utf-8")) is False:
                 c = self._conn.read(1)
-                if c == b"":
+                if c == b'':
                     raise IOError("Serial connection timed out before reading "
                                   "a termination character.")
-                if c != self._terminator.encode("utf-8"):
-                    result += c
-            return result
+                result += c
+            return result[:-len(self._terminator)]
         else:
             raise ValueError("Must read a positive value of characters.")
 

--- a/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/instruments/abstract_instruments/comm/socket_communicator.py
@@ -64,9 +64,9 @@ class SocketCommunicator(io.IOBase, AbstractCommunicator):
     def terminator(self, newval):
         if isinstance(newval, bytes):
             newval = newval.decode("utf-8")
-        if not isinstance(newval, str) or len(newval) > 1:
+        if not isinstance(newval, str):
             raise TypeError("Terminator for socket communicator must be "
-                            "specified as a single character string.")
+                            "specified as a byte or unicode string.")
         self._terminator = newval
 
     @property
@@ -108,15 +108,13 @@ class SocketCommunicator(io.IOBase, AbstractCommunicator):
             return self._conn.recv(size)
         elif size == -1:
             result = bytes()
-            c = b''
-            while c != self._terminator.encode("utf-8"):
+            while result.endswith(self._terminator.encode("utf-8")) is False:
                 c = self._conn.recv(1)
-                if c == b"":
+                if c == b'':
                     raise IOError("Socket connection timed out before reading "
                                   "a termination character.")
-                if c != self._terminator.encode("utf-8"):
-                    result += c
-            return result
+                result += c
+            return result[:-len(self._terminator)]
         else:
             raise ValueError("Must read a positive value of characters.")
 

--- a/instruments/abstract_instruments/comm/vxi11_communicator.py
+++ b/instruments/abstract_instruments/comm/vxi11_communicator.py
@@ -12,12 +12,16 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import io
+import logging
 
 from builtins import str, bytes
 
 import vxi11
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 # CLASSES #####################################################################
 
@@ -76,9 +80,13 @@ class VXI11Communicator(io.IOBase, AbstractCommunicator):
     def terminator(self, newval):
         if isinstance(newval, bytes):
             newval = newval.decode("utf-8")
-        if not isinstance(newval, str) or len(newval) > 1:
+        if not isinstance(newval, str):
             raise TypeError("Terminator for VXI11 communicator must be "
-                            "specified as a single character string.")
+                            "specified as a byte or unicode string.")
+        if len(newval) > 1:
+            logger.warning("VXI11 instruments only support termination"
+                           "characters of length 1. The first character"
+                           "specified will be used.")
         self._inst.term_char = newval
 
     @property

--- a/instruments/tests/test_comm/test_loopback.py
+++ b/instruments/tests/test_comm/test_loopback.py
@@ -52,6 +52,10 @@ def test_loopbackcomm_terminator():
     eq_(comm.terminator, u"\r")
     eq_(comm._terminator, u"\r")
 
+    comm.terminator = "\r\n"
+    eq_(comm.terminator, "\r\n")
+    eq_(comm._terminator, "\r\n")
+
 
 def test_loopbackcomm_timeout():
     comm = LoopbackCommunicator()
@@ -82,6 +86,17 @@ def test_loopbackcomm_read_raw():
     mock_stdin.read = mock.MagicMock()
     comm.read_raw(10)
     mock_stdin.read.assert_called_with(10)
+
+
+def test_loopbackcomm_read_raw_2char_terminator():
+    mock_stdin = mock.MagicMock()
+    mock_stdin.read.side_effect = [b"a", b"b", b"c", b"\r", b"\n"]
+    comm = LoopbackCommunicator(stdin=mock_stdin)
+    comm._terminator = "\r\n"
+
+    eq_(comm.read_raw(), b"abc")
+    mock_stdin.read.assert_has_calls([mock.call(1)]*5)
+    assert mock_stdin.read.call_count == 5
 
 
 def test_loopbackcomm_write_raw():

--- a/instruments/tests/test_comm/test_serial.py
+++ b/instruments/tests/test_comm/test_serial.py
@@ -53,6 +53,10 @@ def test_serialcomm_terminator():
     comm.terminator = "*"
     eq_(comm.terminator, "*")
 
+    comm.terminator = "\r\n"
+    eq_(comm.terminator, "\r\n")
+    eq_(comm._terminator, "\r\n")
+
 
 def test_serialcomm_timeout():
     comm = SerialCommunicator(serial.Serial())
@@ -92,6 +96,17 @@ def test_serialcomm_read_raw():
     comm._conn.read = mock.MagicMock()
     comm.read_raw(10)
     comm._conn.read.assert_called_with(10)
+
+
+def test_loopbackcomm_read_raw_2char_terminator():
+    comm = SerialCommunicator(serial.Serial())
+    comm._conn = mock.MagicMock()
+    comm._conn.read = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\r", b"\n"])
+    comm._terminator = "\r\n"
+
+    eq_(comm.read_raw(), b"abc")
+    comm._conn.read.assert_has_calls([mock.call(1)] * 5)
+    assert comm._conn.read.call_count == 5
 
 
 @raises(IOError)

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -63,6 +63,10 @@ def test_socketcomm_terminator():
     eq_(comm.terminator, u"\r")
     eq_(comm._terminator, u"\r")
 
+    comm.terminator = "\r\n"
+    eq_(comm.terminator, "\r\n")
+    eq_(comm._terminator, "\r\n")
+
 
 def test_socketcomm_timeout():
     comm = SocketCommunicator(socket.socket())
@@ -100,6 +104,17 @@ def test_socketcomm_read_raw():
     comm._conn.recv = mock.MagicMock()
     comm.read_raw(10)
     comm._conn.recv.assert_called_with(10)
+
+
+def test_loopbackcomm_read_raw_2char_terminator():
+    comm = SocketCommunicator(socket.socket())
+    comm._conn = mock.MagicMock()
+    comm._conn.recv = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\r", b"\n"])
+    comm._terminator = "\r\n"
+
+    eq_(comm.read_raw(), b"abc")
+    comm._conn.recv.assert_has_calls([mock.call(1)] * 5)
+    assert comm._conn.recv.call_count == 5
 
 
 @raises(IOError)


### PR DESCRIPTION
PR adds the ability to have termination "characters" longer than a single char. Some instruments will use the Windows style line endings (`\r\n`) as their end-of-string signal. This will allow loopback, serial, and socket connections to read instruments with these EOS signals. In addition, it also removes the restriction for VXI11 connections, but will instead log a warning message that only string terminations of length 1 are supported.

Addresses issue #117 