### PR TITLE
Issue 148 - Property templates should support different commands for getting vs setting

### DIFF
--- a/instruments/agilent/agilent33220a.py
+++ b/instruments/agilent/agilent33220a.py
@@ -87,7 +87,7 @@ class Agilent33220a(SCPIFunctionGenerator):
         super(Agilent33220a, self).frequency = newval
 
     function = enum_property(
-        name="FUNC",
+        command="FUNC",
         enum=Function,
         doc="""
         Gets/sets the output function of the function generator
@@ -98,7 +98,7 @@ class Agilent33220a(SCPIFunctionGenerator):
     )
 
     duty_cycle = int_property(
-        name="FUNC:SQU:DCYC",
+        command="FUNC:SQU:DCYC",
         doc="""
         Gets/sets the duty cycle of a square wave.
 
@@ -111,7 +111,7 @@ class Agilent33220a(SCPIFunctionGenerator):
     )
 
     ramp_symmetry = int_property(
-        name="FUNC:RAMP:SYMM",
+        command="FUNC:RAMP:SYMM",
         doc="""
         Gets/sets the ramp symmetry for ramp waves.
 
@@ -124,7 +124,7 @@ class Agilent33220a(SCPIFunctionGenerator):
     )
 
     output = bool_property(
-        name="OUTP",
+        command="OUTP",
         inst_true="ON",
         inst_false="OFF",
         doc="""
@@ -138,7 +138,7 @@ class Agilent33220a(SCPIFunctionGenerator):
     )
 
     output_sync = bool_property(
-        name="OUTP:SYNC",
+        command="OUTP:SYNC",
         inst_true="ON",
         inst_false="OFF",
         doc="""
@@ -149,7 +149,7 @@ class Agilent33220a(SCPIFunctionGenerator):
     )
 
     output_polarity = enum_property(
-        name="OUTP:POL",
+        command="OUTP:POL",
         enum=OutputPolarity,
         doc="""
         Gets/sets the polarity of the waveform relative to the offset voltage.

--- a/instruments/generic_scpi/scpi_function_generator.py
+++ b/instruments/generic_scpi/scpi_function_generator.py
@@ -75,7 +75,7 @@ class SCPIFunctionGenerator(FunctionGenerator, SCPIInstrument):
     # PROPERTIES #
 
     frequency = unitful_property(
-        name="FREQ",
+        command="FREQ",
         units=pq.Hz,
         doc="""
         Gets/sets the output frequency.
@@ -86,7 +86,7 @@ class SCPIFunctionGenerator(FunctionGenerator, SCPIInstrument):
     )
 
     function = enum_property(
-        name="FUNC",
+        command="FUNC",
         enum=lambda: Function,  # pylint: disable=undefined-variable
         doc="""
         Gets/sets the output function of the function generator
@@ -96,7 +96,7 @@ class SCPIFunctionGenerator(FunctionGenerator, SCPIInstrument):
     )
 
     offset = unitful_property(
-        name="VOLT:OFFS",
+        command="VOLT:OFFS",
         units=pq.volt,
         doc="""
         Gets/sets the offset voltage of the function generator.

--- a/instruments/generic_scpi/scpi_multimeter.py
+++ b/instruments/generic_scpi/scpi_multimeter.py
@@ -141,7 +141,7 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
 
     # pylint: disable=unnecessary-lambda,undefined-variable
     mode = enum_property(
-        name="CONF",
+        command="CONF",
         enum=Mode,
         doc="""
         Gets/sets the current measurement mode for the multimeter.
@@ -157,7 +157,7 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
     )
 
     trigger_mode = enum_property(
-        name="TRIG:SOUR",
+        command="TRIG:SOUR",
         enum=TriggerMode,
         doc="""
             Gets/sets the SCPI Multimeter trigger mode.
@@ -317,7 +317,7 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
         self.sendcmd("SAMP:COUN {}".format(newval))
 
     trigger_delay = unitful_property(
-        name="TRIG:DEL",
+        command="TRIG:DEL",
         units=pq.second,
         doc="""
         Gets/sets the time delay which the multimeter will use following
@@ -329,7 +329,7 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
     )
 
     sample_source = enum_property(
-        name="SAMP:SOUR",
+        command="SAMP:SOUR",
         enum=SampleSource,
         doc="""
         Gets/sets the multimeter sample source. This determines whether the
@@ -344,7 +344,7 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
     )
 
     sample_timer = unitful_property(
-        name="SAMP:TIM",
+        command="SAMP:TIM",
         units=pq.second,
         doc="""
         Gets/sets the sample interval when the sample counter is greater than

--- a/instruments/lakeshore/lakeshore475.py
+++ b/instruments/lakeshore/lakeshore475.py
@@ -269,7 +269,7 @@ class Lakeshore475(SCPIInstrument):
         self.field_control_params = tuple(values)
 
     control_mode = bool_property(
-        name="CMODE",
+        command="CMODE",
         inst_true="1",
         inst_false="0",
         doc="""

--- a/instruments/picowatt/picowattavs47.py
+++ b/instruments/picowatt/picowattavs47.py
@@ -97,7 +97,7 @@ class PicowattAVS47(SCPIInstrument):
         return ProxyList(self, PicowattAVS47.Sensor, range(8))
 
     remote = bool_property(
-        name="REM",
+        command="REM",
         inst_true="1",
         inst_false="0",
         doc="""
@@ -111,7 +111,7 @@ class PicowattAVS47(SCPIInstrument):
     )
 
     input_source = enum_property(
-        name="INP",
+        command="INP",
         enum=InputSource,
         input_decoration=int,
         doc="""
@@ -122,7 +122,7 @@ class PicowattAVS47(SCPIInstrument):
     )
 
     mux_channel = int_property(
-        name="MUX",
+        command="MUX",
         doc="""
         Gets/sets the multiplexer sensor number.
         It is recommended that you ground the input before switching the
@@ -136,7 +136,7 @@ class PicowattAVS47(SCPIInstrument):
     )
 
     excitation = int_property(
-        name="EXC",
+        command="EXC",
         doc="""
         Gets/sets the excitation sensor number.
 
@@ -148,7 +148,7 @@ class PicowattAVS47(SCPIInstrument):
     )
 
     display = int_property(
-        name="DIS",
+        command="DIS",
         doc="""
         Gets/sets the sensor that is displayed on the front panel.
 

--- a/instruments/qubitekk/mc1.py
+++ b/instruments/qubitekk/mc1.py
@@ -91,7 +91,7 @@ class MC1(Instrument):
         self._upper_limit = assume_units(newval, pq.ms).rescale(pq.ms)
 
     direction = unitful_property(
-        name="DIRE",
+        command="DIRE",
         doc="""
         Get the internal direction variable, which is a function of how far
         the motor needs to go.
@@ -104,7 +104,7 @@ class MC1(Instrument):
     )
 
     inertia = unitful_property(
-        name="INER",
+        command="INER",
         doc="""
         Gets/Sets the amount of force required to overcome static inertia. Must
          be between 0 and 100 milliseconds.
@@ -133,7 +133,7 @@ class MC1(Instrument):
         return response
 
     metric_position = unitful_property(
-        name="METR",
+        command="METR",
         doc="""
         Get the estimated motor position, in millimeters.
 
@@ -145,7 +145,7 @@ class MC1(Instrument):
     )
 
     setting = int_property(
-        name="OUTP",
+        command="OUTP",
         doc="""
         Gets/sets the output port of the optical switch. 0 means input 1 is
         directed to output 1, and input 2 is directed to output 2. 1 means that
@@ -158,7 +158,7 @@ class MC1(Instrument):
     )
 
     step_size = unitful_property(
-        name="STEP",
+        command="STEP",
         doc="""
         Gets/Sets the number of milliseconds per step. Must be between 1
         and 100 milliseconds.

--- a/instruments/srs/srs345.py
+++ b/instruments/srs/srs345.py
@@ -78,7 +78,7 @@ class SRS345(SCPIInstrument, FunctionGenerator):
     # PROPERTIES ##
 
     frequency = unitful_property(
-        name="FREQ",
+        command="FREQ",
         units=pq.Hz,
         doc="""
         Gets/sets the output frequency.
@@ -89,7 +89,7 @@ class SRS345(SCPIInstrument, FunctionGenerator):
     )
 
     function = enum_property(
-        name="FUNC",
+        command="FUNC",
         enum=Function,
         input_decoration=int,
         doc="""
@@ -100,7 +100,7 @@ class SRS345(SCPIInstrument, FunctionGenerator):
     )
 
     offset = unitful_property(
-        name="OFFS",
+        command="OFFS",
         units=pq.volt,
         doc="""
         Gets/sets the offset voltage for the output waveform.
@@ -111,7 +111,7 @@ class SRS345(SCPIInstrument, FunctionGenerator):
     )
 
     phase = unitful_property(
-        name="PHSE",
+        command="PHSE",
         units=pq.degree,
         doc="""
         Gets/sets the phase for the output waveform.

--- a/instruments/tests/test_property_factories/test_bool_property.py
+++ b/instruments/tests/test_property_factories/test_bool_property.py
@@ -20,8 +20,8 @@ from . import MockInstrument
 
 def test_bool_property_basics():
     class BoolMock(MockInstrument):
-        mock1 = bool_property('MOCK1', 'ON', 'OFF')
-        mock2 = bool_property('MOCK2', 'YES', 'NO')
+        mock1 = bool_property('MOCK1')
+        mock2 = bool_property('MOCK2', inst_true='YES', inst_false='NO')
 
     mock_inst = BoolMock({'MOCK1?': 'OFF', 'MOCK2?': 'YES'})
 
@@ -36,7 +36,7 @@ def test_bool_property_basics():
 
 def test_bool_property_set_fmt():
     class BoolMock(MockInstrument):
-        mock1 = bool_property('MOCK1', 'ON', 'OFF', set_fmt="{}={}")
+        mock1 = bool_property('MOCK1', set_fmt="{}={}")
 
     mock_instrument = BoolMock({'MOCK1?': 'OFF'})
 
@@ -48,7 +48,7 @@ def test_bool_property_set_fmt():
 @raises(AttributeError)
 def test_bool_property_readonly_writing_fails():
     class BoolMock(MockInstrument):
-        mock1 = bool_property('MOCK1', 'ON', 'OFF', readonly=True)
+        mock1 = bool_property('MOCK1', readonly=True)
 
     mock_instrument = BoolMock({'MOCK1?': 'OFF'})
 
@@ -57,7 +57,7 @@ def test_bool_property_readonly_writing_fails():
 
 def test_bool_property_readonly_reading_passes():
     class BoolMock(MockInstrument):
-        mock1 = bool_property('MOCK1', 'ON', 'OFF', readonly=True)
+        mock1 = bool_property('MOCK1', readonly=True)
 
     mock_instrument = BoolMock({'MOCK1?': 'OFF'})
 
@@ -67,7 +67,7 @@ def test_bool_property_readonly_reading_passes():
 @raises(AttributeError)
 def test_bool_property_writeonly_reading_fails():
     class BoolMock(MockInstrument):
-        mock1 = bool_property('MOCK1', 'ON', 'OFF', writeonly=True)
+        mock1 = bool_property('MOCK1', writeonly=True)
 
     mock_instrument = BoolMock({'MOCK1?': 'OFF'})
 
@@ -76,8 +76,20 @@ def test_bool_property_writeonly_reading_fails():
 
 def test_bool_property_writeonly_writing_passes():
     class BoolMock(MockInstrument):
-        mock1 = bool_property('MOCK1', 'ON', 'OFF', writeonly=True)
+        mock1 = bool_property('MOCK1', writeonly=True)
 
     mock_instrument = BoolMock({'MOCK1?': 'OFF'})
 
     mock_instrument.mock1 = False
+
+
+def test_bool_property_set_cmd():
+    class BoolMock(MockInstrument):
+        mock1 = bool_property('MOCK1', set_cmd='FOOBAR')
+
+    mock_inst = BoolMock({'MOCK1?': 'OFF'})
+
+    eq_(mock_inst.mock1, False)
+    mock_inst.mock1 = True
+
+    eq_(mock_inst.value, 'MOCK1?\nFOOBAR ON\n')

--- a/instruments/tests/test_property_factories/test_bounded_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_bounded_unitful_property.py
@@ -124,7 +124,7 @@ def test_bounded_unitful_property_static_range_with_units():
 @mock.patch("instruments.util_fns.unitful_property")
 def test_bounded_unitful_property_passes_kwargs(mock_unitful_property):
     bounded_unitful_property(
-        name='MOCK',
+        command='MOCK',
         units=pq.Hz,
         derp="foobar"
     )
@@ -139,7 +139,7 @@ def test_bounded_unitful_property_passes_kwargs(mock_unitful_property):
 @mock.patch("instruments.util_fns.unitful_property")
 def test_bounded_unitful_property_valid_range_none(mock_unitful_property):
     bounded_unitful_property(
-        name='MOCK',
+        command='MOCK',
         units=pq.Hz,
         valid_range=(None, None)
     )

--- a/instruments/tests/test_property_factories/test_enum_property.py
+++ b/instruments/tests/test_property_factories/test_enum_property.py
@@ -196,3 +196,18 @@ def test_enum_property_readonly_reading_passes():
 
     eq_(mock_instrument.a, SillyEnum.a)
     eq_(mock_instrument.value, 'MOCK:A?\n')
+
+
+def test_enum_property_set_cmd():
+    class SillyEnum(Enum):
+        a = 'aa'
+
+    class EnumMock(MockInstrument):
+        a = enum_property('MOCK:A', SillyEnum, set_cmd='FOOBAR:A')
+
+    mock_inst = EnumMock({'MOCK:A?': 'aa'})
+
+    eq_(mock_inst.a, SillyEnum.a)
+    mock_inst.a = SillyEnum.a
+
+    eq_(mock_inst.value, 'MOCK:A?\nFOOBAR:A aa\n')

--- a/instruments/tests/test_property_factories/test_int_property.py
+++ b/instruments/tests/test_property_factories/test_int_property.py
@@ -97,3 +97,15 @@ def test_int_property_format_code():
 
     mock_inst.int_property = 1
     eq_(mock_inst.value, 'MOCK {:e}\n'.format(1))
+
+
+def test_int_property_set_cmd():
+    class IntMock(MockInstrument):
+        int_property = int_property('MOCK', set_cmd='FOOBAR')
+
+    mock_inst = IntMock({'MOCK?': '1'})
+
+    eq_(mock_inst.int_property, 1)
+    mock_inst.int_property = 1
+
+    eq_(mock_inst.value, 'MOCK?\nFOOBAR 1\n')

--- a/instruments/tests/test_property_factories/test_string_property.py
+++ b/instruments/tests/test_property_factories/test_string_property.py
@@ -52,3 +52,15 @@ def test_string_property_no_bookmark_symbol():
 
     mock_inst.mock_property = 'foo'
     eq_(mock_inst.value, 'MOCK?\nMOCK foo\n')
+
+
+def test_string_property_set_cmd():
+    class StringMock(MockInstrument):
+        mock_property = string_property('MOCK', set_cmd='FOOBAR')
+
+    mock_inst = StringMock({'MOCK?': '"derp"'})
+
+    eq_(mock_inst.mock_property, 'derp')
+
+    mock_inst.mock_property = 'qwerty'
+    eq_(mock_inst.value, 'MOCK?\nFOOBAR "qwerty"\n')

--- a/instruments/tests/test_property_factories/test_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_unitful_property.py
@@ -242,3 +242,18 @@ def test_unitful_property_split_str():
     value = mock_inst.unitful_property
     assert value.magnitude == 1000
     assert value.units == pq.hertz
+
+
+def test_unitful_property_name_read_not_none():
+    class UnitfulMock(MockInstrument):
+        a = unitful_property(
+            'MOCK',
+            units=pq.hertz,
+            set_cmd='FOOBAR'
+        )
+
+    mock_inst = UnitfulMock({'MOCK?': '1000'})
+    eq_(mock_inst.a, 1000 * pq.hertz)
+    mock_inst.a = 1000 * pq.hertz
+
+    eq_(mock_inst.value, 'MOCK?\nFOOBAR {:e}\n'.format(1000))

--- a/instruments/tests/test_property_factories/test_unitless_property.py
+++ b/instruments/tests/test_property_factories/test_unitless_property.py
@@ -88,3 +88,15 @@ def test_unitless_property_readonly_reading_passes():
     mock_inst = UnitlessMock({'MOCK?': '1'})
 
     eq_(mock_inst.mock_property, 1)
+
+
+def test_unitless_property_set_cmd():
+    class UnitlessMock(MockInstrument):
+        mock_property = unitless_property('MOCK', set_cmd='FOOBAR')
+
+    mock_inst = UnitlessMock({'MOCK?': '1'})
+
+    eq_(mock_inst.mock_property, 1)
+    mock_inst.mock_property = 1
+
+    eq_(mock_inst.value, 'MOCK?\nFOOBAR {:e}\n'.format(1))

--- a/instruments/thorlabs/lcc25.py
+++ b/instruments/thorlabs/lcc25.py
@@ -95,8 +95,8 @@ class LCC25(Instrument):
 
     enable = bool_property(
         "enable",
-        "1",
-        "0",
+        inst_true="1",
+        inst_false="0",
         set_fmt="{}={}",
         doc="""
         Gets/sets the output enable status.
@@ -109,8 +109,8 @@ class LCC25(Instrument):
 
     extern = bool_property(
         "extern",
-        "1",
-        "0",
+        inst_true="1",
+        inst_false="0",
         set_fmt="{}={}",
         doc="""
         Gets/sets the use of the external TTL modulation.
@@ -124,8 +124,8 @@ class LCC25(Instrument):
 
     remote = bool_property(
         "remote",
-        "1",
-        "0",
+        inst_true="1",
+        inst_false="0",
         set_fmt="{}={}",
         doc="""
         Gets/sets front panel lockout status for remote instrument operation.

--- a/instruments/thorlabs/sc10.py
+++ b/instruments/thorlabs/sc10.py
@@ -67,8 +67,8 @@ class SC10(Instrument):
 
     enable = bool_property(
         "ens",
-        "1",
-        "0",
+        inst_true="1",
+        inst_false="0",
         set_fmt="{}={}",
         doc="""
         Gets/sets the shutter enable status, False for disabled, True if
@@ -182,8 +182,8 @@ class SC10(Instrument):
 
     closed = bool_property(
         "closed",
-        "1",
-        "0",
+        inst_true="1",
+        inst_false="0",
         readonly=True,
         doc="""
         Gets the shutter closed status.
@@ -197,8 +197,8 @@ class SC10(Instrument):
 
     interlock = bool_property(
         "interlock",
-        "1",
-        "0",
+        inst_true="1",
+        inst_false="0",
         readonly=True,
         doc="""
         Gets the interlock tripped status.


### PR DESCRIPTION
This PR adds optional `set_cmd=None` parameter to each property factory to allow for those rare instruments that have asymmetric command strings for getting vs setting. We have one of those in the repo right now, so this will let us refactor that instrument to use the property factories.

This also renames the main parameter of those functions from `name` to `command` to go in line with `set_cmd`.

If `set_cmd` is not specified, then `command` is used for both the getting and setting string.

(address issue #148 )