### PR TITLE
Fix pyVISA version checking

### DIFF
--- a/instruments/abstract_instruments/comm/visa_communicator.py
+++ b/instruments/abstract_instruments/comm/visa_communicator.py
@@ -45,7 +45,8 @@ class VisaCommunicator(io.IOBase, AbstractCommunicator):
         if visa is None:
             raise ImportError("PyVISA required for accessing VISA instruments.")
 
-        version = int(visa.__version__.replace(".", ""))
+        version = int(visa.__version__.replace(".", "").ljust(3, "0"))
+        # pylint: disable=no-member
         if (version < 160 and isinstance(conn, visa.Instrument)) or \
                 (version >= 160 and isinstance(conn, visa.Resource)):
             self._conn = conn


### PR DESCRIPTION
- Temporarily resolves an issue regarding version checking for `pyvisa`

This should be redone in a more robust way to prevent this from continuously having problems. Or at this point, just drop `pyvisa < 1.6`.