### PR TITLE
Ch toptica functionality

### DIFF
--- a/doc/examples/ex_topticatopmode.py
+++ b/doc/examples/ex_topticatopmode.py
@@ -12,6 +12,8 @@ if system() == 'Windows':
 else:
       tm = ik.toptica.TopMode.open_serial('/dev/ttyACM0', 115200)
 
+print("The top mode's serial number is: ", tm.firmware)
+print("The top mode's serial number is: ", tm.serial_number)
 
 print("The current lock state is: ", tm.locked)
 print("The current interlock state is: ", tm.interlock)

--- a/doc/examples/toptica/91-toptica.rules
+++ b/doc/examples/toptica/91-toptica.rules
@@ -1,0 +1,1 @@
+SUBSYSTEMS=="usb", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="29ba", ATTRS{idProduct}=="0002", SYMLINK+="toptica_laser", MODE="0666"

--- a/doc/examples/toptica/ex_topticatopmode.py
+++ b/doc/examples/toptica/ex_topticatopmode.py
@@ -10,6 +10,7 @@ from platform import system
 if system() == 'Windows':
       tm = ik.toptica.TopMode.open_serial('COM14', 115200)
 else:
+      # this assumes that the rules in file 91-toptica.rules have been applied
       tm = ik.toptica.TopMode.open_serial('/dev/toptica_laser', 115200)
 
 print("The top mode's firmware is: ", tm.firmware)

--- a/doc/examples/toptica/ex_topticatopmode.py
+++ b/doc/examples/toptica/ex_topticatopmode.py
@@ -10,9 +10,9 @@ from platform import system
 if system() == 'Windows':
       tm = ik.toptica.TopMode.open_serial('COM14', 115200)
 else:
-      tm = ik.toptica.TopMode.open_serial('/dev/ttyACM0', 115200)
+      tm = ik.toptica.TopMode.open_serial('/dev/toptica_laser', 115200)
 
-print("The top mode's serial number is: ", tm.firmware)
+print("The top mode's firmware is: ", tm.firmware)
 print("The top mode's serial number is: ", tm.serial_number)
 
 print("The current lock state is: ", tm.locked)

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -82,11 +82,14 @@ def test_laser_enable():
         ik.toptica.TopMode,
         [
             "(param-ref 'laser1:emission)",
+            "(param-ref 'laser1:serial-number)",
             "(param-set! 'laser1:enable-emission #t)"
         ],
         [
             "(param-ref 'laser1:emission)\r",
             "#f",
+            "> (param-ref 'laser1:serial-number)\r",
+            "bloop1",
             "> (param-set! 'laser1:enable-emission #t)\r",
             "0",
             "> "
@@ -102,10 +105,13 @@ def test_laser_enable_error():
     with expected_protocol(
         ik.toptica.TopMode,
         [
+            "(param-ref 'laser1:serial-number)",
             "(param-set! 'laser1:enable-emission #t)"
         ],
         [
-            "(param-set! 'laser1:enable-emission #t)\r",
+            "(param-ref 'laser1:serial-number)\r",
+            "bloop1",
+            "> (param-set! 'laser1:enable-emission #t)\r",
             "0",
             "> "
         ],
@@ -166,10 +172,13 @@ def test_laser_lock_start():
     with expected_protocol(
         ik.toptica.TopMode,
         [
+            "(param-ref 'laser1:serial-number)",
             "(param-ref 'laser1:charm:reg:started)"
         ],
         [
-            "(param-ref 'laser1:charm:reg:started)\r",
+            "(param-ref 'laser1:serial-number)\r",
+            "bloop1",
+            "> (param-ref 'laser1:charm:reg:started)\r",
             "\"\"",
             "> "
         ],

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -7,10 +7,10 @@ Module containing tests for the Toptica Topmode
 # IMPORTS #####################################################################
 
 from __future__ import absolute_import
-
+from datetime import datetime
 from nose.tools import raises
 import quantities as pq
-from datetime import datetime
+
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -18,7 +18,7 @@ from instruments.tests import expected_protocol
 # TESTS #######################################################################
 
 
-def test_serial_number():
+def test_laser_serial_number():
     with expected_protocol(
         ik.toptica.TopMode,
         [

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -525,7 +525,7 @@ def test_firmware():
         ],
         sep="\n"
     ) as tm:
-        assert tm.firmware == [1, 2, 1]
+        assert tm.firmware == (1, 2, 1)
 
 
 def test_serial_number():

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -156,10 +156,10 @@ def test_laser_mode_hop():
     with expected_protocol(
         ik.toptica.TopMode,
         [
-            "(param-ref 'laser1:charm:reg:mh-occured)"
+            "(param-ref 'laser1:charm:reg:mh-occurred)"
         ],
         [
-            "(param-ref 'laser1:charm:reg:mh-occured)\r",
+            "(param-ref 'laser1:charm:reg:mh-occurred)\r",
             "#f",
             "> "
         ],

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import
 
 from nose.tools import raises
 import quantities as pq
+from datetime import datetime
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -100,6 +101,26 @@ def test_laser_enable():
         tm.laser[0].enable = True
 
 
+@raises(RuntimeError)
+def test_laser_enable_no_laser():
+    with expected_protocol(
+        ik.toptica.TopMode,
+        [
+            "(param-ref 'laser1:serial-number)",
+            "(param-set! 'laser1:enable-emission #t)"
+        ],
+        [
+            "(param-ref 'laser1:serial-number)\r",
+            "unknown",
+            "> (param-set! 'laser1:enable-emission #t)\r",
+            "0",
+            "> "
+        ],
+        sep="\n"
+    ) as tm:
+        tm.laser[0].enable = True
+
+
 @raises(TypeError)
 def test_laser_enable_error():
     with expected_protocol(
@@ -187,7 +208,27 @@ def test_laser_lock_start():
         assert tm.laser[0].lock_start is None
 
 
-def test_laser_first_mode_hop_time():
+def test_laser_lock_start_with_date():
+    with expected_protocol(
+        ik.toptica.TopMode,
+        [
+            "(param-ref 'laser1:serial-number)",
+            "(param-ref 'laser1:charm:reg:started)"
+        ],
+        [
+            "(param-ref 'laser1:serial-number)\r",
+            "bloop1",
+            "> (param-ref 'laser1:charm:reg:started)\r",
+            "\"2012-12-01 01:02:01\"",
+            "> "
+        ],
+        sep="\n"
+    ) as tm:
+        _date = datetime(2012, 12, 1, 1, 2, 1)
+        assert tm.laser[0].lock_start == _date
+
+
+def test_laser_first_mode_hop_time_none():
     with expected_protocol(
         ik.toptica.TopMode,
         [
@@ -201,6 +242,23 @@ def test_laser_first_mode_hop_time():
         sep="\n"
     ) as tm:
         assert tm.laser[0].first_mode_hop_time is None
+
+
+def test_laser_first_mode_hop_time():
+    with expected_protocol(
+        ik.toptica.TopMode,
+        [
+            "(param-ref 'laser1:charm:reg:first-mh)"
+        ],
+        [
+            "(param-ref 'laser1:charm:reg:first-mh)\r",
+            "\"2012-12-01 01:02:01\"",
+            "> "
+        ],
+        sep="\n"
+    ) as tm:
+        _date = datetime(2012, 12, 1, 1, 2, 1)
+        assert tm.laser[0].first_mode_hop_time == _date
 
 
 def test_laser_latest_mode_hop_time():
@@ -437,6 +495,38 @@ def test_enable():
         tm.enable = False
 
 
+def test_firmware():
+    with expected_protocol(
+        ik.toptica.TopMode,
+        [
+            "(param-ref 'fw-ver)"
+        ],
+        [
+            "(param-ref 'fw-ver)\r",
+            "1.02.01",
+            "> "
+        ],
+        sep="\n"
+    ) as tm:
+        assert tm.firmware == (1, 2, 1)
+
+
+def test_serial_number():
+    with expected_protocol(
+        ik.toptica.TopMode,
+        [
+            "(param-ref 'serial-number)"
+        ],
+        [
+            "(param-ref 'serial-number)\r",
+            "010101",
+            "> "
+        ],
+        sep="\n"
+    ) as tm:
+        assert tm.serial_number == '010101'
+
+
 @raises(TypeError)
 def test_enable_error():
     with expected_protocol(
@@ -499,6 +589,22 @@ def test_fpga_status():
         sep="\n"
     ) as tm:
         assert tm.fpga_status is True
+
+
+def test_fpga_status_false():
+    with expected_protocol(
+        ik.toptica.TopMode,
+        [
+            "(param-ref 'system-health)"
+        ],
+        [
+            "(param-ref 'system-health)\r",
+            "#f",
+            "> "
+        ],
+        sep="\n"
+    ) as tm:
+        assert tm.fpga_status is False
 
 
 def test_temperature_status():

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -261,7 +261,7 @@ def test_laser_first_mode_hop_time():
         assert tm.laser[0].first_mode_hop_time == _date
 
 
-def test_laser_latest_mode_hop_time():
+def test_laser_latest_mode_hop_time_none():
     with expected_protocol(
         ik.toptica.TopMode,
         [
@@ -275,6 +275,23 @@ def test_laser_latest_mode_hop_time():
         sep="\n"
     ) as tm:
         assert tm.laser[0].latest_mode_hop_time is None
+
+
+def test_laser_latest_mode_hop_time():
+    with expected_protocol(
+        ik.toptica.TopMode,
+        [
+            "(param-ref 'laser1:charm:reg:latest-mh)"
+        ],
+        [
+            "(param-ref 'laser1:charm:reg:latest-mh)\r",
+            "\"2012-12-01 01:02:01\"",
+            "> "
+        ],
+        sep="\n"
+    ) as tm:
+        _date = datetime(2012, 12, 1, 1, 2, 1)
+        assert tm.laser[0].latest_mode_hop_time == _date
 
 
 def test_laser_correction_status():

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -508,7 +508,7 @@ def test_firmware():
         ],
         sep="\n"
     ) as tm:
-        assert tm.firmware == (1, 2, 1)
+        assert tm.firmware == [1, 2, 1]
 
 
 def test_serial_number():

--- a/instruments/tests/test_toptica/test_toptica_utils.py
+++ b/instruments/tests/test_toptica/test_toptica_utils.py
@@ -29,7 +29,7 @@ def test_convert_boolean_value():
 
 def test_convert_toptica_datetime():
     blo = datetime.datetime.now()
-    blo_str = datetime.datetime.now().strftime("%b %d %Y %I:%M%p")
+    blo_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     assert toptica_utils.convert_toptica_datetime('""\r') is None
     blo2 = toptica_utils.convert_toptica_datetime(blo_str)
     diff = blo - blo2

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -13,7 +13,7 @@ from __future__ import division
 from __future__ import unicode_literals
 
 from re import sub
-from builtins import range
+from builtins import range, map
 from enum import IntEnum
 
 
@@ -423,7 +423,7 @@ class TopMode(Instrument):
         :return: The firmware version of the charm controller
         :type: `str`
         """
-        firmware = [int(i) for i in self.reference("fw-ver").split(".")]
+        firmware = tuple(map(int, self.reference("fw-ver").split(".")))
         return firmware
 
     @property

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -424,10 +424,6 @@ class TopMode(Instrument):
         :type: `str`
         """
         firmware = [int(i) for i in self.reference("fw-ver").split(".")]
-
-        if len(firmware) < 3:
-            for _ in range(3 - len(firmware)):
-                firmware.append(0)
         return firmware
 
     @property

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -12,9 +12,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
+from re import sub
 from builtins import range
 from enum import IntEnum
-from re import sub
+
 
 import quantities as pq
 
@@ -138,13 +139,10 @@ class TopMode(Instrument):
         @enable.setter
         def enable(self, newval):
             if not isinstance(newval, bool):
-                raise TypeError("Emission status must be a boolean, "
-                            "got: {}".format(type(newval)))
+                raise TypeError("Emission status must be a boolean, got: {}".
+                                format(type(newval)))
             if not self.is_connected:
-                print("not connected")
                 return
-            else:
-                print("finished connecting")
             self.parent.set(self.name + ":enable-emission", newval)
 
         @property
@@ -245,9 +243,9 @@ class TopMode(Instrument):
             if not self.is_connected:
                 return
             response = self.parent.reference(self.name + ":charm:reg:started")
-            # if mode locking has not started yet, the device will respond with an empty date string.
-            # This causes a problem with ctdate.
-            if len(response)<2:
+            # if mode locking has not started yet, the device will respond with an empty
+            # date string. This causes a problem with ctdate.
+            if len(response) < 2:
                 return None
             return ctdate(response)
 
@@ -260,8 +258,8 @@ class TopMode(Instrument):
             :type: `datetime`
             """
             response = self.parent.reference(self.name + ":charm:reg:first-mh")
-            # if the mode has not hopped, the device will respond with an empty date string.
-            # This causes a problem with ctdate.
+            # if the mode has not hopped, the device will respond with an empty date
+            # string. This causes a problem with ctdate.
             if len(response) < 2:
                 return None
             return ctdate(response)
@@ -276,8 +274,8 @@ class TopMode(Instrument):
             :type: `datetime`
             """
             response = self.parent.reference(self.name + ":charm:reg:latest-mh")
-            # if the mode has not hopped, the device will respond with an empty date string.
-            # This causes a problem with ctdate.
+            # if the mode has not hopped, the device will respond with an empty date
+            # string. This causes a problem with ctdate.
             if len(response) < 2:
                 return None
             return ctdate(response)

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -423,12 +423,11 @@ class TopMode(Instrument):
         :return: The firmware version of the charm controller
         :type: `str`
         """
-        firmware = self.reference("fw-ver").split(".")
+        firmware = [int(i) for i in self.reference("fw-ver").split(".")]
 
         if len(firmware) < 3:
             for _ in range(3 - len(firmware)):
                 firmware.append(0)
-        firmware = tuple(map(int, firmware))
         return firmware
 
     @property

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -229,7 +229,6 @@ class TopMode(Instrument):
             :type: `bool`
             """
             response = self.parent.reference(self.name + ":charm:reg:mh-occurred")
-            print(response)
             return ctbool(response)
 
         @property

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -423,7 +423,13 @@ class TopMode(Instrument):
         :return: The firmware version of the charm controller
         :type: `str`
         """
-        return self.reference("fw-ver")
+        firmware = self.reference("fw-ver").split(".")
+
+        if len(firmware) < 3:
+            for _ in range(3 - len(firmware)):
+                firmware.append(0)
+        firmware = tuple(map(int, firmware))
+        return firmware
 
     @property
     def fpga_status(self):

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -230,7 +230,9 @@ class TopMode(Instrument):
             :return: Mode-hop status of the specified laser
             :type: `bool`
             """
-            return ctbool(self.parent.reference(self.name + ":charm:reg:mh-occured"))
+            response = self.parent.reference(self.name + ":charm:reg:mh-occurred")
+            print(response)
+            return ctbool(response)
 
         @property
         def lock_start(self):
@@ -242,8 +244,12 @@ class TopMode(Instrument):
             """
             if not self.is_connected:
                 return
-
-            return ctdate(self.parent.reference(self.name + ":charm:reg:started"))
+            response = self.parent.reference(self.name + ":charm:reg:started")
+            # if mode locking has not started yet, the device will respond with an empty date string.
+            # This causes a problem with ctdate.
+            if len(response)<2:
+                return None
+            return ctdate(response)
 
         @property
         def first_mode_hop_time(self):
@@ -253,7 +259,12 @@ class TopMode(Instrument):
             :return: The datetime of the first mode hop for the specified laser
             :type: `datetime`
             """
-            return ctdate(self.parent.reference(self.name + ":charm:reg:first-mh"))
+            response = self.parent.reference(self.name + ":charm:reg:first-mh")
+            # if the mode has not hopped, the device will respond with an empty date string.
+            # This causes a problem with ctdate.
+            if len(response) < 2:
+                return None
+            return ctdate(response)
 
         @property
         def latest_mode_hop_time(self):
@@ -264,7 +275,12 @@ class TopMode(Instrument):
                 specified laser
             :type: `datetime`
             """
-            return ctdate(self.parent.reference(self.name + ":charm:reg:latest-mh"))
+            response = self.parent.reference(self.name + ":charm:reg:latest-mh")
+            # if the mode has not hopped, the device will respond with an empty date string.
+            # This causes a problem with ctdate.
+            if len(response) < 2:
+                return None
+            return ctdate(response)
 
         @property
         def correction_status(self):

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -376,6 +376,16 @@ class TopMode(Instrument):
         return ctbool(self.reference("interlock-open"))
 
     @property
+    def firmware(self):
+        """
+        Gets the firmware version of the charm controller
+
+        :return: The firmware version of the charm controller
+        :type: `str`
+        """
+        return self.reference("fm-ver")
+
+    @property
     def fpga_status(self):
         """
         Gets the FPGA health status
@@ -389,6 +399,16 @@ class TopMode(Instrument):
             return False
         response = int(response)
         return False if response % 2 else True
+
+    @property
+    def serial_number(self):
+        """
+        Gets the serial number of the charm controller
+
+        :return: The serial number of the charm controller
+        :type: `str`
+        """
+        return self.reference("serial-number")
 
     @property
     def temperature_status(self):

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -139,8 +139,8 @@ class TopMode(Instrument):
         @enable.setter
         def enable(self, newval):
             if not isinstance(newval, bool):
-                raise TypeError("Emission status must be a boolean, got: {}".
-                                format(type(newval)))
+                raise TypeError("Emission status must be a boolean, "
+                                "got: {}".format(type(newval)))
             if not self.is_connected:
                 return
             self.parent.set(self.name + ":enable-emission", newval)
@@ -148,7 +148,10 @@ class TopMode(Instrument):
         @property
         def is_connected(self):
             """
-            Check whether a laser is even connected
+            Check whether a laser is connected
+
+            :return: Whether the controller successfully connected to a laser
+            :type: `bool`
             """
             if self.serial_number == 'unknown':
                 raise RuntimeError("Laser was not recognized by charm "
@@ -158,7 +161,7 @@ class TopMode(Instrument):
         @property
         def on_time(self):
             """
-            Gets the 'on time' value for the laser
+            Gets the amount of time the laser has been emitting light
 
             :return: The 'on time' value for the specified laser
             :units: Seconds (s)

--- a/instruments/toptica/toptica_utils.py
+++ b/instruments/toptica/toptica_utils.py
@@ -38,4 +38,4 @@ def convert_toptica_datetime(response):
     if response.find('""') >= 0:
         return None
     else:
-        return datetime.strptime(response, '%b %d %Y %I:%M%p')
+        return datetime.strptime(response, '%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
Copy of PR #119 just with develop as the base branch

This PR contains several updates relating to toptica topmode charm controller.
this includes:

fixing a command spelling error
adding the udev rule
adding firmware and topmode charm controller serial number
handling the situation when no laser is plugged into the controller