### PR TITLE
Freeze pylint to version 1.6.5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 mock
 nose
-pylint
+pylint==1.6.5


### PR DESCRIPTION
Version `1.7.0` of `pylint` introduces a bunch of new rule checks which break the current build. While we work on making the changes, the build should remain green on the previous version.

This PR fixes the version to `1.6.5`, which is really something I should have done a long time ago.