### PR TITLE
[WIP] Extended YAML support

### DIFF
--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -286,7 +286,8 @@ class Instrument(object):
     # CLASS METHODS #
 
     URI_SCHEMES = ["serial", "tcpip", "gpib+usb",
-                   "gpib+serial", "visa", "file", "usbtmc", "vxi11"]
+                   "gpib+serial", "visa", "file", "usbtmc", "vxi11",
+                   "test"]
 
     @classmethod
     def open_from_uri(cls, uri):
@@ -306,6 +307,7 @@ class Instrument(object):
             gpib+serial:///dev/ttyACM0/15 # Currently non-functional.
             visa://USB::0x0699::0x0401::C0000001::0::INSTR
             usbtmc://USB::0x0699::0x0401::C0000001::0::INSTR
+            test://
 
         For the ``serial`` URI scheme, baud rates may be explicitly specified
         using the query parameter ``baud=``, as in the example
@@ -391,6 +393,8 @@ class Instrument(object):
             #   vxi11://192.168.1.104
             #   vxi11://TCPIP::192.168.1.105::gpib,5::INSTR
             return cls.open_vxi11(parsed_uri.netloc, **kwargs)
+        elif parsed_uri.scheme == "test":
+            return cls.open_test(**kwargs)
         else:
             raise NotImplementedError("Invalid scheme or not yet "
                                       "implemented.")

--- a/instruments/config.py
+++ b/instruments/config.py
@@ -65,6 +65,17 @@ def load_instruments(conf_file_name, conf_path="/"):
     the form
     ``{'ddg': instruments.srs.SRSDG645.open_from_uri('gpib+usb://COM7/15')}``.
 
+    Optionally, each the value of each instrument key can also contain a dictionary
+    of attributes to set on the newly-created instrument. For instance, the following
+    dictionary creates a ThorLabs APT motor controller instrument with a single motor
+    model configured::
+
+        rot_stage:
+            class: !!python/name:instruments.thorabsapt.APTMotorController
+            uri: serial:///dev/ttyUSB0?baud=115200
+            attrs:
+                channel[0].motor_model: PRM1-Z8
+
     By specifying a path within the configuration file, one can load only a part
     of the given file. For instance, consider the configuration::
 

--- a/instruments/config.py
+++ b/instruments/config.py
@@ -16,6 +16,8 @@ try:
 except ImportError:
     yaml = None
 
+from instruments.util_fns import setattr_expression
+
 # FUNCTIONS ###################################################################
 
 
@@ -114,13 +116,7 @@ def load_instruments(conf_file_name, conf_path="/"):
             if 'attrs' in value:
                 # We have some attrs we can set on the newly created instrument.
                 for attr_name, attr_value in value['attrs'].items():
-                    # Allow "." in attribute names so that we can set attributes
-                    # recursively.
-                    target = inst_dict[name]
-                    while '.' in attr_name:
-                        head, attr_name = attr_name.split('.', 1)
-                        target = getattr(target, head)
-                    setattr(target, attr_name, attr_value)
+                    setattr_expression(inst_dict[name], attr_name, attr_value)
 
         except IOError as ex:
             # FIXME: need to subclass Warning so that repeated warnings

--- a/instruments/config.py
+++ b/instruments/config.py
@@ -18,6 +18,8 @@ except ImportError:
 
 import quantities as pq
 
+from future.builtins import str
+
 from instruments.util_fns import setattr_expression
 
 # FUNCTIONS ###################################################################
@@ -51,6 +53,10 @@ def walk_dict(d, path):
         return walk_dict(d[path[0]], path[1:])
 
 def quantity_constructor(loader, node):
+    """
+    Constructs a `pq.Quantity` instance from a PyYAML
+    node tagged as ``!Q``.
+    """
     # Follows the example of http://stackoverflow.com/a/43081967/267841.
     value = loader.construct_scalar(node)
     magnitude, units = value.split(" ", 1)
@@ -130,7 +136,7 @@ def load_instruments(conf_file_name, conf_path="/"):
     # Add support for the physical quantity tag.
     yaml.add_constructor(u'!Q', quantity_constructor)
 
-    if isinstance(conf_file_name, (str, unicode)):
+    if isinstance(conf_file_name, str):
         with open(conf_file_name, 'r') as f:
             conf_dict = yaml.load(f)
     else:

--- a/instruments/tests/test_config.py
+++ b/instruments/tests/test_config.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for util_fns.py
+"""
+
+# IMPORTS ####################################################################
+
+from __future__ import absolute_import, unicode_literals
+
+from io import StringIO
+
+import quantities as pq
+
+from unittest import skipIf
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from instruments import Instrument
+from instruments.config import (
+    load_instruments
+)
+
+# TEST CASES #################################################################
+
+# pylint: disable=protected-access,missing-docstring
+
+@skipIf(yaml is None, "PyYAML is not installed.")
+def test_load_test_instrument():
+    config_data = StringIO(u"""
+test:
+    class: !!python/name:instruments.Instrument
+    uri: test://
+""")
+    insts = load_instruments(config_data)
+    assert isinstance(insts['test'], Instrument)
+
+@skipIf(yaml is None, "PyYAML is not installed.")
+def test_load_test_instrument_subtree():
+    config_data = StringIO(u"""
+instruments:
+    test:
+        class: !!python/name:instruments.Instrument
+        uri: test://
+""")
+    insts = load_instruments(config_data, conf_path="/instruments")
+    assert isinstance(insts['test'], Instrument)
+
+@skipIf(yaml is None, "PyYAML is not installed.")
+def test_yaml_quantity_tag():
+    yaml_data = StringIO(u"""
+a:
+    b: !Q 37 tesla
+    c: !Q 41.2 inches
+    d: !Q 98
+""")
+    data = yaml.load(yaml_data)
+    assert data['a']['b'] == pq.Quantity(37, 'tesla')
+    assert data['a']['c'] == pq.Quantity(41.2, 'inches')
+    assert data['a']['d'] == 98
+
+@skipIf(yaml is None, "PyYAML is not installed.")
+def test_load_test_instrument_setattr():
+    config_data = StringIO(u"""
+test:
+    class: !!python/name:instruments.Instrument
+    uri: test://
+    attrs:
+        foo: !Q 111 GHz
+""")
+    insts = load_instruments(config_data)
+    assert insts['test'].foo == pq.Quantity(111, 'GHz')

--- a/instruments/tests/test_config.py
+++ b/instruments/tests/test_config.py
@@ -10,9 +10,9 @@ from __future__ import absolute_import, unicode_literals
 
 from io import StringIO
 
-import quantities as pq
-
 from unittest import skipIf
+
+import quantities as pq
 
 try:
     import yaml

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -16,7 +16,8 @@ from nose.tools import raises, eq_
 
 from instruments.util_fns import (
     ProxyList,
-    assume_units, convert_temperature
+    assume_units, convert_temperature,
+    setattr_expression
 )
 
 # TEST CASES #################################################################
@@ -169,3 +170,46 @@ def test_temperater_conversion_failure():
 @raises(ValueError)
 def test_assume_units_failures():
     assume_units(1, 'm').rescale('s')
+
+def test_setattr_expression_simple():
+    class A(object):
+        x = 'x'
+        y = 'y'
+        z = 'z'
+
+    a = A()
+    setattr_expression(a, 'x', 'foo')
+    assert a.x == 'foo'
+
+def test_setattr_expression_index():
+    class A(object):
+        x = ['x', 'y', 'z']
+
+    a = A()
+    setattr_expression(a, 'x[1]', 'foo')
+    assert a.x[1] == 'foo'
+
+def test_setattr_expression_nested():
+    class B(object):
+        x = 'x'
+    class A(object):
+        b = None
+        def __init__(self):
+            self.b = B()
+
+    a = A()
+    setattr_expression(a, 'b.x', 'foo')
+    assert a.b.x == 'foo'
+
+def test_setattr_expression_both():
+    class B(object):
+        x = 'x'
+    class A(object):
+        b = None
+        def __init__(self):
+            self.b = [B()]
+
+    a = A()
+    setattr_expression(a, 'b[0].x', 'foo')
+    assert a.b[0].x == 'foo'
+

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -212,4 +212,3 @@ def test_setattr_expression_both():
     a = A()
     setattr_expression(a, 'b[0].x', 'foo')
     assert a.b[0].x == 'foo'
-

--- a/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/thorlabs/thorlabsapt.py
@@ -520,6 +520,9 @@ class APTMotorController(ThorLabsAPT):
             logger.warning("Scale factors for controller %s and motor %s are "
                            "unknown", self._apt.model_number, motor_model)
 
+        # We copy the docstring below, so it's OK for this method
+        # to not have a docstring of its own.
+        # pylint: disable=missing-docstring
         def set_scale(self, motor_model):
             warnings.warn(
                 "The set_scale method has been deprecated in favor "
@@ -542,12 +545,12 @@ class APTMotorController(ThorLabsAPT):
             :type: `str` or `None`
             """
             return self._motor_model
-        
+
         @motor_model.setter
         def motor_model(self, newval):
             self._set_scale(newval)
             self._motor_model = newval
-        
+
 
         # MOTOR COMMANDS #
 

--- a/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/thorlabs/thorlabsapt.py
@@ -12,6 +12,7 @@ from __future__ import division
 import re
 import struct
 import logging
+import warnings
 
 from builtins import range
 import quantities as pq
@@ -443,6 +444,8 @@ class APTMotorController(ThorLabsAPT):
 
         # INSTANCE VARIABLES #
 
+        _motor_model = None
+
         #: Sets the scale between the encoder counts and physical units
         #: for the position, velocity and acceleration parameters of this
         #: channel. By default, set to dimensionless, indicating that the proper
@@ -496,7 +499,7 @@ class APTMotorController(ThorLabsAPT):
 
         # UNIT CONVERSION METHODS #
 
-        def set_scale(self, motor_model):
+        def _set_scale(self, motor_model):
             """
             Sets the scale factors for this motor channel, based on the model
             of the attached motor and the specifications of the driver of which
@@ -516,6 +519,35 @@ class APTMotorController(ThorLabsAPT):
             # model.
             logger.warning("Scale factors for controller %s and motor %s are "
                            "unknown", self._apt.model_number, motor_model)
+
+        def set_scale(self, motor_model):
+            warnings.warn(
+                "The set_scale method has been deprecated in favor "
+                "of the motor_model property.",
+                DeprecationWarning
+            )
+            return self._set_scale(motor_model)
+
+        set_scale.__doc__ = _set_scale.__doc__
+
+        @property
+        def motor_model(self):
+            """
+            Gets or sets the model name of the attached motor.
+            Note that the scale factors for this motor channel are based on the model
+            of the attached motor and the specifications of the driver of which
+            this is a channel, such that setting a new motor model will update
+            the scale factors accordingly.
+
+            :type: `str` or `None`
+            """
+            return self._motor_model
+        
+        @motor_model.setter
+        def motor_model(self, newval):
+            self._set_scale(newval)
+            self._motor_model = newval
+        
 
         # MOTOR COMMANDS #
 


### PR DESCRIPTION
This PR (still work in progress) adds to existing YAML config-file support by updating it for Py3 and by allowing config files to specify attributes to be set on newly-created instruments. This is useful, for instance, in the case of ThorLabs APT motor controller devices, where the model of each attached motor must be manually specified. Since this is a fairly significant set of changes, I wanted to open the PR in advance of writing tests and better documentation so as to get feedback on the design.

In particular, this PR adds the following functionality:

- A new special ``test://`` instrument URI schema to make it easier to test config support in lieu of actual devices.
- Support for instantiating unitful numbers from within YAML files, with a new ``!Q`` tag.
- Support for new ``attrs`` config sections of the following form:
```yaml
instrument_id:
    class: !!python/name:instruments.ClassName
    uri: schema://inst
    attrs:
        foo: bar
        baz[0].blah: !Q 1 tesla
```
- Slight refactoring to the ThorLabs APT classes to allow for better use with config files (backwards-compatible, guarded with a ``DeprecationWarning``).

I intend on adding the following to the PR:
- [ ] Removing all pylint warnings introduced.
- [ ] Writing tests for the new attr minilanguage, YAML tags, ``test://`` URI, and ``attrs`` config sections.
- [ ] Adding references to new functionality to the user guide.