### PR TITLE
Pin ruamel version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ enum34
 python-vxi11>=0.8
 pyusb
 python-usbtmc
-ruamel.yaml<=0.15
+ruamel.yaml~=0.14.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ enum34
 python-vxi11>=0.8
 pyusb
 python-usbtmc
-ruamel.yaml
+ruamel.yaml<=0.15


### PR DESCRIPTION
Looks like they're actively working on a new 0.15 version of `ruamel.yaml`, which doesn't seem to currently compile on Python 3.4 Travis environments, so for now I'm just going to stick with the 0.14 version.