### PR TITLE
Fix timeout and terminator for USBTMC

### DIFF
--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -54,7 +54,7 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
 
         :type: `str`
         """
-        return self._filelike.term_char
+        return chr(self._filelike.term_char)
 
     @terminator.setter
     def terminator(self, newval):
@@ -78,7 +78,7 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, pq.second).rescale(pq.ms).magnitude
+        newval = assume_units(newval, pq.second).rescale(pq.s).magnitude
         self._filelike.timeout = newval
 
     # FILE-LIKE METHODS #

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -40,7 +40,7 @@ def test_usbtmccomm_init_missing_module():
 def test_usbtmccomm_terminator_getter(mock_usbtmc):
     comm = USBTMCCommunicator()
 
-    term_char = mock.PropertyMock(return_value="\n")
+    term_char = mock.PropertyMock(return_value=10)
     type(comm._filelike).term_char = term_char
 
     eq_(comm.terminator, "\n")
@@ -74,10 +74,10 @@ def test_usbtmccomm_timeout(mock_usbtmc):
     timeout.assert_called_with()
 
     comm.timeout = 10
-    timeout.assert_called_with(array(10000.0))
+    timeout.assert_called_with(array(10.0))
 
     comm.timeout = 1000 * pq.millisecond
-    timeout.assert_called_with(array(1000.0))
+    timeout.assert_called_with(array(1.0))
 
 
 @mock.patch(patch_path)


### PR DESCRIPTION
The `python-usbtmc` package seems to expect an `int` value for the terminator character, and an `int` representing the number of seconds for the timeout.

For timeout, we were actually providing a value in milliseconds. It looks like library actually expects it in seconds, and then it internally converts this value to milliseconds.

This PR should fix these issues.