### PR TITLE
Bump version 0.4.0 -> 0.4.1

### DIFF
--- a/instruments/__init__.py
+++ b/instruments/__init__.py
@@ -36,7 +36,7 @@ from .config import load_instruments
 # In keeping with PEP-396, we define a version number of the form
 # {major}.{minor}[.{postrelease}]{prerelease-tag}
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 __title__ = "instrumentkit"
 __description__ = "Test and measurement communication library"


### PR DESCRIPTION
- Removes version pin for `numpy`
- Adds version requirement of `quantities>=0.12.1` to ensure users don't have issues with `numpy>=1.13.0`