### PR TITLE
Use new version of quantities

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ InstrumentKit
     :target: https://travis-ci.org/Galvant/InstrumentKit
     :alt: Travis-CI build status
 
-.. image:: https://img.shields.io/coveralls/Galvant/InstrumentKit/dev.svg?maxAge=2592000
-    :target: https://coveralls.io/r/Galvant/InstrumentKit?branch=dev
+.. image:: https://img.shields.io/coveralls/Galvant/InstrumentKit/master.svg?maxAge=2592000
+    :target: https://coveralls.io/github/Galvant/InstrumentKit?branch=master
     :alt: Coveralls code coverage
 
 .. image:: https://readthedocs.org/projects/instrumentkit/badge/?version=latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy<1.13.0
+numpy
 pyserial
-quantities
+quantities>=0.12.1
 future>=0.15
 enum34
 python-vxi11>=0.8


### PR DESCRIPTION
A new version of `python-quantities` has finally been published to address the issue with `numpy>=1.13.0`. This PR ensures that we're using the newest version so that users can use newer versions of numpy if they so choose.

I'm also sneaking in a small fix for the badges in the readme with this patch so that they actually point to the master branch of IK on Coveralls.