### PR TITLE
[WIP] Support for remote serial ports

### DIFF
--- a/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/abstract_instruments/comm/serial_communicator.py
@@ -34,7 +34,13 @@ class SerialCommunicator(io.IOBase, AbstractCommunicator):
     def __init__(self, conn):
         super(SerialCommunicator, self).__init__(self)
 
-        if isinstance(conn, serial.Serial):
+        allowed_bases = (serial.Serial, )
+        try:
+            allowed_bases += (serial.serialutil.SerialBase, )
+        except AttributeError:
+            pass
+
+        if isinstance(conn, allowed_bases):
             self._conn = conn
             self._terminator = "\n"
             self._debug = False

--- a/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/abstract_instruments/comm/serial_communicator.py
@@ -178,8 +178,10 @@ class SerialCommunicator(io.IOBase, AbstractCommunicator):
 
         :param str msg: The command message to send to the instrument
         """
-        msg += self._terminator
-        self.write(msg)
+
+        message = msg.decode(encoding='UTF-8')
+        message += self._terminator
+        self.write(message)
 
     def _query(self, msg, size=-1):
         """

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -15,9 +15,10 @@ from __future__ import unicode_literals
 import os
 import collections
 import socket
+import serial
 
 from builtins import map
-from serial import SerialException
+from serial import SerialException 
 from serial.tools.list_ports import comports
 
 from future.standard_library import install_aliases
@@ -41,7 +42,7 @@ except (ImportError, WindowsError, OSError):
 from instruments.abstract_instruments.comm import (
     SocketCommunicator, USBCommunicator, VisaCommunicator, FileCommunicator,
     LoopbackCommunicator, GPIBCommunicator, AbstractCommunicator,
-    USBTMCCommunicator, VXI11Communicator, serial_manager
+    USBTMCCommunicator, VXI11Communicator, serial_manager, SerialCommunicator
 )
 from instruments.errors import AcknowledgementError, PromptError
 
@@ -523,6 +524,26 @@ class Instrument(object):
             write_timeout=write_timeout
         )
         return cls(ser)
+
+    @classmethod
+    def open_serial_remote(cls, url=None, baud=115200, dsrdtr=False, rtscts=False,
+                    xonxoff = True, timeout=3):
+        """
+        This method follows updates in the API for PySerial so that IK can use the new 
+        serial.serial_for_url constuctor for serial devices.
+        TODO: Finish me
+        """
+        # baudrate=9600, bytesize=8, parity='N', stopbits=1, timeout=None, xonxoff=False, rtscts=False, dsrdtr=False
+        #Should put in parsing to check for valid URL?
+        ser = serial.serial_for_url(
+            url, 
+            baudrate=baud,
+            timeout=timeout,
+            xonxoff=xonxoff, 
+            rtscts=rtscts, 
+            dsrdtr=dsrdtr
+        )
+        return cls(SerialCommunicator(ser))
 
     @classmethod
     def open_gpibusb(cls, port, gpib_address, timeout=3, write_timeout=3):

--- a/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/thorlabs/thorlabsapt.py
@@ -474,7 +474,8 @@ class APTMotorController(ThorLabsAPT):
                 'DRV113': (pq.Quantity(20480, 'ct/mm'),) * 3,
                 'DRV114': (pq.Quantity(20480, 'ct/mm'),) * 3,
                 'FW103':  (pq.Quantity(25600 / 360, 'ct/deg'),) * 3,
-                'NR360':  (pq.Quantity(25600 / 5.4546, 'ct/deg'),) * 3
+                'NR360':  (pq.Quantity(25600 / 5.4546, 'ct/deg'),) * 3,
+                'PRM1-Z8': (pq.Quantity(1919.64 / 360 ,'ct/deg'),) * 3
             },
             # TODO: add other tables here.
         }


### PR DESCRIPTION
Since the original development of IK, PySerial has added additional support for specifying remote serial ports. Here a new method is added for using this new specification (documented in PySerial [here](https://pyserial.readthedocs.io/en/latest/url_handlers.html)). I needed this because Thorlabs comm ports are not exposed on Windows, and so I can forward with [this](https://pyserial.readthedocs.io/en/latest/examples.html#single-port-tcp-ip-serial-bridge-rfc-2217) PySerial example to a Linux machine to actually write to the device. There is also maybe one or two changes that I needed to make for the byte/string python versioning issue, which can be removed once #167 is done.