### PR TITLE
Nose to pytest transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+.pytest_cache
 
 #Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - "pip install -r dev-requirements.txt"
   - pip install python-coveralls
   - pip install coverage
+  - pip install pytest-cov
 before_script:
   # We use before_script to report version and path information in a way
   # that can be easily hidden by Travis' log folding. Moreover, a nonzero
@@ -17,12 +18,12 @@ before_script:
   # even sensibly get version information, we correctly abort.
   - which python
   - python --version
-  - which nosetests
-  - nosetests --version
+  - which pytest
+  - pytest --version
   - which pylint
   - pylint --version
 script:
-  - nosetests --with-coverage -w instruments
+  - pytest --cov=instruments
   - pylint --py3k instruments
   - pylint --disable=I instruments
 after_success:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 mock
-nose
+pytest
 hypothesis
 pylint==1.7.1
+astroid==1.5.3

--- a/doc/source/devguide/index.rst
+++ b/doc/source/devguide/index.rst
@@ -9,7 +9,7 @@ InstrumentKit Development Guide
     code_style
     testing
     util_fns
-    
+
 Introduction
 ============
 
@@ -34,7 +34,7 @@ provided ``dev-requirements.txt``::
 $ pip install -r dev-requirements.txt
 
 - mock
-- nose
+- pytest
 - pylint
 
 Optional Development Dependencies

--- a/doc/source/devguide/testing.rst
+++ b/doc/source/devguide/testing.rst
@@ -20,13 +20,13 @@ of InstrumentKit will not, in general, have access to each instrument that
 is supported--- we rely on automated testing to ensure that future changes
 do not cause invalid or undesired operation.
 
-For InstrumentKit, we rely heavily on `nose`_, a mature and flexible
+For InstrumentKit, we rely heavily on `pytest`_, a mature and flexible
 unit-testing framework for Python. When run from the command line via
-``nosetests``, or when run by Travis CI, nose will automatically execute
+``pytest``, or when run by Travis CI, pytest will automatically execute
 functions and methods whose names start with ``test`` in packages, modules
 and classes whose names start with ``test`` or ``Test``, depending. (Please
-see the `nose`_ documentation for full details, as this is not intended
-to be a guide to nose so much as a guide to how we use it in IK.)
+see the `pytest`_ documentation for full details, as this is not intended
+to be a guide to pytest so much as a guide to how we use it in IK.)
 Because of this, we keep all test cases in the ``instruments.tests``
 package, under a subpackage named for the particular manufacturer,
 such as ``instruments.tests.test_srs``. The tests for each instrument should
@@ -88,4 +88,4 @@ Protocol Assertion Functions
 
 .. autofunction:: expected_protocol
 
-.. _nose: https://nose.readthedocs.org/en/latest/
+.. _pytest: https://docs.pytest.org/en/latest/

--- a/instruments/tests/__init__.py
+++ b/instruments/tests/__init__.py
@@ -112,5 +112,5 @@ def make_name_test(ins_class, name_cmd="*IDN?"):
     """
     def test():
         with expected_protocol(ins_class, name_cmd + "\n", "NAME\n") as ins:
-            assert ins.name ==  "NAME"
+            assert ins.name == "NAME"
     return test

--- a/instruments/tests/__init__.py
+++ b/instruments/tests/__init__.py
@@ -19,6 +19,11 @@ from builtins import bytes, str
 
 from nose.tools import nottest, eq_
 
+try:
+    from unittest import mock  # from Python 3.3 onward, this is in the stdlib
+except ImportError:
+    import mock
+
 # FUNCTIONS ##################################################################
 
 

--- a/instruments/tests/__init__.py
+++ b/instruments/tests/__init__.py
@@ -17,8 +17,6 @@ from io import BytesIO
 
 from builtins import bytes, str
 
-from nose.tools import nottest, eq_
-
 try:
     from unittest import mock  # from Python 3.3 onward, this is in the stdlib
 except ImportError:
@@ -95,7 +93,6 @@ Got:
     #     """Only read {} bytes out of {}""".format(current, end)
 
 
-@nottest
 def unit_eq(a, b, msg=None, thresh=1e-5):
     """
     Asserts that two unitful quantites ``a`` and ``b``
@@ -108,7 +105,6 @@ def unit_eq(a, b, msg=None, thresh=1e-5):
     assert a.units == b.units, "{} and {} have different units".format(a, b)
 
 
-@nottest
 def make_name_test(ins_class, name_cmd="*IDN?"):
     """
     Given an instrument class, produces a test which asserts that the instrument
@@ -116,5 +112,5 @@ def make_name_test(ins_class, name_cmd="*IDN?"):
     """
     def test():
         with expected_protocol(ins_class, name_cmd + "\n", "NAME\n") as ins:
-            eq_(ins.name, "NAME")
+            assert ins.name ==  "NAME"
     return test

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -16,7 +16,6 @@ import serial
 from serial.tools.list_ports_common import ListPortInfo
 
 import pytest
-from . import mock
 import numpy as np
 
 import instruments as ik
@@ -28,6 +27,8 @@ from instruments.abstract_instruments.comm import (
     USBTMCCommunicator, VXI11Communicator, serial_manager, SerialCommunicator
 )
 from instruments.errors import AcknowledgementError, PromptError
+
+from . import mock
 
 # TESTS ######################################################################
 

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -15,7 +15,7 @@ from builtins import bytes
 import serial
 from serial.tools.list_ports_common import ListPortInfo
 
-from nose.tools import raises
+import pytest
 from . import mock
 import numpy as np
 
@@ -62,23 +62,23 @@ def test_instrument_binblockread_two_reads():
     np.testing.assert_array_equal(calls_expected, calls_actual)
 
 
-@raises(IOError)
 def test_instrument_binblockread_too_many_reads():
-    inst = ik.Instrument.open_test()
-    data = bytes.fromhex("00000001000200030004")
-    inst._file.read_raw = mock.MagicMock(
-        side_effect=[b"#", b"2", b"10", data[:6], b"", b"", b""]
-    )
+    with pytest.raises(IOError):
+        inst = ik.Instrument.open_test()
+        data = bytes.fromhex("00000001000200030004")
+        inst._file.read_raw = mock.MagicMock(
+            side_effect=[b"#", b"2", b"10", data[:6], b"", b"", b""]
+        )
 
-    _ = inst.binblockread(2)
+        _ = inst.binblockread(2)
 
 
-@raises(IOError)
 def test_instrument_binblockread_bad_block_start():
-    inst = ik.Instrument.open_test()
-    inst._file.read_raw = mock.MagicMock(return_value=b"@")
+    with pytest.raises(IOError):
+        inst = ik.Instrument.open_test()
+        inst._file.read_raw = mock.MagicMock(return_value=b"@")
 
-    _ = inst.binblockread(2)
+        _ = inst.binblockread(2)
 
 
 # OPEN CONNECTION TESTS
@@ -179,73 +179,73 @@ def test_instrument_open_serial_by_usb_ids_and_serial_number(mock_serial_manager
     )
 
 
-@raises(serial.SerialException)
 @mock.patch("instruments.abstract_instruments.instrument.comports")
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")
 def test_instrument_open_serial_by_usb_ids_multiple_matches(_, mock_comports):
-    fake_device = ListPortInfo()
-    fake_device.vid = 0
-    fake_device.pid = 1000
-    fake_device.serial_number = 'a1'
-    fake_device.device = 'COM1'
+    with pytest.raises(serial.SerialException):
+        fake_device = ListPortInfo()
+        fake_device.vid = 0
+        fake_device.pid = 1000
+        fake_device.serial_number = 'a1'
+        fake_device.device = 'COM1'
 
-    fake_device2 = ListPortInfo()
-    fake_device2.vid = 0
-    fake_device2.pid = 1000
-    fake_device2.serial_number = 'b2'
-    fake_device2.device = 'COM2'
+        fake_device2 = ListPortInfo()
+        fake_device2.vid = 0
+        fake_device2.pid = 1000
+        fake_device2.serial_number = 'b2'
+        fake_device2.device = 'COM2'
 
-    mock_comports.return_value = [fake_device, fake_device2]
+        mock_comports.return_value = [fake_device, fake_device2]
 
-    _ = ik.Instrument.open_serial(baud=1234, vid=0, pid=1000)
+        _ = ik.Instrument.open_serial(baud=1234, vid=0, pid=1000)
 
 
-@raises(ValueError)
 @mock.patch("instruments.abstract_instruments.instrument.comports", new=fake_comports)
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")
 def test_instrument_open_serial_by_usb_ids_incorrect_serial_num(mock_serial_manager):
-    mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
-    _ = ik.Instrument.open_serial(baud=1234, vid=0, pid=1000, serial_number="xyz")
+    with pytest.raises(ValueError):
+        mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
+        _ = ik.Instrument.open_serial(baud=1234, vid=0, pid=1000, serial_number="xyz")
 
 
-@raises(ValueError)
 @mock.patch("instruments.abstract_instruments.instrument.comports", new=fake_comports)
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")
 def test_instrument_open_serial_by_usb_ids_cant_find(mock_serial_manager):
-    mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
-    _ = ik.Instrument.open_serial(baud=1234, vid=1234, pid=1000)
+    with pytest.raises(ValueError):
+        mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
+        _ = ik.Instrument.open_serial(baud=1234, vid=1234, pid=1000)
 
 
-@raises(ValueError)
 @mock.patch("instruments.abstract_instruments.instrument.comports", new=fake_comports)
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")
 def test_instrument_open_serial_no_port(mock_serial_manager):
-    mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
-    _ = ik.Instrument.open_serial(baud=1234)
+    with pytest.raises(ValueError):
+        mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
+        _ = ik.Instrument.open_serial(baud=1234)
 
 
-@raises(ValueError)
 @mock.patch("instruments.abstract_instruments.instrument.comports", new=fake_comports)
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")
 def test_instrument_open_serial_by_usb_ids_and_port(mock_serial_manager):
-    mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
-    _ = ik.Instrument.open_serial(port="COM1", baud=1234, vid=1234, pid=1000)
+    with pytest.raises(ValueError):
+        mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
+        _ = ik.Instrument.open_serial(port="COM1", baud=1234, vid=1234, pid=1000)
 
 
-@raises(ValueError)
 @mock.patch("instruments.abstract_instruments.instrument.comports", new=fake_comports)
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")
 def test_instrument_open_serial_by_usb_vid_no_pid(mock_serial_manager):
-    mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
-    _ = ik.Instrument.open_serial(baud=1234, vid=1234)
+    with pytest.raises(ValueError):
+        mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
+        _ = ik.Instrument.open_serial(baud=1234, vid=1234)
 
 
-@raises(ValueError)
 @mock.patch("instruments.abstract_instruments.instrument.comports", new=fake_comports)
 @mock.patch("instruments.abstract_instruments.instrument.serial_manager")
 def test_instrument_open_serial_by_usb_pid_no_vid(mock_serial_manager):
-    mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
-    _ = ik.Instrument.open_serial(baud=1234, pid=1234)
+    with pytest.raises(ValueError):
+        mock_serial_manager.new_serial_connection.return_value.__class__ = SerialCommunicator
+        _ = ik.Instrument.open_serial(baud=1234, pid=1234)
 
 
 # TEST OPEN_GPIBUSB ##########################################################
@@ -273,10 +273,10 @@ def test_instrument_open_gpibusb(mock_serial_manager, mock_gpib_comm):
     )
 
 
-@raises(ImportError)
 @mock.patch("instruments.abstract_instruments.instrument.visa", new=None)
 def test_instrument_open_visa_import_error():
-    _ = ik.Instrument.open_visa("abc123")
+    with pytest.raises(ImportError):
+        _ = ik.Instrument.open_visa("abc123")
 
 
 @mock.patch("instruments.abstract_instruments.instrument.VisaCommunicator")
@@ -418,16 +418,16 @@ def test_instrument_open_from_uri_vxi11(mock_open_conn):
     mock_open_conn.assert_called_with("TCPIP::192.168.1.105::gpib,5::INSTR")
 
 
-@raises(NotImplementedError)
 def test_instrument_open_from_uri_invalid_scheme():
-    _ = ik.Instrument.open_from_uri("foo://bar")
+    with pytest.raises(NotImplementedError):
+        _ = ik.Instrument.open_from_uri("foo://bar")
 
 
 # INIT TESTS
 
-@raises(TypeError)
 def test_instrument_init_bad_filelike():
-    _ = ik.Instrument(mock.MagicMock())
+    with pytest.raises(TypeError):
+        _ = ik.Instrument(mock.MagicMock())
 
 
 def test_instrument_init():
@@ -502,19 +502,19 @@ def test_instrument_sendcmd_noprompt_multiple_ack():
     inst._file.sendcmd.assert_called_with("foobar")
 
 
-@raises(AcknowledgementError)
 def test_instrument_sendcmd_bad_ack():
-    mock_filelike = mock.MagicMock()
-    mock_filelike.__class__ = AbstractCommunicator
-    inst = ik.Instrument(mock_filelike)
+    with pytest.raises(AcknowledgementError):
+        mock_filelike = mock.MagicMock()
+        mock_filelike.__class__ = AbstractCommunicator
+        inst = ik.Instrument(mock_filelike)
 
-    def new_ack(msg):
-        return msg
+        def new_ack(msg):
+            return msg
 
-    inst._ack_expected = new_ack
-    inst.read = mock.MagicMock(return_value="derp")
+        inst._ack_expected = new_ack
+        inst.read = mock.MagicMock(return_value="derp")
 
-    inst.sendcmd("foobar")
+        inst.sendcmd("foobar")
 
 
 def test_instrument_sendcmd_noack():
@@ -530,16 +530,16 @@ def test_instrument_sendcmd_noack():
     inst._file.sendcmd.assert_called_with("foobar")
 
 
-@raises(PromptError)
 def test_instrument_sendcmd_noack_bad_prompt():
-    mock_filelike = mock.MagicMock()
-    mock_filelike.__class__ = AbstractCommunicator
-    inst = ik.Instrument(mock_filelike)
+    with pytest.raises(PromptError):
+        mock_filelike = mock.MagicMock()
+        mock_filelike.__class__ = AbstractCommunicator
+        inst = ik.Instrument(mock_filelike)
 
-    inst.prompt = "> "
-    inst.read = mock.MagicMock(return_value="* ")
+        inst.prompt = "> "
+        inst.read = mock.MagicMock(return_value="* ")
 
-    inst.sendcmd("foobar")
+        inst.sendcmd("foobar")
 
 
 def test_instrument_sendcmd():
@@ -621,19 +621,19 @@ def test_instrument_query_noprompt_multiple_ack():
     inst.read.assert_called_with(-1)
 
 
-@raises(AcknowledgementError)
 def test_instrument_query_bad_ack():
-    mock_filelike = mock.MagicMock()
-    mock_filelike.__class__ = AbstractCommunicator
-    inst = ik.Instrument(mock_filelike)
-    inst.read = mock.MagicMock(return_value="derp")
+    with pytest.raises(AcknowledgementError):
+        mock_filelike = mock.MagicMock()
+        mock_filelike.__class__ = AbstractCommunicator
+        inst = ik.Instrument(mock_filelike)
+        inst.read = mock.MagicMock(return_value="derp")
 
-    def new_ack(msg):
-        return msg
+        def new_ack(msg):
+            return msg
 
-    inst._ack_expected = new_ack
+        inst._ack_expected = new_ack
 
-    _ = inst.query("foobar?")
+        _ = inst.query("foobar?")
 
 
 def test_instrument_query_noack():
@@ -658,17 +658,17 @@ def test_instrument_query_noack():
     inst.read.assert_called_with(2)
 
 
-@raises(PromptError)
 def test_instrument_query_noack_bad_prompt():
-    mock_filelike = mock.MagicMock()
-    mock_filelike.__class__ = AbstractCommunicator
-    inst = ik.Instrument(mock_filelike)
-    inst._file.query.return_value = "datas"
+    with pytest.raises(PromptError):
+        mock_filelike = mock.MagicMock()
+        mock_filelike.__class__ = AbstractCommunicator
+        inst = ik.Instrument(mock_filelike)
+        inst._file.query.return_value = "datas"
 
-    inst.prompt = "> "
-    inst.read = mock.MagicMock(return_value="* ")
+        inst.prompt = "> "
+        inst.read = mock.MagicMock(return_value="* ")
 
-    _ = inst.query("foobar?")
+        _ = inst.query("foobar?")
 
 
 def test_instrument_query():

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -16,8 +16,7 @@ import serial
 from serial.tools.list_ports_common import ListPortInfo
 
 from nose.tools import raises
-import mock
-
+from . import mock
 import numpy as np
 
 import instruments as ik

--- a/instruments/tests/test_comm/test_file.py
+++ b/instruments/tests/test_comm/test_file.py
@@ -9,7 +9,7 @@ Unit tests for the file communication layer
 from __future__ import absolute_import
 
 from nose.tools import raises, eq_
-import mock
+from .. import mock
 
 from instruments.abstract_instruments.comm import FileCommunicator
 

--- a/instruments/tests/test_comm/test_file.py
+++ b/instruments/tests/test_comm/test_file.py
@@ -8,7 +8,8 @@ Unit tests for the file communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 from .. import mock
 
 from instruments.abstract_instruments.comm import FileCommunicator
@@ -46,10 +47,10 @@ def test_filecomm_address_getter_no_name():
     eq_(comm.address, None)
 
 
-@raises(NotImplementedError)
 def test_filecomm_address_setter():
-    comm = FileCommunicator(mock.MagicMock())
-    comm.address = "abc123"
+    with pytest.raises(NotImplementedError):
+        comm = FileCommunicator(mock.MagicMock())
+        comm.address = "abc123"
 
 
 def test_filecomm_terminator():
@@ -64,16 +65,16 @@ def test_filecomm_terminator():
     eq_(comm._terminator, "*")
 
 
-@raises(NotImplementedError)
 def test_filecomm_timeout_getter():
-    comm = FileCommunicator(mock.MagicMock())
-    _ = comm.timeout
+    with pytest.raises(NotImplementedError):
+        comm = FileCommunicator(mock.MagicMock())
+        _ = comm.timeout
 
 
-@raises(NotImplementedError)
 def test_filecomm_timeout_setter():
-    comm = FileCommunicator(mock.MagicMock())
-    comm.timeout = 1
+    with pytest.raises(NotImplementedError):
+        comm = FileCommunicator(mock.MagicMock())
+        comm.timeout = 1
 
 
 def test_filecomm_close():

--- a/instruments/tests/test_comm/test_file.py
+++ b/instruments/tests/test_comm/test_file.py
@@ -9,9 +9,9 @@ Unit tests for the file communication layer
 from __future__ import absolute_import
 
 import pytest
-from .. import mock
 
 from instruments.abstract_instruments.comm import FileCommunicator
+from .. import mock
 
 # TEST CASES #################################################################
 
@@ -33,7 +33,7 @@ def test_filecomm_address_getter():
     mock_name = mock.PropertyMock(return_value="/home/user/file")
     type(comm._filelike).name = mock_name
 
-    assert comm.address ==  "/home/user/file"
+    assert comm.address == "/home/user/file"
     mock_name.assert_called_with()
 
 
@@ -43,7 +43,7 @@ def test_filecomm_address_getter_no_name():
 
     del comm._filelike.name
 
-    assert comm.address ==  None
+    assert comm.address is None
 
 
 def test_filecomm_address_setter():
@@ -55,13 +55,13 @@ def test_filecomm_address_setter():
 def test_filecomm_terminator():
     comm = FileCommunicator(mock.MagicMock())
 
-    assert comm.terminator ==  "\n"
+    assert comm.terminator == "\n"
 
     comm.terminator = "*"
-    assert comm._terminator ==  "*"
+    assert comm._terminator == "*"
 
     comm.terminator = b"*"
-    assert comm._terminator ==  "*"
+    assert comm._terminator == "*"
 
 
 def test_filecomm_timeout_getter():
@@ -87,7 +87,7 @@ def test_filecomm_read_raw():
     comm = FileCommunicator(mock.MagicMock())
     comm._filelike.read = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\n"])
 
-    assert comm.read_raw() ==  b"abc"
+    assert comm.read_raw() == b"abc"
     comm._filelike.read.assert_has_calls([mock.call(1)] * 4)
     assert comm._filelike.read.call_count == 4
 
@@ -115,7 +115,7 @@ def test_filecomm_query():
     comm._testing = True  # to disable the delay in the _query function
     comm._filelike.read = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\n"])
 
-    assert comm._query("mock") ==  "abc"
+    assert comm._query("mock") == "abc"
 
 
 def test_filecomm_seek():
@@ -128,7 +128,7 @@ def test_filecomm_tell():
     comm = FileCommunicator(mock.MagicMock())
     comm._filelike.tell.return_value = 5
 
-    assert comm.tell() ==  5
+    assert comm.tell() == 5
     comm._filelike.tell.assert_called_with()
 
 

--- a/instruments/tests/test_comm/test_file.py
+++ b/instruments/tests/test_comm/test_file.py
@@ -8,7 +8,6 @@ Unit tests for the file communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 from .. import mock
 
@@ -34,7 +33,7 @@ def test_filecomm_address_getter():
     mock_name = mock.PropertyMock(return_value="/home/user/file")
     type(comm._filelike).name = mock_name
 
-    eq_(comm.address, "/home/user/file")
+    assert comm.address ==  "/home/user/file"
     mock_name.assert_called_with()
 
 
@@ -44,7 +43,7 @@ def test_filecomm_address_getter_no_name():
 
     del comm._filelike.name
 
-    eq_(comm.address, None)
+    assert comm.address ==  None
 
 
 def test_filecomm_address_setter():
@@ -56,13 +55,13 @@ def test_filecomm_address_setter():
 def test_filecomm_terminator():
     comm = FileCommunicator(mock.MagicMock())
 
-    eq_(comm.terminator, "\n")
+    assert comm.terminator ==  "\n"
 
     comm.terminator = "*"
-    eq_(comm._terminator, "*")
+    assert comm._terminator ==  "*"
 
     comm.terminator = b"*"
-    eq_(comm._terminator, "*")
+    assert comm._terminator ==  "*"
 
 
 def test_filecomm_timeout_getter():
@@ -88,7 +87,7 @@ def test_filecomm_read_raw():
     comm = FileCommunicator(mock.MagicMock())
     comm._filelike.read = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\n"])
 
-    eq_(comm.read_raw(), b"abc")
+    assert comm.read_raw() ==  b"abc"
     comm._filelike.read.assert_has_calls([mock.call(1)] * 4)
     assert comm._filelike.read.call_count == 4
 
@@ -116,7 +115,7 @@ def test_filecomm_query():
     comm._testing = True  # to disable the delay in the _query function
     comm._filelike.read = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\n"])
 
-    eq_(comm._query("mock"), "abc")
+    assert comm._query("mock") ==  "abc"
 
 
 def test_filecomm_seek():
@@ -129,7 +128,7 @@ def test_filecomm_tell():
     comm = FileCommunicator(mock.MagicMock())
     comm._filelike.tell.return_value = 5
 
-    eq_(comm.tell(), 5)
+    assert comm.tell() ==  5
     comm._filelike.tell.assert_called_with()
 
 

--- a/instruments/tests/test_comm/test_gi_gpibusb.py
+++ b/instruments/tests/test_comm/test_gi_gpibusb.py
@@ -9,12 +9,12 @@ Unit tests for the GI GPIBUSB communication layer
 from __future__ import absolute_import
 
 import pytest
-from .. import mock
 import serial
 import quantities as pq
 
 from instruments.abstract_instruments.comm import GPIBCommunicator, SerialCommunicator
 from instruments.tests import unit_eq
+from .. import mock
 
 # TEST CASES #################################################################
 
@@ -34,10 +34,10 @@ def test_gpibusbcomm_init_correct_values_new_firmware():
     mock_gpib.query.return_value = "5"
     comm = GPIBCommunicator(mock_gpib, 1)
 
-    assert comm._terminator ==  "\n"
-    assert comm._version ==  5
-    assert comm._eos ==  "\n"
-    assert comm._eoi ==  True
+    assert comm._terminator == "\n"
+    assert comm._version == 5
+    assert comm._eos == "\n"
+    assert comm._eoi is True
     unit_eq(comm._timeout, 1000 * pq.millisecond)
 
 
@@ -47,7 +47,7 @@ def test_gpibusbcomm_init_correct_values_old_firmware():
     mock_gpib.query.return_value = "4"
     comm = GPIBCommunicator(mock_gpib, 1)
 
-    assert comm._eos ==  10
+    assert comm._eos == 10
 
 
 def test_gpibusbcomm_address():
@@ -58,16 +58,16 @@ def test_gpibusbcomm_address():
     type(comm._file).address = port_name
 
     # Check that our address function is working
-    assert comm.address, (1 ==  "/dev/address")
+    assert comm.address == (1, "/dev/address")
     port_name.assert_called_with()
 
     # Able to set GPIB address
     comm.address = 5
-    assert comm._gpib_address ==  5
+    assert comm._gpib_address == 5
 
     # Able to set address with a list
     comm.address = [6, "/dev/foobar"]
-    assert comm._gpib_address ==  6
+    assert comm._gpib_address == 6
     port_name.assert_called_with("/dev/foobar")
 
 
@@ -90,14 +90,14 @@ def test_gpibusbcomm_eoi():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eoi = True
-    assert comm.eoi ==  True
-    assert comm._eoi ==  True
+    assert comm.eoi is True
+    assert comm._eoi is True
     comm._file.sendcmd.assert_called_with("++eoi 1")
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eoi = False
-    assert comm.eoi ==  False
-    assert comm._eoi ==  False
+    assert comm.eoi is False
+    assert comm._eoi is False
     comm._file.sendcmd.assert_called_with("++eoi 0")
 
 
@@ -107,14 +107,14 @@ def test_gpibusbcomm_eoi_old_firmware():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eoi = True
-    assert comm.eoi ==  True
-    assert comm._eoi ==  True
+    assert comm.eoi is True
+    assert comm._eoi is True
     comm._file.sendcmd.assert_called_with("+eoi:1")
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eoi = False
-    assert comm.eoi ==  False
-    assert comm._eoi ==  False
+    assert comm.eoi is False
+    assert comm._eoi is False
     comm._file.sendcmd.assert_called_with("+eoi:0")
 
 
@@ -131,8 +131,8 @@ def test_gpibusbcomm_eos_rn():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eos = "\r\n"
-    assert comm.eos ==  "\r\n"
-    assert comm._eos ==  "\r\n"
+    assert comm.eos == "\r\n"
+    assert comm._eos == "\r\n"
     comm._file.sendcmd.assert_called_with("++eos 0")
 
 
@@ -142,8 +142,8 @@ def test_gpibusbcomm_eos_r():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eos = "\r"
-    assert comm.eos ==  "\r"
-    assert comm._eos ==  "\r"
+    assert comm.eos == "\r"
+    assert comm._eos == "\r"
     comm._file.sendcmd.assert_called_with("++eos 1")
 
 
@@ -153,8 +153,8 @@ def test_gpibusbcomm_eos_n():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eos = "\n"
-    assert comm.eos ==  "\n"
-    assert comm._eos ==  "\n"
+    assert comm.eos == "\n"
+    assert comm._eos == "\n"
     comm._file.sendcmd.assert_called_with("++eos 2")
 
 
@@ -171,7 +171,7 @@ def test_gpibusbcomm_eos_old_firmware():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eos = "\n"
-    assert comm._eos ==  10
+    assert comm._eos == 10
     comm._file.sendcmd.assert_called_with("+eos:10")
 
 
@@ -180,16 +180,16 @@ def test_gpibusbcomm_terminator():
     comm._version = 5
 
     # Default terminator should be eoi
-    assert comm.terminator ==  "eoi"
-    assert comm._eoi ==  True
+    assert comm.terminator == "eoi"
+    assert comm._eoi is True
 
     comm.terminator = "\n"
-    assert comm.terminator ==  "\n"
-    assert comm._eoi ==  False
+    assert comm.terminator == "\n"
+    assert comm._eoi is False
 
     comm.terminator = "eoi"
-    assert comm.terminator ==  "eoi"
-    assert comm._eoi ==  True
+    assert comm.terminator == "eoi"
+    assert comm._eoi is True
 
 
 def test_gpibusbcomm_timeout():
@@ -215,7 +215,7 @@ def test_gpibusbcomm_read_raw():
     comm._version = 5
     comm._file.read_raw = mock.MagicMock(return_value=b"abc")
 
-    assert comm.read_raw(3) ==  b"abc"
+    assert comm.read_raw(3) == b"abc"
     comm._file.read_raw.assert_called_with(3)
 
 
@@ -257,7 +257,7 @@ def test_gpibusbcomm_query():
     comm._file.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    assert comm._query("mock?") ==  "answer"
+    assert comm._query("mock?") == "answer"
     comm.sendcmd.assert_called_with("mock?")
     comm._file.read.assert_called_with(-1)
 
@@ -273,7 +273,7 @@ def test_gpibusbcomm_query_no_question_mark():
     comm._file.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    assert comm._query("mock") ==  "answer"
+    assert comm._query("mock") == "answer"
     comm.sendcmd.assert_called_with("mock")
     comm._file.read.assert_called_with(-1)
     comm._file.sendcmd.assert_has_calls([mock.call("+read")])

--- a/instruments/tests/test_comm/test_gi_gpibusb.py
+++ b/instruments/tests/test_comm/test_gi_gpibusb.py
@@ -8,7 +8,6 @@ Unit tests for the GI GPIBUSB communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 from .. import mock
 import serial
@@ -35,10 +34,10 @@ def test_gpibusbcomm_init_correct_values_new_firmware():
     mock_gpib.query.return_value = "5"
     comm = GPIBCommunicator(mock_gpib, 1)
 
-    eq_(comm._terminator, "\n")
-    eq_(comm._version, 5)
-    eq_(comm._eos, "\n")
-    eq_(comm._eoi, True)
+    assert comm._terminator ==  "\n"
+    assert comm._version ==  5
+    assert comm._eos ==  "\n"
+    assert comm._eoi ==  True
     unit_eq(comm._timeout, 1000 * pq.millisecond)
 
 
@@ -48,7 +47,7 @@ def test_gpibusbcomm_init_correct_values_old_firmware():
     mock_gpib.query.return_value = "4"
     comm = GPIBCommunicator(mock_gpib, 1)
 
-    eq_(comm._eos, 10)
+    assert comm._eos ==  10
 
 
 def test_gpibusbcomm_address():
@@ -59,16 +58,16 @@ def test_gpibusbcomm_address():
     type(comm._file).address = port_name
 
     # Check that our address function is working
-    eq_(comm.address, (1, "/dev/address"))
+    assert comm.address, (1 ==  "/dev/address")
     port_name.assert_called_with()
 
     # Able to set GPIB address
     comm.address = 5
-    eq_(comm._gpib_address, 5)
+    assert comm._gpib_address ==  5
 
     # Able to set address with a list
     comm.address = [6, "/dev/foobar"]
-    eq_(comm._gpib_address, 6)
+    assert comm._gpib_address ==  6
     port_name.assert_called_with("/dev/foobar")
 
 
@@ -91,14 +90,14 @@ def test_gpibusbcomm_eoi():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eoi = True
-    eq_(comm.eoi, True)
-    eq_(comm._eoi, True)
+    assert comm.eoi ==  True
+    assert comm._eoi ==  True
     comm._file.sendcmd.assert_called_with("++eoi 1")
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eoi = False
-    eq_(comm.eoi, False)
-    eq_(comm._eoi, False)
+    assert comm.eoi ==  False
+    assert comm._eoi ==  False
     comm._file.sendcmd.assert_called_with("++eoi 0")
 
 
@@ -108,14 +107,14 @@ def test_gpibusbcomm_eoi_old_firmware():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eoi = True
-    eq_(comm.eoi, True)
-    eq_(comm._eoi, True)
+    assert comm.eoi ==  True
+    assert comm._eoi ==  True
     comm._file.sendcmd.assert_called_with("+eoi:1")
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eoi = False
-    eq_(comm.eoi, False)
-    eq_(comm._eoi, False)
+    assert comm.eoi ==  False
+    assert comm._eoi ==  False
     comm._file.sendcmd.assert_called_with("+eoi:0")
 
 
@@ -132,8 +131,8 @@ def test_gpibusbcomm_eos_rn():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eos = "\r\n"
-    eq_(comm.eos, "\r\n")
-    eq_(comm._eos, "\r\n")
+    assert comm.eos ==  "\r\n"
+    assert comm._eos ==  "\r\n"
     comm._file.sendcmd.assert_called_with("++eos 0")
 
 
@@ -143,8 +142,8 @@ def test_gpibusbcomm_eos_r():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eos = "\r"
-    eq_(comm.eos, "\r")
-    eq_(comm._eos, "\r")
+    assert comm.eos ==  "\r"
+    assert comm._eos ==  "\r"
     comm._file.sendcmd.assert_called_with("++eos 1")
 
 
@@ -154,8 +153,8 @@ def test_gpibusbcomm_eos_n():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eos = "\n"
-    eq_(comm.eos, "\n")
-    eq_(comm._eos, "\n")
+    assert comm.eos ==  "\n"
+    assert comm._eos ==  "\n"
     comm._file.sendcmd.assert_called_with("++eos 2")
 
 
@@ -172,7 +171,7 @@ def test_gpibusbcomm_eos_old_firmware():
 
     comm._file.sendcmd = mock.MagicMock()
     comm.eos = "\n"
-    eq_(comm._eos, 10)
+    assert comm._eos ==  10
     comm._file.sendcmd.assert_called_with("+eos:10")
 
 
@@ -181,16 +180,16 @@ def test_gpibusbcomm_terminator():
     comm._version = 5
 
     # Default terminator should be eoi
-    eq_(comm.terminator, "eoi")
-    eq_(comm._eoi, True)
+    assert comm.terminator ==  "eoi"
+    assert comm._eoi ==  True
 
     comm.terminator = "\n"
-    eq_(comm.terminator, "\n")
-    eq_(comm._eoi, False)
+    assert comm.terminator ==  "\n"
+    assert comm._eoi ==  False
 
     comm.terminator = "eoi"
-    eq_(comm.terminator, "eoi")
-    eq_(comm._eoi, True)
+    assert comm.terminator ==  "eoi"
+    assert comm._eoi ==  True
 
 
 def test_gpibusbcomm_timeout():
@@ -216,7 +215,7 @@ def test_gpibusbcomm_read_raw():
     comm._version = 5
     comm._file.read_raw = mock.MagicMock(return_value=b"abc")
 
-    eq_(comm.read_raw(3), b"abc")
+    assert comm.read_raw(3) ==  b"abc"
     comm._file.read_raw.assert_called_with(3)
 
 
@@ -258,7 +257,7 @@ def test_gpibusbcomm_query():
     comm._file.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    eq_(comm._query("mock?"), "answer")
+    assert comm._query("mock?") ==  "answer"
     comm.sendcmd.assert_called_with("mock?")
     comm._file.read.assert_called_with(-1)
 
@@ -274,7 +273,7 @@ def test_gpibusbcomm_query_no_question_mark():
     comm._file.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    eq_(comm._query("mock"), "answer")
+    assert comm._query("mock") ==  "answer"
     comm.sendcmd.assert_called_with("mock")
     comm._file.read.assert_called_with(-1)
     comm._file.sendcmd.assert_has_calls([mock.call("+read")])

--- a/instruments/tests/test_comm/test_gi_gpibusb.py
+++ b/instruments/tests/test_comm/test_gi_gpibusb.py
@@ -8,7 +8,8 @@ Unit tests for the GI GPIBUSB communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 from .. import mock
 import serial
 import quantities as pq
@@ -71,17 +72,17 @@ def test_gpibusbcomm_address():
     port_name.assert_called_with("/dev/foobar")
 
 
-@raises(ValueError)
 def test_gpibusbcomm_address_out_of_range():
-    comm = GPIBCommunicator(mock.MagicMock(), 1)
+    with pytest.raises(ValueError):
+        comm = GPIBCommunicator(mock.MagicMock(), 1)
 
-    comm.address = 31
+        comm.address = 31
 
 
-@raises(TypeError)
 def test_gpibusbcomm_address_wrong_type():
-    comm = GPIBCommunicator(mock.MagicMock(), 1)
-    comm.address = "derp"
+    with pytest.raises(TypeError):
+        comm = GPIBCommunicator(mock.MagicMock(), 1)
+        comm.address = "derp"
 
 
 def test_gpibusbcomm_eoi():
@@ -118,11 +119,11 @@ def test_gpibusbcomm_eoi_old_firmware():
     comm._file.sendcmd.assert_called_with("+eoi:0")
 
 
-@raises(TypeError)
 def test_gpibusbcomm_eoi_bad_type():
-    comm = GPIBCommunicator(mock.MagicMock(), 1)
-    comm._version = 5
-    comm.eoi = "abc"
+    with pytest.raises(TypeError):
+        comm = GPIBCommunicator(mock.MagicMock(), 1)
+        comm._version = 5
+        comm.eoi = "abc"
 
 
 def test_gpibusbcomm_eos_rn():
@@ -158,11 +159,11 @@ def test_gpibusbcomm_eos_n():
     comm._file.sendcmd.assert_called_with("++eos 2")
 
 
-@raises(ValueError)
 def test_gpibusbcomm_eos_invalid():
-    comm = GPIBCommunicator(mock.MagicMock(), 1)
-    comm._version = 5
-    comm.eos = "*"
+    with pytest.raises(ValueError):
+        comm = GPIBCommunicator(mock.MagicMock(), 1)
+        comm._version = 5
+        comm.eos = "*"
 
 
 def test_gpibusbcomm_eos_old_firmware():

--- a/instruments/tests/test_comm/test_gi_gpibusb.py
+++ b/instruments/tests/test_comm/test_gi_gpibusb.py
@@ -9,7 +9,7 @@ Unit tests for the GI GPIBUSB communication layer
 from __future__ import absolute_import
 
 from nose.tools import raises, eq_
-import mock
+from .. import mock
 import serial
 import quantities as pq
 

--- a/instruments/tests/test_comm/test_loopback.py
+++ b/instruments/tests/test_comm/test_loopback.py
@@ -8,7 +8,8 @@ Unit tests for the loopback communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 from .. import mock
 
 from instruments.abstract_instruments.comm import LoopbackCommunicator
@@ -132,16 +133,16 @@ def test_loopbackcomm_query():
     comm.read.assert_called_with(10)
 
 
-@raises(NotImplementedError)
 def test_loopbackcomm_seek():
-    comm = LoopbackCommunicator()
-    comm.seek(1)
+    with pytest.raises(NotImplementedError):
+        comm = LoopbackCommunicator()
+        comm.seek(1)
 
 
-@raises(NotImplementedError)
 def test_loopbackcomm_tell():
-    comm = LoopbackCommunicator()
-    comm.tell()
+    with pytest.raises(NotImplementedError):
+        comm = LoopbackCommunicator()
+        comm.tell()
 
 
 def test_loopbackcomm_flush_input():

--- a/instruments/tests/test_comm/test_loopback.py
+++ b/instruments/tests/test_comm/test_loopback.py
@@ -9,7 +9,7 @@ Unit tests for the loopback communication layer
 from __future__ import absolute_import
 
 from nose.tools import raises, eq_
-import mock
+from .. import mock
 
 from instruments.abstract_instruments.comm import LoopbackCommunicator
 

--- a/instruments/tests/test_comm/test_loopback.py
+++ b/instruments/tests/test_comm/test_loopback.py
@@ -9,9 +9,9 @@ Unit tests for the loopback communication layer
 from __future__ import absolute_import
 
 import pytest
-from .. import mock
 
 from instruments.abstract_instruments.comm import LoopbackCommunicator
+from .. import mock
 
 # TEST CASES #################################################################
 
@@ -34,7 +34,7 @@ def test_loopbackcomm_address(mock_sys):
     comm._conn = mock.MagicMock()
 
     # Check that our address function is working
-    assert comm.address ==  "address"
+    assert comm.address == "address"
     mock_name.assert_called_with()
 
 
@@ -42,28 +42,28 @@ def test_loopbackcomm_terminator():
     comm = LoopbackCommunicator()
 
     # Default terminator should be \n
-    assert comm.terminator ==  "\n"
+    assert comm.terminator == "\n"
 
     comm.terminator = b"*"
-    assert comm.terminator ==  "*"
-    assert comm._terminator ==  "*"
+    assert comm.terminator == "*"
+    assert comm._terminator == "*"
 
     comm.terminator = u"\r"
-    assert comm.terminator ==  u"\r"
-    assert comm._terminator ==  u"\r"
+    assert comm.terminator == u"\r"
+    assert comm._terminator == u"\r"
 
     comm.terminator = "\r\n"
-    assert comm.terminator ==  "\r\n"
-    assert comm._terminator ==  "\r\n"
+    assert comm.terminator == "\r\n"
+    assert comm._terminator == "\r\n"
 
 
 def test_loopbackcomm_timeout():
     comm = LoopbackCommunicator()
 
-    assert comm.timeout ==  0
+    assert comm.timeout == 0
 
     comm.timeout = 10
-    assert comm.timeout ==  0  # setting should be ignored
+    assert comm.timeout == 0  # setting should be ignored
 
 
 def test_loopbackcomm_close():
@@ -79,7 +79,7 @@ def test_loopbackcomm_read_raw():
     mock_stdin.read.side_effect = [b"a", b"b", b"c", b"\n"]
     comm = LoopbackCommunicator(stdin=mock_stdin)
 
-    assert comm.read_raw() ==  b"abc"
+    assert comm.read_raw() == b"abc"
     mock_stdin.read.assert_has_calls([mock.call(1)]*4)
     assert mock_stdin.read.call_count == 4
 
@@ -94,7 +94,7 @@ def test_loopbackcomm_read_raw_2char_terminator():
     comm = LoopbackCommunicator(stdin=mock_stdin)
     comm._terminator = "\r\n"
 
-    assert comm.read_raw() ==  b"abc"
+    assert comm.read_raw() == b"abc"
     mock_stdin.read.assert_has_calls([mock.call(1)]*5)
     assert mock_stdin.read.call_count == 5
 
@@ -124,7 +124,7 @@ def test_loopbackcomm_query():
     comm.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    assert comm._query("mock") ==  "answer"
+    assert comm._query("mock") == "answer"
     comm.sendcmd.assert_called_with("mock")
     comm.read.assert_called_with(-1)
 

--- a/instruments/tests/test_comm/test_loopback.py
+++ b/instruments/tests/test_comm/test_loopback.py
@@ -8,7 +8,6 @@ Unit tests for the loopback communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 from .. import mock
 
@@ -35,7 +34,7 @@ def test_loopbackcomm_address(mock_sys):
     comm._conn = mock.MagicMock()
 
     # Check that our address function is working
-    eq_(comm.address, "address")
+    assert comm.address ==  "address"
     mock_name.assert_called_with()
 
 
@@ -43,28 +42,28 @@ def test_loopbackcomm_terminator():
     comm = LoopbackCommunicator()
 
     # Default terminator should be \n
-    eq_(comm.terminator, "\n")
+    assert comm.terminator ==  "\n"
 
     comm.terminator = b"*"
-    eq_(comm.terminator, "*")
-    eq_(comm._terminator, "*")
+    assert comm.terminator ==  "*"
+    assert comm._terminator ==  "*"
 
     comm.terminator = u"\r"
-    eq_(comm.terminator, u"\r")
-    eq_(comm._terminator, u"\r")
+    assert comm.terminator ==  u"\r"
+    assert comm._terminator ==  u"\r"
 
     comm.terminator = "\r\n"
-    eq_(comm.terminator, "\r\n")
-    eq_(comm._terminator, "\r\n")
+    assert comm.terminator ==  "\r\n"
+    assert comm._terminator ==  "\r\n"
 
 
 def test_loopbackcomm_timeout():
     comm = LoopbackCommunicator()
 
-    eq_(comm.timeout, 0)
+    assert comm.timeout ==  0
 
     comm.timeout = 10
-    eq_(comm.timeout, 0)  # setting should be ignored
+    assert comm.timeout ==  0  # setting should be ignored
 
 
 def test_loopbackcomm_close():
@@ -80,7 +79,7 @@ def test_loopbackcomm_read_raw():
     mock_stdin.read.side_effect = [b"a", b"b", b"c", b"\n"]
     comm = LoopbackCommunicator(stdin=mock_stdin)
 
-    eq_(comm.read_raw(), b"abc")
+    assert comm.read_raw() ==  b"abc"
     mock_stdin.read.assert_has_calls([mock.call(1)]*4)
     assert mock_stdin.read.call_count == 4
 
@@ -95,7 +94,7 @@ def test_loopbackcomm_read_raw_2char_terminator():
     comm = LoopbackCommunicator(stdin=mock_stdin)
     comm._terminator = "\r\n"
 
-    eq_(comm.read_raw(), b"abc")
+    assert comm.read_raw() ==  b"abc"
     mock_stdin.read.assert_has_calls([mock.call(1)]*5)
     assert mock_stdin.read.call_count == 5
 
@@ -125,7 +124,7 @@ def test_loopbackcomm_query():
     comm.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    eq_(comm._query("mock"), "answer")
+    assert comm._query("mock") ==  "answer"
     comm.sendcmd.assert_called_with("mock")
     comm.read.assert_called_with(-1)
 

--- a/instruments/tests/test_comm/test_serial.py
+++ b/instruments/tests/test_comm/test_serial.py
@@ -9,12 +9,12 @@ Unit tests for the serial communication layer
 from __future__ import absolute_import
 
 import pytest
-from .. import mock
 import serial
 import quantities as pq
 
 from instruments.abstract_instruments.comm import SerialCommunicator
 from instruments.tests import unit_eq
+from .. import mock
 
 # TEST CASES #################################################################
 
@@ -40,7 +40,7 @@ def test_serialcomm_address():
     type(comm._conn).port = port_name
 
     # Check that our address function is working
-    assert comm.address ==  "/dev/address"
+    assert comm.address == "/dev/address"
     port_name.assert_called_with()
 
 
@@ -48,14 +48,14 @@ def test_serialcomm_terminator():
     comm = SerialCommunicator(serial.Serial())
 
     # Default terminator should be \n
-    assert comm.terminator ==  "\n"
+    assert comm.terminator == "\n"
 
     comm.terminator = "*"
-    assert comm.terminator ==  "*"
+    assert comm.terminator == "*"
 
     comm.terminator = "\r\n"
-    assert comm.terminator ==  "\r\n"
-    assert comm._terminator ==  "\r\n"
+    assert comm.terminator == "\r\n"
+    assert comm._terminator == "\r\n"
 
 
 def test_serialcomm_timeout():
@@ -89,7 +89,7 @@ def test_serialcomm_read_raw():
     comm._conn = mock.MagicMock()
     comm._conn.read = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\n"])
 
-    assert comm.read_raw() ==  b"abc"
+    assert comm.read_raw() == b"abc"
     comm._conn.read.assert_has_calls([mock.call(1)]*4)
     assert comm._conn.read.call_count == 4
 
@@ -104,7 +104,7 @@ def test_loopbackcomm_read_raw_2char_terminator():
     comm._conn.read = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\r", b"\n"])
     comm._terminator = "\r\n"
 
-    assert comm.read_raw() ==  b"abc"
+    assert comm.read_raw() == b"abc"
     comm._conn.read.assert_has_calls([mock.call(1)] * 5)
     assert comm._conn.read.call_count == 5
 
@@ -140,7 +140,7 @@ def test_serialcomm_query():
     comm.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    assert comm._query("mock") ==  "answer"
+    assert comm._query("mock") == "answer"
     comm.sendcmd.assert_called_with("mock")
     comm.read.assert_called_with(-1)
 

--- a/instruments/tests/test_comm/test_serial.py
+++ b/instruments/tests/test_comm/test_serial.py
@@ -9,7 +9,7 @@ Unit tests for the serial communication layer
 from __future__ import absolute_import
 
 from nose.tools import raises, eq_
-import mock
+from .. import mock
 import serial
 import quantities as pq
 

--- a/instruments/tests/test_comm/test_serial.py
+++ b/instruments/tests/test_comm/test_serial.py
@@ -8,7 +8,8 @@ Unit tests for the serial communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 from .. import mock
 import serial
 import quantities as pq
@@ -26,9 +27,9 @@ def test_serialcomm_init():
     assert isinstance(comm._conn, serial.Serial) is True
 
 
-@raises(TypeError)
 def test_serialcomm_init_wrong_filelike():
-    _ = SerialCommunicator("derp")
+    with pytest.raises(TypeError):
+        _ = SerialCommunicator("derp")
 
 
 def test_serialcomm_address():
@@ -109,13 +110,13 @@ def test_loopbackcomm_read_raw_2char_terminator():
     assert comm._conn.read.call_count == 5
 
 
-@raises(IOError)
 def test_serialcomm_read_raw_timeout():
-    comm = SerialCommunicator(serial.Serial())
-    comm._conn = mock.MagicMock()
-    comm._conn.read = mock.MagicMock(side_effect=[b"a", b"b", b""])
+    with pytest.raises(IOError):
+        comm = SerialCommunicator(serial.Serial())
+        comm._conn = mock.MagicMock()
+        comm._conn.read = mock.MagicMock(side_effect=[b"a", b"b", b""])
 
-    _ = comm.read_raw(-1)
+        _ = comm.read_raw(-1)
 
 
 def test_serialcomm_write_raw():
@@ -148,16 +149,16 @@ def test_serialcomm_query():
     comm.read.assert_called_with(10)
 
 
-@raises(NotImplementedError)
 def test_serialcomm_seek():
-    comm = SerialCommunicator(serial.Serial())
-    comm.seek(1)
+    with pytest.raises(NotImplementedError):
+        comm = SerialCommunicator(serial.Serial())
+        comm.seek(1)
 
 
-@raises(NotImplementedError)
 def test_serialcomm_tell():
-    comm = SerialCommunicator(serial.Serial())
-    comm.tell()
+    with pytest.raises(NotImplementedError):
+        comm = SerialCommunicator(serial.Serial())
+        comm.tell()
 
 
 def test_serialcomm_flush_input():

--- a/instruments/tests/test_comm/test_serial.py
+++ b/instruments/tests/test_comm/test_serial.py
@@ -8,7 +8,6 @@ Unit tests for the serial communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 from .. import mock
 import serial
@@ -41,7 +40,7 @@ def test_serialcomm_address():
     type(comm._conn).port = port_name
 
     # Check that our address function is working
-    eq_(comm.address, "/dev/address")
+    assert comm.address ==  "/dev/address"
     port_name.assert_called_with()
 
 
@@ -49,14 +48,14 @@ def test_serialcomm_terminator():
     comm = SerialCommunicator(serial.Serial())
 
     # Default terminator should be \n
-    eq_(comm.terminator, "\n")
+    assert comm.terminator ==  "\n"
 
     comm.terminator = "*"
-    eq_(comm.terminator, "*")
+    assert comm.terminator ==  "*"
 
     comm.terminator = "\r\n"
-    eq_(comm.terminator, "\r\n")
-    eq_(comm._terminator, "\r\n")
+    assert comm.terminator ==  "\r\n"
+    assert comm._terminator ==  "\r\n"
 
 
 def test_serialcomm_timeout():
@@ -90,7 +89,7 @@ def test_serialcomm_read_raw():
     comm._conn = mock.MagicMock()
     comm._conn.read = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\n"])
 
-    eq_(comm.read_raw(), b"abc")
+    assert comm.read_raw() ==  b"abc"
     comm._conn.read.assert_has_calls([mock.call(1)]*4)
     assert comm._conn.read.call_count == 4
 
@@ -105,7 +104,7 @@ def test_loopbackcomm_read_raw_2char_terminator():
     comm._conn.read = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\r", b"\n"])
     comm._terminator = "\r\n"
 
-    eq_(comm.read_raw(), b"abc")
+    assert comm.read_raw() ==  b"abc"
     comm._conn.read.assert_has_calls([mock.call(1)] * 5)
     assert comm._conn.read.call_count == 5
 
@@ -141,7 +140,7 @@ def test_serialcomm_query():
     comm.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    eq_(comm._query("mock"), "answer")
+    assert comm._query("mock") ==  "answer"
     comm.sendcmd.assert_called_with("mock")
     comm.read.assert_called_with(-1)
 

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -10,7 +10,8 @@ from __future__ import absolute_import
 
 import socket
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 from .. import mock
 import quantities as pq
 
@@ -29,9 +30,9 @@ def test_socketcomm_init():
     assert comm._conn == socket_object
 
 
-@raises(TypeError)
 def test_socketcomm_init_wrong_filelike():
-    _ = SocketCommunicator("derp")
+    with pytest.raises(TypeError):
+        _ = SocketCommunicator("derp")
 
 
 def test_socketcomm_address():
@@ -43,10 +44,10 @@ def test_socketcomm_address():
     comm._conn.getpeername.assert_called_with()
 
 
-@raises(NotImplementedError)
 def test_socketcomm_address_setting():
-    comm = SocketCommunicator(socket.socket())
-    comm.address = "foobar"
+    with pytest.raises(NotImplementedError):
+        comm = SocketCommunicator(socket.socket())
+        comm.address = "foobar"
 
 
 def test_socketcomm_terminator():
@@ -117,13 +118,13 @@ def test_loopbackcomm_read_raw_2char_terminator():
     assert comm._conn.recv.call_count == 5
 
 
-@raises(IOError)
 def test_serialcomm_read_raw_timeout():
-    comm = SocketCommunicator(socket.socket())
-    comm._conn = mock.MagicMock()
-    comm._conn.recv = mock.MagicMock(side_effect=[b"a", b"b", b""])
+    with pytest.raises(IOError):
+        comm = SocketCommunicator(socket.socket())
+        comm._conn = mock.MagicMock()
+        comm._conn.recv = mock.MagicMock(side_effect=[b"a", b"b", b""])
 
-    _ = comm.read_raw(-1)
+        _ = comm.read_raw(-1)
 
 
 def test_socketcomm_write_raw():
@@ -156,16 +157,16 @@ def test_socketcomm_query():
     comm.read.assert_called_with(10)
 
 
-@raises(NotImplementedError)
 def test_socketcomm_seek():
-    comm = SocketCommunicator(socket.socket())
-    comm.seek(1)
+    with pytest.raises(NotImplementedError):
+        comm = SocketCommunicator(socket.socket())
+        comm.seek(1)
 
 
-@raises(NotImplementedError)
 def test_socketcomm_tell():
-    comm = SocketCommunicator(socket.socket())
-    comm.tell()
+    with pytest.raises(NotImplementedError):
+        comm = SocketCommunicator(socket.socket())
+        comm.tell()
 
 
 def test_socketcomm_flush_input():

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -11,11 +11,11 @@ from __future__ import absolute_import
 import socket
 
 import pytest
-from .. import mock
 import quantities as pq
 
 from instruments.abstract_instruments.comm import SocketCommunicator
 from instruments.tests import unit_eq
+from .. import mock
 
 # TEST CASES #################################################################
 
@@ -39,7 +39,7 @@ def test_socketcomm_address():
     comm._conn = mock.MagicMock()
     comm._conn.getpeername.return_value = "127.0.0.1", 1234
 
-    assert comm.address, ("127.0.0.1" ==  1234)
+    assert comm.address == ("127.0.0.1", 1234)
     comm._conn.getpeername.assert_called_with()
 
 
@@ -53,19 +53,19 @@ def test_socketcomm_terminator():
     comm = SocketCommunicator(socket.socket())
 
     # Default terminator should be \n
-    assert comm.terminator ==  "\n"
+    assert comm.terminator == "\n"
 
     comm.terminator = b"*"
-    assert comm.terminator ==  "*"
-    assert comm._terminator ==  "*"
+    assert comm.terminator == "*"
+    assert comm._terminator == "*"
 
     comm.terminator = u"\r"
-    assert comm.terminator ==  u"\r"
-    assert comm._terminator ==  u"\r"
+    assert comm.terminator == u"\r"
+    assert comm._terminator == u"\r"
 
     comm.terminator = "\r\n"
-    assert comm.terminator ==  "\r\n"
-    assert comm._terminator ==  "\r\n"
+    assert comm.terminator == "\r\n"
+    assert comm._terminator == "\r\n"
 
 
 def test_socketcomm_timeout():
@@ -97,7 +97,7 @@ def test_socketcomm_read_raw():
     comm._conn = mock.MagicMock()
     comm._conn.recv = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\n"])
 
-    assert comm.read_raw() ==  b"abc"
+    assert comm.read_raw() == b"abc"
     comm._conn.recv.assert_has_calls([mock.call(1)]*4)
     assert comm._conn.recv.call_count == 4
 
@@ -112,7 +112,7 @@ def test_loopbackcomm_read_raw_2char_terminator():
     comm._conn.recv = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\r", b"\n"])
     comm._terminator = "\r\n"
 
-    assert comm.read_raw() ==  b"abc"
+    assert comm.read_raw() == b"abc"
     comm._conn.recv.assert_has_calls([mock.call(1)] * 5)
     assert comm._conn.recv.call_count == 5
 
@@ -148,7 +148,7 @@ def test_socketcomm_query():
     comm.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    assert comm._query("mock") ==  "answer"
+    assert comm._query("mock") == "answer"
     comm.sendcmd.assert_called_with("mock")
     comm.read.assert_called_with(-1)
 

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import socket
 
 from nose.tools import raises, eq_
-import mock
+from .. import mock
 import quantities as pq
 
 from instruments.abstract_instruments.comm import SocketCommunicator

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import
 
 import socket
 
-from nose.tools import eq_
 import pytest
 from .. import mock
 import quantities as pq
@@ -40,7 +39,7 @@ def test_socketcomm_address():
     comm._conn = mock.MagicMock()
     comm._conn.getpeername.return_value = "127.0.0.1", 1234
 
-    eq_(comm.address, ("127.0.0.1", 1234))
+    assert comm.address, ("127.0.0.1" ==  1234)
     comm._conn.getpeername.assert_called_with()
 
 
@@ -54,19 +53,19 @@ def test_socketcomm_terminator():
     comm = SocketCommunicator(socket.socket())
 
     # Default terminator should be \n
-    eq_(comm.terminator, "\n")
+    assert comm.terminator ==  "\n"
 
     comm.terminator = b"*"
-    eq_(comm.terminator, "*")
-    eq_(comm._terminator, "*")
+    assert comm.terminator ==  "*"
+    assert comm._terminator ==  "*"
 
     comm.terminator = u"\r"
-    eq_(comm.terminator, u"\r")
-    eq_(comm._terminator, u"\r")
+    assert comm.terminator ==  u"\r"
+    assert comm._terminator ==  u"\r"
 
     comm.terminator = "\r\n"
-    eq_(comm.terminator, "\r\n")
-    eq_(comm._terminator, "\r\n")
+    assert comm.terminator ==  "\r\n"
+    assert comm._terminator ==  "\r\n"
 
 
 def test_socketcomm_timeout():
@@ -98,7 +97,7 @@ def test_socketcomm_read_raw():
     comm._conn = mock.MagicMock()
     comm._conn.recv = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\n"])
 
-    eq_(comm.read_raw(), b"abc")
+    assert comm.read_raw() ==  b"abc"
     comm._conn.recv.assert_has_calls([mock.call(1)]*4)
     assert comm._conn.recv.call_count == 4
 
@@ -113,7 +112,7 @@ def test_loopbackcomm_read_raw_2char_terminator():
     comm._conn.recv = mock.MagicMock(side_effect=[b"a", b"b", b"c", b"\r", b"\n"])
     comm._terminator = "\r\n"
 
-    eq_(comm.read_raw(), b"abc")
+    assert comm.read_raw() ==  b"abc"
     comm._conn.recv.assert_has_calls([mock.call(1)] * 5)
     assert comm._conn.recv.call_count == 5
 
@@ -149,7 +148,7 @@ def test_socketcomm_query():
     comm.read = mock.MagicMock(return_value="answer")
     comm.sendcmd = mock.MagicMock()
 
-    eq_(comm._query("mock"), "answer")
+    assert comm._query("mock") ==  "answer"
     comm.sendcmd.assert_called_with("mock")
     comm.read.assert_called_with(-1)
 

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -9,7 +9,7 @@ Unit tests for the USBTMC communication layer
 from __future__ import absolute_import
 
 from nose.tools import raises, eq_
-import mock
+from .. import mock
 
 import quantities as pq
 from numpy import array

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -9,13 +9,13 @@ Unit tests for the USBTMC communication layer
 from __future__ import absolute_import
 
 import pytest
-from .. import mock
 
 import quantities as pq
 from numpy import array
 
 from instruments.abstract_instruments.comm import USBTMCCommunicator
 from instruments.tests import unit_eq
+from .. import mock
 
 # TEST CASES #################################################################
 
@@ -43,7 +43,7 @@ def test_usbtmccomm_terminator_getter(mock_usbtmc):
     term_char = mock.PropertyMock(return_value=10)
     type(comm._filelike).term_char = term_char
 
-    assert comm.terminator ==  "\n"
+    assert comm.terminator == "\n"
     term_char.assert_called_with()
 
 
@@ -55,11 +55,11 @@ def test_usbtmccomm_terminator_setter(mock_usbtmc):
     type(comm._filelike).term_char = term_char
 
     comm.terminator = "*"
-    assert comm._terminator ==  "*"
+    assert comm._terminator == "*"
     term_char.assert_called_with(42)
 
     comm.terminator = b"*"
-    assert comm._terminator ==  "*"
+    assert comm._terminator == "*"
     term_char.assert_called_with(42)
 
 
@@ -93,7 +93,7 @@ def test_usbtmccomm_read_raw(mock_usbtmc):
     comm = USBTMCCommunicator()
     comm._filelike.read_raw = mock.MagicMock(return_value=b"abc")
 
-    assert comm.read_raw() ==  b"abc"
+    assert comm.read_raw() == b"abc"
     comm._filelike.read_raw.assert_called_with(num=-1)
     assert comm._filelike.read_raw.call_count == 1
 
@@ -124,7 +124,7 @@ def test_usbtmccomm_query(mock_usbtmc):
     comm = USBTMCCommunicator()
     comm._filelike.ask = mock.MagicMock(return_value="answer")
 
-    assert comm._query("mock") ==  "answer"
+    assert comm._query("mock") == "answer"
     comm._filelike.ask.assert_called_with("mock", num=-1, encoding="utf-8")
 
     comm._query("mock", size=10)

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -8,7 +8,6 @@ Unit tests for the USBTMC communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 from .. import mock
 
@@ -44,7 +43,7 @@ def test_usbtmccomm_terminator_getter(mock_usbtmc):
     term_char = mock.PropertyMock(return_value=10)
     type(comm._filelike).term_char = term_char
 
-    eq_(comm.terminator, "\n")
+    assert comm.terminator ==  "\n"
     term_char.assert_called_with()
 
 
@@ -56,11 +55,11 @@ def test_usbtmccomm_terminator_setter(mock_usbtmc):
     type(comm._filelike).term_char = term_char
 
     comm.terminator = "*"
-    eq_(comm._terminator, "*")
+    assert comm._terminator ==  "*"
     term_char.assert_called_with(42)
 
     comm.terminator = b"*"
-    eq_(comm._terminator, "*")
+    assert comm._terminator ==  "*"
     term_char.assert_called_with(42)
 
 
@@ -94,7 +93,7 @@ def test_usbtmccomm_read_raw(mock_usbtmc):
     comm = USBTMCCommunicator()
     comm._filelike.read_raw = mock.MagicMock(return_value=b"abc")
 
-    eq_(comm.read_raw(), b"abc")
+    assert comm.read_raw() ==  b"abc"
     comm._filelike.read_raw.assert_called_with(num=-1)
     assert comm._filelike.read_raw.call_count == 1
 
@@ -125,7 +124,7 @@ def test_usbtmccomm_query(mock_usbtmc):
     comm = USBTMCCommunicator()
     comm._filelike.ask = mock.MagicMock(return_value="answer")
 
-    eq_(comm._query("mock"), "answer")
+    assert comm._query("mock") ==  "answer"
     comm._filelike.ask.assert_called_with("mock", num=-1, encoding="utf-8")
 
     comm._query("mock", size=10)

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -8,7 +8,8 @@ Unit tests for the USBTMC communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 from .. import mock
 
 import quantities as pq
@@ -30,10 +31,10 @@ def test_usbtmccomm_init(mock_usbtmc):
     mock_usbtmc.Instrument.assert_called_with("foobar", var1=123)
 
 
-@raises(ImportError)
 @mock.patch(patch_path, new=None)
 def test_usbtmccomm_init_missing_module():
-    _ = USBTMCCommunicator()
+    with pytest.raises(ImportError):
+        _ = USBTMCCommunicator()
 
 
 @mock.patch(patch_path)
@@ -131,18 +132,18 @@ def test_usbtmccomm_query(mock_usbtmc):
     comm._filelike.ask.assert_called_with("mock", num=10, encoding="utf-8")
 
 
-@raises(NotImplementedError)
 @mock.patch(patch_path)
 def test_usbtmccomm_seek(mock_usbtmc):
-    comm = USBTMCCommunicator()
-    comm.seek(1)
+    with pytest.raises(NotImplementedError):
+        comm = USBTMCCommunicator()
+        comm.seek(1)
 
 
-@raises(NotImplementedError)
 @mock.patch(patch_path)
 def test_usbtmccomm_tell(mock_usbtmc):
-    comm = USBTMCCommunicator()
-    comm.tell()
+    with pytest.raises(NotImplementedError):
+        comm = USBTMCCommunicator()
+        comm.tell()
 
 
 @mock.patch(patch_path)

--- a/instruments/tests/test_comm/test_vxi11.py
+++ b/instruments/tests/test_comm/test_vxi11.py
@@ -8,7 +8,6 @@ Unit tests for the VXI11 communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 from .. import mock
 
@@ -46,7 +45,7 @@ def test_vxi11comm_address(mock_vxi11):
     type(comm._inst).name = name
 
     # Check that our address function is working
-    eq_(comm.address, ["host", "name"])
+    assert comm.address, ["host" ==  "name"]
     host.assert_called_with()
     name.assert_called_with()
 
@@ -58,7 +57,7 @@ def test_vxi11comm_terminator(mock_vxi11):
     term_char = mock.PropertyMock(return_value="\n")
     type(comm._inst).term_char = term_char
 
-    eq_(comm.terminator, "\n")
+    assert comm.terminator ==  "\n"
     term_char.assert_called_with()
 
     comm.terminator = "*"
@@ -72,7 +71,7 @@ def test_vxi11comm_timeout(mock_vxi11):
     timeout = mock.PropertyMock(return_value=30)
     type(comm._inst).timeout = timeout
 
-    eq_(comm.timeout, 30)
+    assert comm.timeout ==  30
     timeout.assert_called_with()
 
     comm.timeout = 10
@@ -101,7 +100,7 @@ def test_vxi11comm_read(mock_vxi11):
     comm = VXI11Communicator()
     comm._inst.read_raw.return_value = b"mock"
 
-    eq_(comm.read_raw(), b"mock")
+    assert comm.read_raw() ==  b"mock"
     comm._inst.read_raw.assert_called_with(num=-1)
 
     comm.read(10)
@@ -129,7 +128,7 @@ def test_vxi11comm_query(mock_vxi11):
     comm = VXI11Communicator()
     comm._inst.ask.return_value = "answer"
 
-    eq_(comm._query("mock"), "answer")
+    assert comm._query("mock") ==  "answer"
     comm._inst.ask.assert_called_with("mock", num=-1)
 
     comm._query("mock", size=10)

--- a/instruments/tests/test_comm/test_vxi11.py
+++ b/instruments/tests/test_comm/test_vxi11.py
@@ -9,7 +9,7 @@ Unit tests for the VXI11 communication layer
 from __future__ import absolute_import
 
 from nose.tools import raises, eq_
-import mock
+from .. import mock
 
 from instruments.abstract_instruments.comm import VXI11Communicator
 

--- a/instruments/tests/test_comm/test_vxi11.py
+++ b/instruments/tests/test_comm/test_vxi11.py
@@ -8,7 +8,8 @@ Unit tests for the VXI11 communication layer
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 from .. import mock
 
 from instruments.abstract_instruments.comm import VXI11Communicator
@@ -26,10 +27,10 @@ def test_vxi11comm_init(mock_vxi11):
     mock_vxi11.Instrument.assert_called_with("host")
 
 
-@raises(ImportError)
 @mock.patch(import_base, new=None)
 def test_vxi11comm_init_no_vxi11():
-    _ = VXI11Communicator("host")
+    with pytest.raises(ImportError):
+        _ = VXI11Communicator("host")
 
 
 @mock.patch(import_base)
@@ -135,22 +136,22 @@ def test_vxi11comm_query(mock_vxi11):
     comm._inst.ask.assert_called_with("mock", num=10)
 
 
-@raises(NotImplementedError)
 @mock.patch(import_base)
 def test_vxi11comm_seek(mock_vxi11):
-    comm = VXI11Communicator()
-    comm.seek(1)
+    with pytest.raises(NotImplementedError):
+        comm = VXI11Communicator()
+        comm.seek(1)
 
 
-@raises(NotImplementedError)
 @mock.patch(import_base)
 def test_vxi11comm_tell(mock_vxi11):
-    comm = VXI11Communicator()
-    comm.tell()
+    with pytest.raises(NotImplementedError):
+        comm = VXI11Communicator()
+        comm.tell()
 
 
-@raises(NotImplementedError)
 @mock.patch(import_base)
 def test_vxi11comm_flush(mock_vxi11):
-    comm = VXI11Communicator()
-    comm.flush_input()
+    with pytest.raises(NotImplementedError):
+        comm = VXI11Communicator()
+        comm.flush_input()

--- a/instruments/tests/test_comm/test_vxi11.py
+++ b/instruments/tests/test_comm/test_vxi11.py
@@ -9,9 +9,9 @@ Unit tests for the VXI11 communication layer
 from __future__ import absolute_import
 
 import pytest
-from .. import mock
 
 from instruments.abstract_instruments.comm import VXI11Communicator
+from .. import mock
 
 # TEST CASES #################################################################
 
@@ -45,7 +45,7 @@ def test_vxi11comm_address(mock_vxi11):
     type(comm._inst).name = name
 
     # Check that our address function is working
-    assert comm.address, ["host" ==  "name"]
+    assert comm.address == ["host", "name"]
     host.assert_called_with()
     name.assert_called_with()
 
@@ -57,7 +57,7 @@ def test_vxi11comm_terminator(mock_vxi11):
     term_char = mock.PropertyMock(return_value="\n")
     type(comm._inst).term_char = term_char
 
-    assert comm.terminator ==  "\n"
+    assert comm.terminator == "\n"
     term_char.assert_called_with()
 
     comm.terminator = "*"
@@ -71,7 +71,7 @@ def test_vxi11comm_timeout(mock_vxi11):
     timeout = mock.PropertyMock(return_value=30)
     type(comm._inst).timeout = timeout
 
-    assert comm.timeout ==  30
+    assert comm.timeout == 30
     timeout.assert_called_with()
 
     comm.timeout = 10
@@ -100,7 +100,7 @@ def test_vxi11comm_read(mock_vxi11):
     comm = VXI11Communicator()
     comm._inst.read_raw.return_value = b"mock"
 
-    assert comm.read_raw() ==  b"mock"
+    assert comm.read_raw() == b"mock"
     comm._inst.read_raw.assert_called_with(num=-1)
 
     comm.read(10)
@@ -128,7 +128,7 @@ def test_vxi11comm_query(mock_vxi11):
     comm = VXI11Communicator()
     comm._inst.ask.return_value = "answer"
 
-    assert comm._query("mock") ==  "answer"
+    assert comm._query("mock") == "answer"
     comm._inst.ask.assert_called_with("mock", num=-1)
 
     comm._query("mock", size=10)

--- a/instruments/tests/test_holzworth/test_holzworth_hs9000.py
+++ b/instruments/tests/test_holzworth/test_holzworth_hs9000.py
@@ -9,11 +9,11 @@ Unit tests for the Holzworth HS9000
 from __future__ import absolute_import
 
 import quantities as pq
-from .. import mock
 
 import instruments as ik
 from instruments.tests import expected_protocol
 from instruments.units import dBm
+from .. import mock
 
 # TEST CLASSES ################################################################
 

--- a/instruments/tests/test_holzworth/test_holzworth_hs9000.py
+++ b/instruments/tests/test_holzworth/test_holzworth_hs9000.py
@@ -9,7 +9,7 @@ Unit tests for the Holzworth HS9000
 from __future__ import absolute_import
 
 import quantities as pq
-import mock
+from .. import mock
 
 import instruments as ik
 from instruments.tests import expected_protocol

--- a/instruments/tests/test_hp/test_hp3456a.py
+++ b/instruments/tests/test_hp/test_hp3456a.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 import quantities as pq
 import numpy as np
-from nose.tools import raises
+import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -34,20 +34,20 @@ def test_hp3456a_trigger_mode():
         dmm.trigger_mode = dmm.TriggerMode.hold
 
 
-@raises(ValueError)
 def test_hp3456a_number_of_digits():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "W6STG",
-            "REG"
-        ], [
-            "+06.00000E+0"
-        ],
-        sep="\r"
-    ) as dmm:
-        dmm.number_of_digits = 7
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "W6STG",
+                "REG"
+            ], [
+                "+06.00000E+0"
+            ],
+            sep="\r"
+        ) as dmm:
+            dmm.number_of_digits = 7
 
 
 def test_hp3456a_number_of_digits_invalid():
@@ -112,20 +112,20 @@ def test_hp3456a_nplc():
         assert dmm.nplc == 1
 
 
-@raises(ValueError)
 def test_hp3456a_nplc_invalid():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "W1STI",
-            "REI"
-        ], [
-            "+1.00000E+0"
-        ],
-        sep="\r"
-    ) as dmm:
-        dmm.nplc = 0
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "W1STI",
+                "REI"
+            ], [
+                "+1.00000E+0"
+            ],
+            sep="\r"
+        ) as dmm:
+            dmm.nplc = 0
 
 
 def test_hp3456a_mode():
@@ -350,48 +350,48 @@ def test_hp3456a_input_range():
         dmm.input_range = 1e3 * pq.ohm
 
 
-@raises(ValueError)
 def test_hp3456a_input_range_invalid_str():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [],
-        [],
-        sep="\r"
-    ) as dmm:
-        dmm.input_range = "derp"
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [],
+            [],
+            sep="\r"
+        ) as dmm:
+            dmm.input_range = "derp"
 
 
-@raises(ValueError)
 def test_hp3456a_input_range_invalid_range():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [],
-        [],
-        sep="\r"
-    ) as dmm:
-        dmm.input_range = 1 * pq.ohm
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [],
+            [],
+            sep="\r"
+        ) as dmm:
+            dmm.input_range = 1 * pq.ohm
 
 
-@raises(TypeError)
 def test_hp3456a_input_range_bad_type():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [],
-        [],
-        sep="\r"
-    ) as dmm:
-        dmm.input_range = True
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [],
+            [],
+            sep="\r"
+        ) as dmm:
+            dmm.input_range = True
 
 
-@raises(ValueError)
 def test_hp3456a_input_range_bad_units():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [],
-        [],
-        sep="\r"
-    ) as dmm:
-        dmm.input_range = 1 * pq.amp
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [],
+            [],
+            sep="\r"
+        ) as dmm:
+            dmm.input_range = 1 * pq.amp
 
 
 def test_hp3456a_relative():
@@ -411,15 +411,15 @@ def test_hp3456a_relative():
         assert dmm.relative is True
 
 
-@raises(TypeError)
 def test_hp3456a_relative_bad_type():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [],
-        [],
-        sep="\r"
-    ) as dmm:
-        dmm.relative = "derp"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [],
+            [],
+            sep="\r"
+        ) as dmm:
+            dmm.relative = "derp"
 
 
 def test_hp3456a_auto_zero():
@@ -454,34 +454,34 @@ def test_hp3456a_filter():
         dmm.filter = True
 
 
-@raises(TypeError)
 def test_hp3456a_register_read_bad_name():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [],
-        [],
-        sep="\r"
-    ) as dmm:
-        dmm._register_read("foobar")
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [],
+            [],
+            sep="\r"
+        ) as dmm:
+            dmm._register_read("foobar")
 
 
-@raises(TypeError)
 def test_hp3456a_register_write_bad_name():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [],
-        [],
-        sep="\r"
-    ) as dmm:
-        dmm._register_write("foobar", 1)
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [],
+            [],
+            sep="\r"
+        ) as dmm:
+            dmm._register_write("foobar", 1)
 
 
-@raises(ValueError)
 def test_hp3456a_register_write_bad_register():
-    with expected_protocol(
-        ik.hp.HP3456a,
-        [],
-        [],
-        sep="\r"
-    ) as dmm:
-        dmm._register_write(dmm.Register.mean, 1)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.hp.HP3456a,
+            [],
+            [],
+            sep="\r"
+        ) as dmm:
+            dmm._register_write(dmm.Register.mean, 1)

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -9,7 +9,7 @@ Unit tests for the HP 6624a power supply
 from __future__ import absolute_import
 
 import quantities as pq
-import mock
+from .. import mock
 from nose.tools import raises
 
 import instruments as ik

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 import quantities as pq
 from .. import mock
-from nose.tools import raises
+import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -206,15 +206,15 @@ def test_all_voltage():
         hp.voltage = (1 * pq.V, 2 * pq.V, 3 * pq.V, 4 * pq.V)
 
 
-@raises(ValueError)
 def test_all_voltage_wrong_length():
-    with expected_protocol(
-        ik.hp.HP6624a,
-        [],
-        [],
-        sep="\n"
-    ) as hp:
-        hp.voltage = (1 * pq.volt, 2 * pq.volt)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.hp.HP6624a,
+            [],
+            [],
+            sep="\n"
+        ) as hp:
+            hp.voltage = (1 * pq.volt, 2 * pq.volt)
 
 
 def test_all_current():
@@ -249,15 +249,15 @@ def test_all_current():
         hp.current = (1 * pq.A, 2 * pq.A, 3 * pq.A, 4 * pq.A)
 
 
-@raises(ValueError)
 def test_all_current_wrong_length():
-    with expected_protocol(
-        ik.hp.HP6624a,
-        [],
-        [],
-        sep="\n"
-    ) as hp:
-        hp.current = (1 * pq.amp, 2 * pq.amp)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.hp.HP6624a,
+            [],
+            [],
+            sep="\n"
+        ) as hp:
+            hp.current = (1 * pq.amp, 2 * pq.amp)
 
 
 def test_all_voltage_sense():
@@ -323,23 +323,23 @@ def test_channel_count():
         hp.channel_count = 3
 
 
-@raises(TypeError)
 def test_channel_count_wrong_type():
-    with expected_protocol(
-        ik.hp.HP6624a,
-        [],
-        [],
-        sep="\n"
-    ) as hp:
-        hp.channel_count = "foobar"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.hp.HP6624a,
+            [],
+            [],
+            sep="\n"
+        ) as hp:
+            hp.channel_count = "foobar"
 
 
-@raises(ValueError)
 def test_channel_count_too_small():
-    with expected_protocol(
-        ik.hp.HP6624a,
-        [],
-        [],
-        sep="\n"
-    ) as hp:
-        hp.channel_count = 0
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.hp.HP6624a,
+            [],
+            [],
+            sep="\n"
+        ) as hp:
+            hp.channel_count = 0

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -9,11 +9,11 @@ Unit tests for the HP 6624a power supply
 from __future__ import absolute_import
 
 import quantities as pq
-from .. import mock
 import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
+from .. import mock
 
 # TESTS #######################################################################
 

--- a/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/tests/test_keithley/test_keithley2182.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 import quantities as pq
 import numpy as np
-from nose.tools import raises
+import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -73,23 +73,23 @@ def test_channel_measure_temperature():
         assert channel.measure() == 1.234 * pq.celsius
 
 
-@raises(ValueError)
 def test_channel_measure_unknown_temperature_units():
-    with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "SENS:CHAN 1",
-            "SENS:DATA:FRES?",
-            "SENS:FUNC?",
-            "UNIT:TEMP?"
-        ],
-        [
-            "1.234",
-            "TEMP",
-            "Z"
-        ]
-    ) as inst:
-        inst.channel[0].measure()
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.keithley.Keithley2182,
+            [
+                "SENS:CHAN 1",
+                "SENS:DATA:FRES?",
+                "SENS:FUNC?",
+                "UNIT:TEMP?"
+            ],
+            [
+                "1.234",
+                "TEMP",
+                "Z"
+            ]
+        ) as inst:
+            inst.channel[0].measure()
 
 
 def test_units():
@@ -166,14 +166,14 @@ def test_measure():
         assert inst.measure() == 1.234 * pq.volt
 
 
-@raises(TypeError)
 def test_measure_invalid_mode():
-    with expected_protocol(
-        ik.keithley.Keithley2182,
-        [],
-        []
-    ) as inst:
-        inst.measure("derp")
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.keithley.Keithley2182,
+            [],
+            []
+        ) as inst:
+            inst.measure("derp")
 
 
 def test_relative_get():
@@ -227,11 +227,11 @@ def test_relative_set_start_disabled():
         inst.relative = True
 
 
-@raises(TypeError)
 def test_relative_set_wrong_type():
-    with expected_protocol(
-        ik.keithley.Keithley2182,
-        [],
-        []
-    ) as inst:
-        inst.relative = "derp"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.keithley.Keithley2182,
+            [],
+            []
+        ) as inst:
+            inst.relative = "derp"

--- a/instruments/tests/test_keithley/test_keithley6514.py
+++ b/instruments/tests/test_keithley/test_keithley6514.py
@@ -9,7 +9,7 @@ Unit tests for the Keithley 6514 electrometer
 from __future__ import absolute_import
 
 import quantities as pq
-from nose.tools import raises
+import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -28,10 +28,10 @@ def test_valid_range():
     assert inst._valid_range(inst.Mode.charge) == inst.ValidRange.charge
 
 
-@raises(ValueError)
 def test_valid_range_invalid():
-    inst = ik.keithley.Keithley6514.open_test()
-    inst._valid_range(inst.TriggerMode.immediate)
+    with pytest.raises(ValueError):
+        inst = ik.keithley.Keithley6514.open_test()
+        inst._valid_range(inst.TriggerMode.immediate)
 
 
 def test_parse_measurement():
@@ -176,18 +176,18 @@ def test_input_range():
         inst.input_range = 20 * pq.volt
 
 
-@raises(ValueError)
 def test_input_range_invalid():
-    with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "FUNCTION?"
-        ],
-        [
-            '"VOLT:DC"'
-        ]
-    ) as inst:
-        inst.input_range = 10 * pq.volt
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.keithley.Keithley6514,
+            [
+                "FUNCTION?"
+            ],
+            [
+                '"VOLT:DC"'
+            ]
+        ) as inst:
+            inst.input_range = 10 * pq.volt
 
 
 def test_auto_config():

--- a/instruments/tests/test_ondax/test_lm.py
+++ b/instruments/tests/test_ondax/test_lm.py
@@ -8,7 +8,7 @@ Unit tests for the Ondax Laser Module
 
 from __future__ import absolute_import
 
-from nose.tools import raises
+import pytest
 
 import quantities
 
@@ -62,15 +62,15 @@ def test_acc_disable():
         assert not lm.acc.enabled
 
 
-@raises(TypeError)
 def test_acc_enable_not_boolean():
-    with expected_protocol(
-            ondax.LM,
-            [],
-            [],
-            sep="\r"
-    ) as lm:
-        lm.acc.enabled = "foobar"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+                ondax.LM,
+                [],
+                [],
+                sep="\r"
+        ) as lm:
+            lm.acc.enabled = "foobar"
 
 
 def test_acc_on():
@@ -145,15 +145,15 @@ def test_apc_disable():
         assert not lm.apc.enabled
 
 
-@raises(TypeError)
 def test_apc_enable_not_boolean():
-    with expected_protocol(
-            ondax.LM,
-            [],
-            [],
-            sep="\r"
-    ) as lm:
-        lm.apc.enabled = "foobar"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+                ondax.LM,
+                [],
+                [],
+                sep="\r"
+        ) as lm:
+            lm.apc.enabled = "foobar"
 
 
 
@@ -249,15 +249,15 @@ def test_modulation_disabled():
         assert not lm.modulation.enabled
 
 
-@raises(TypeError)
 def test_modulation_enable_not_boolean():
-    with expected_protocol(
-            ondax.LM,
-            [],
-            [],
-            sep="\r"
-    ) as lm:
-        lm.modulation.enabled = "foobar"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+                ondax.LM,
+                [],
+                [],
+                sep="\r"
+        ) as lm:
+            lm.modulation.enabled = "foobar"
 
 
 def test_tec_current():
@@ -318,15 +318,15 @@ def test_tec_disable():
         assert not lm.tec.enabled
 
 
-@raises(TypeError)
 def test_tec_enable_not_boolean():
-    with expected_protocol(
-            ondax.LM,
-            [],
-            [],
-            sep="\r"
-    ) as lm:
-        lm.tec.enabled = "foobar"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+                ondax.LM,
+                [],
+                [],
+                sep="\r"
+        ) as lm:
+            lm.tec.enabled = "foobar"
 
 
 def test_firmware():
@@ -469,15 +469,15 @@ def test_disable():
         assert not lm.enabled
 
 
-@raises(TypeError)
 def test_enable_not_boolean():
-    with expected_protocol(
-            ondax.LM,
-            [],
-            [],
-            sep="\r"
-    ) as lm:
-        lm.enabled = "foobar"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+                ondax.LM,
+                [],
+                [],
+                sep="\r"
+        ) as lm:
+            lm.enabled = "foobar"
 
 
 def test_save():

--- a/instruments/tests/test_property_factories/test_bool_property.py
+++ b/instruments/tests/test_property_factories/test_bool_property.py
@@ -25,13 +25,13 @@ def test_bool_property_basics():
 
     mock_inst = BoolMock({'MOCK1?': 'OFF', 'MOCK2?': 'YES'})
 
-    assert mock_inst.mock1 ==  False
-    assert mock_inst.mock2 ==  True
+    assert mock_inst.mock1 is False
+    assert mock_inst.mock2 is True
 
     mock_inst.mock1 = True
     mock_inst.mock2 = False
 
-    assert mock_inst.value ==  'MOCK1?\nMOCK2?\nMOCK1 ON\nMOCK2 NO\n'
+    assert mock_inst.value == 'MOCK1?\nMOCK2?\nMOCK1 ON\nMOCK2 NO\n'
 
 
 def test_bool_property_set_fmt():
@@ -42,7 +42,7 @@ def test_bool_property_set_fmt():
 
     mock_instrument.mock1 = True
 
-    assert mock_instrument.value ==  'MOCK1=ON\n'
+    assert mock_instrument.value == 'MOCK1=ON\n'
 
 
 def test_bool_property_readonly_writing_fails():
@@ -61,7 +61,7 @@ def test_bool_property_readonly_reading_passes():
 
     mock_instrument = BoolMock({'MOCK1?': 'OFF'})
 
-    assert mock_instrument.mock1 ==  False
+    assert mock_instrument.mock1 is False
 
 
 def test_bool_property_writeonly_reading_fails():
@@ -89,7 +89,7 @@ def test_bool_property_set_cmd():
 
     mock_inst = BoolMock({'MOCK1?': 'OFF'})
 
-    assert mock_inst.mock1 ==  False
+    assert mock_inst.mock1 is False
     mock_inst.mock1 = True
 
-    assert mock_inst.value ==  'MOCK1?\nFOOBAR ON\n'
+    assert mock_inst.value == 'MOCK1?\nFOOBAR ON\n'

--- a/instruments/tests/test_property_factories/test_bool_property.py
+++ b/instruments/tests/test_property_factories/test_bool_property.py
@@ -8,7 +8,6 @@ Module containing tests for the bool property factories
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 
 from instruments.util_fns import bool_property
@@ -26,13 +25,13 @@ def test_bool_property_basics():
 
     mock_inst = BoolMock({'MOCK1?': 'OFF', 'MOCK2?': 'YES'})
 
-    eq_(mock_inst.mock1, False)
-    eq_(mock_inst.mock2, True)
+    assert mock_inst.mock1 ==  False
+    assert mock_inst.mock2 ==  True
 
     mock_inst.mock1 = True
     mock_inst.mock2 = False
 
-    eq_(mock_inst.value, 'MOCK1?\nMOCK2?\nMOCK1 ON\nMOCK2 NO\n')
+    assert mock_inst.value ==  'MOCK1?\nMOCK2?\nMOCK1 ON\nMOCK2 NO\n'
 
 
 def test_bool_property_set_fmt():
@@ -43,7 +42,7 @@ def test_bool_property_set_fmt():
 
     mock_instrument.mock1 = True
 
-    eq_(mock_instrument.value, 'MOCK1=ON\n')
+    assert mock_instrument.value ==  'MOCK1=ON\n'
 
 
 def test_bool_property_readonly_writing_fails():
@@ -62,7 +61,7 @@ def test_bool_property_readonly_reading_passes():
 
     mock_instrument = BoolMock({'MOCK1?': 'OFF'})
 
-    eq_(mock_instrument.mock1, False)
+    assert mock_instrument.mock1 ==  False
 
 
 def test_bool_property_writeonly_reading_fails():
@@ -90,7 +89,7 @@ def test_bool_property_set_cmd():
 
     mock_inst = BoolMock({'MOCK1?': 'OFF'})
 
-    eq_(mock_inst.mock1, False)
+    assert mock_inst.mock1 ==  False
     mock_inst.mock1 = True
 
-    eq_(mock_inst.value, 'MOCK1?\nFOOBAR ON\n')
+    assert mock_inst.value ==  'MOCK1?\nFOOBAR ON\n'

--- a/instruments/tests/test_property_factories/test_bool_property.py
+++ b/instruments/tests/test_property_factories/test_bool_property.py
@@ -8,7 +8,8 @@ Module containing tests for the bool property factories
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 
 from instruments.util_fns import bool_property
 from . import MockInstrument
@@ -45,14 +46,14 @@ def test_bool_property_set_fmt():
     eq_(mock_instrument.value, 'MOCK1=ON\n')
 
 
-@raises(AttributeError)
 def test_bool_property_readonly_writing_fails():
-    class BoolMock(MockInstrument):
-        mock1 = bool_property('MOCK1', readonly=True)
+    with pytest.raises(AttributeError):
+        class BoolMock(MockInstrument):
+            mock1 = bool_property('MOCK1', readonly=True)
 
-    mock_instrument = BoolMock({'MOCK1?': 'OFF'})
+        mock_instrument = BoolMock({'MOCK1?': 'OFF'})
 
-    mock_instrument.mock1 = True
+        mock_instrument.mock1 = True
 
 
 def test_bool_property_readonly_reading_passes():
@@ -64,14 +65,14 @@ def test_bool_property_readonly_reading_passes():
     eq_(mock_instrument.mock1, False)
 
 
-@raises(AttributeError)
 def test_bool_property_writeonly_reading_fails():
-    class BoolMock(MockInstrument):
-        mock1 = bool_property('MOCK1', writeonly=True)
+    with pytest.raises(AttributeError):
+        class BoolMock(MockInstrument):
+            mock1 = bool_property('MOCK1', writeonly=True)
 
-    mock_instrument = BoolMock({'MOCK1?': 'OFF'})
+        mock_instrument = BoolMock({'MOCK1?': 'OFF'})
 
-    _ = mock_instrument.mock1
+        _ = mock_instrument.mock1
 
 
 def test_bool_property_writeonly_writing_passes():

--- a/instruments/tests/test_property_factories/test_bounded_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_bounded_unitful_property.py
@@ -9,11 +9,11 @@ Module containing tests for the bounded unitful property factories
 from __future__ import absolute_import
 
 import pytest
-from .. import mock
 import quantities as pq
 
 from instruments.util_fns import bounded_unitful_property
 from . import MockInstrument
+from .. import mock
 
 # TEST CASES #################################################################
 
@@ -30,9 +30,9 @@ def test_bounded_unitful_property_basics():
     mock_inst = BoundedUnitfulMock(
         {'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
 
-    assert mock_inst.property ==  1000 * pq.hertz
-    assert mock_inst.property_min ==  10 * pq.hertz
-    assert mock_inst.property_max ==  9999 * pq.hertz
+    assert mock_inst.property == 1000 * pq.hertz
+    assert mock_inst.property_min == 10 * pq.hertz
+    assert mock_inst.property_max == 9999 * pq.hertz
 
     mock_inst.property = 1000 * pq.hertz
 
@@ -75,8 +75,8 @@ def test_bounded_unitful_property_min_fmt_str():
 
     mock_inst = BoundedUnitfulMock({'MOCK MIN?': '10'})
 
-    assert mock_inst.property_min ==  10 * pq.Hz
-    assert mock_inst.value ==  'MOCK MIN?\n'
+    assert mock_inst.property_min == 10 * pq.Hz
+    assert mock_inst.value == 'MOCK MIN?\n'
 
 
 def test_bounded_unitful_property_max_fmt_str():
@@ -89,8 +89,8 @@ def test_bounded_unitful_property_max_fmt_str():
 
     mock_inst = BoundedUnitfulMock({'MOCK MAX?': '9999'})
 
-    assert mock_inst.property_max ==  9999 * pq.Hz
-    assert mock_inst.value ==  'MOCK MAX?\n'
+    assert mock_inst.property_max == 9999 * pq.Hz
+    assert mock_inst.value == 'MOCK MAX?\n'
 
 
 def test_bounded_unitful_property_static_range():
@@ -103,8 +103,8 @@ def test_bounded_unitful_property_static_range():
 
     mock_inst = BoundedUnitfulMock()
 
-    assert mock_inst.property_min ==  10 * pq.Hz
-    assert mock_inst.property_max ==  9999 * pq.Hz
+    assert mock_inst.property_min == 10 * pq.Hz
+    assert mock_inst.property_max == 9999 * pq.Hz
 
 
 def test_bounded_unitful_property_static_range_with_units():
@@ -117,8 +117,8 @@ def test_bounded_unitful_property_static_range_with_units():
 
     mock_inst = BoundedUnitfulMock()
 
-    assert mock_inst.property_min ==  10 * 1000 * pq.Hz
-    assert mock_inst.property_max ==  9999 * 1000 * pq.Hz
+    assert mock_inst.property_min == 10 * 1000 * pq.Hz
+    assert mock_inst.property_max == 9999 * 1000 * pq.Hz
 
 
 @mock.patch("instruments.util_fns.unitful_property")
@@ -160,5 +160,5 @@ def test_bounded_unitful_property_returns_none():
 
     mock_inst = BoundedUnitfulMock()
 
-    assert mock_inst.property_min ==  None
-    assert mock_inst.property_max ==  None
+    assert mock_inst.property_min is None
+    assert mock_inst.property_max is None

--- a/instruments/tests/test_property_factories/test_bounded_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_bounded_unitful_property.py
@@ -9,7 +9,7 @@ Module containing tests for the bounded unitful property factories
 from __future__ import absolute_import
 
 from nose.tools import raises, eq_
-import mock
+from .. import mock
 import quantities as pq
 
 from instruments.util_fns import bounded_unitful_property

--- a/instruments/tests/test_property_factories/test_bounded_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_bounded_unitful_property.py
@@ -8,7 +8,6 @@ Module containing tests for the bounded unitful property factories
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 from .. import mock
 import quantities as pq
@@ -31,9 +30,9 @@ def test_bounded_unitful_property_basics():
     mock_inst = BoundedUnitfulMock(
         {'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
 
-    eq_(mock_inst.property, 1000 * pq.hertz)
-    eq_(mock_inst.property_min, 10 * pq.hertz)
-    eq_(mock_inst.property_max, 9999 * pq.hertz)
+    assert mock_inst.property ==  1000 * pq.hertz
+    assert mock_inst.property_min ==  10 * pq.hertz
+    assert mock_inst.property_max ==  9999 * pq.hertz
 
     mock_inst.property = 1000 * pq.hertz
 
@@ -76,8 +75,8 @@ def test_bounded_unitful_property_min_fmt_str():
 
     mock_inst = BoundedUnitfulMock({'MOCK MIN?': '10'})
 
-    eq_(mock_inst.property_min, 10 * pq.Hz)
-    eq_(mock_inst.value, 'MOCK MIN?\n')
+    assert mock_inst.property_min ==  10 * pq.Hz
+    assert mock_inst.value ==  'MOCK MIN?\n'
 
 
 def test_bounded_unitful_property_max_fmt_str():
@@ -90,8 +89,8 @@ def test_bounded_unitful_property_max_fmt_str():
 
     mock_inst = BoundedUnitfulMock({'MOCK MAX?': '9999'})
 
-    eq_(mock_inst.property_max, 9999 * pq.Hz)
-    eq_(mock_inst.value, 'MOCK MAX?\n')
+    assert mock_inst.property_max ==  9999 * pq.Hz
+    assert mock_inst.value ==  'MOCK MAX?\n'
 
 
 def test_bounded_unitful_property_static_range():
@@ -104,8 +103,8 @@ def test_bounded_unitful_property_static_range():
 
     mock_inst = BoundedUnitfulMock()
 
-    eq_(mock_inst.property_min, 10 * pq.Hz)
-    eq_(mock_inst.property_max, 9999 * pq.Hz)
+    assert mock_inst.property_min ==  10 * pq.Hz
+    assert mock_inst.property_max ==  9999 * pq.Hz
 
 
 def test_bounded_unitful_property_static_range_with_units():
@@ -118,8 +117,8 @@ def test_bounded_unitful_property_static_range_with_units():
 
     mock_inst = BoundedUnitfulMock()
 
-    eq_(mock_inst.property_min, 10 * 1000 * pq.Hz)
-    eq_(mock_inst.property_max, 9999 * 1000 * pq.Hz)
+    assert mock_inst.property_min ==  10 * 1000 * pq.Hz
+    assert mock_inst.property_max ==  9999 * 1000 * pq.Hz
 
 
 @mock.patch("instruments.util_fns.unitful_property")
@@ -161,5 +160,5 @@ def test_bounded_unitful_property_returns_none():
 
     mock_inst = BoundedUnitfulMock()
 
-    eq_(mock_inst.property_min, None)
-    eq_(mock_inst.property_max, None)
+    assert mock_inst.property_min ==  None
+    assert mock_inst.property_max ==  None

--- a/instruments/tests/test_property_factories/test_bounded_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_bounded_unitful_property.py
@@ -8,7 +8,8 @@ Module containing tests for the bounded unitful property factories
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 from .. import mock
 import quantities as pq
 
@@ -37,32 +38,32 @@ def test_bounded_unitful_property_basics():
     mock_inst.property = 1000 * pq.hertz
 
 
-@raises(ValueError)
 def test_bounded_unitful_property_set_outside_max():
-    class BoundedUnitfulMock(MockInstrument):
-        property, property_min, property_max = bounded_unitful_property(
-            'MOCK',
-            units=pq.hertz
-        )
+    with pytest.raises(ValueError):
+        class BoundedUnitfulMock(MockInstrument):
+            property, property_min, property_max = bounded_unitful_property(
+                'MOCK',
+                units=pq.hertz
+            )
 
-    mock_inst = BoundedUnitfulMock(
-        {'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
+        mock_inst = BoundedUnitfulMock(
+            {'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
 
-    mock_inst.property = 10000 * pq.hertz  # Should raise ValueError
+        mock_inst.property = 10000 * pq.hertz  # Should raise ValueError
 
 
-@raises(ValueError)
 def test_bounded_unitful_property_set_outside_min():
-    class BoundedUnitfulMock(MockInstrument):
-        property, property_min, property_max = bounded_unitful_property(
-            'MOCK',
-            units=pq.hertz
-        )
+    with pytest.raises(ValueError):
+        class BoundedUnitfulMock(MockInstrument):
+            property, property_min, property_max = bounded_unitful_property(
+                'MOCK',
+                units=pq.hertz
+            )
 
-    mock_inst = BoundedUnitfulMock(
-        {'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
+        mock_inst = BoundedUnitfulMock(
+            {'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
 
-    mock_inst.property = 1 * pq.hertz  # Should raise ValueError
+        mock_inst.property = 1 * pq.hertz  # Should raise ValueError
 
 
 def test_bounded_unitful_property_min_fmt_str():

--- a/instruments/tests/test_property_factories/test_enum_property.py
+++ b/instruments/tests/test_property_factories/test_enum_property.py
@@ -9,7 +9,8 @@ Module containing tests for the enum property factories
 from __future__ import absolute_import
 
 from enum import Enum, IntEnum
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 
 from instruments.util_fns import enum_property
 from . import MockInstrument
@@ -41,18 +42,18 @@ def test_enum_property():
     eq_(mock_inst.value, 'MOCK:A?\nMOCK:B?\nMOCK:A bb\nMOCK:B aa\nMOCK:B bb\n')
 
 
-@raises(ValueError)
 def test_enum_property_invalid():
-    class SillyEnum(Enum):
-        a = 'aa'
-        b = 'bb'
+    with pytest.raises(ValueError):
+        class SillyEnum(Enum):
+            a = 'aa'
+            b = 'bb'
 
-    class EnumMock(MockInstrument):
-        a = enum_property('MOCK:A', SillyEnum)
+        class EnumMock(MockInstrument):
+            a = enum_property('MOCK:A', SillyEnum)
 
-    mock_inst = EnumMock({'MOCK:A?': 'aa', 'MOCK:B?': 'bb'})
+        mock_inst = EnumMock({'MOCK:A?': 'aa', 'MOCK:B?': 'bb'})
 
-    mock_inst.a = 'c'
+        mock_inst.a = 'c'
 
 
 def test_enum_property_set_fmt():
@@ -146,17 +147,17 @@ def test_enum_property_output_decoration_not_a_function():
     eq_(mock_instrument.value, 'MOCK:A 0.23\n')
 
 
-@raises(AttributeError)
 def test_enum_property_writeonly_reading_fails():
-    class SillyEnum(Enum):
-        a = 'aa'
+    with pytest.raises(AttributeError):
+        class SillyEnum(Enum):
+            a = 'aa'
 
-    class EnumMock(MockInstrument):
-        a = enum_property('MOCK:A', SillyEnum, writeonly=True)
+        class EnumMock(MockInstrument):
+            a = enum_property('MOCK:A', SillyEnum, writeonly=True)
 
-    mock_instrument = EnumMock()
+        mock_instrument = EnumMock()
 
-    _ = mock_instrument.a
+        _ = mock_instrument.a
 
 
 def test_enum_property_writeonly_writing_passes():
@@ -172,17 +173,17 @@ def test_enum_property_writeonly_writing_passes():
     eq_(mock_instrument.value, 'MOCK:A aa\n')
 
 
-@raises(AttributeError)
 def test_enum_property_readonly_writing_fails():
-    class SillyEnum(Enum):
-        a = 'aa'
+    with pytest.raises(AttributeError):
+        class SillyEnum(Enum):
+            a = 'aa'
 
-    class EnumMock(MockInstrument):
-        a = enum_property('MOCK:A', SillyEnum, readonly=True)
+        class EnumMock(MockInstrument):
+            a = enum_property('MOCK:A', SillyEnum, readonly=True)
 
-    mock_instrument = EnumMock({'MOCK:A?': 'aa'})
+        mock_instrument = EnumMock({'MOCK:A?': 'aa'})
 
-    mock_instrument.a = SillyEnum.a
+        mock_instrument.a = SillyEnum.a
 
 
 def test_enum_property_readonly_reading_passes():

--- a/instruments/tests/test_property_factories/test_enum_property.py
+++ b/instruments/tests/test_property_factories/test_enum_property.py
@@ -9,7 +9,6 @@ Module containing tests for the enum property factories
 from __future__ import absolute_import
 
 from enum import Enum, IntEnum
-from nose.tools import eq_
 import pytest
 
 from instruments.util_fns import enum_property
@@ -31,15 +30,15 @@ def test_enum_property():
 
     mock_inst = EnumMock({'MOCK:A?': 'aa', 'MOCK:B?': 'bb'})
 
-    eq_(mock_inst.a, SillyEnum.a)
-    eq_(mock_inst.b, SillyEnum.b)
+    assert mock_inst.a ==  SillyEnum.a
+    assert mock_inst.b ==  SillyEnum.b
 
     # Test EnumValues, string values and string names.
     mock_inst.a = SillyEnum.b
     mock_inst.b = 'a'
     mock_inst.b = 'bb'
 
-    eq_(mock_inst.value, 'MOCK:A?\nMOCK:B?\nMOCK:A bb\nMOCK:B aa\nMOCK:B bb\n')
+    assert mock_inst.value ==  'MOCK:A?\nMOCK:B?\nMOCK:A bb\nMOCK:B aa\nMOCK:B bb\n'
 
 
 def test_enum_property_invalid():
@@ -66,7 +65,7 @@ def test_enum_property_set_fmt():
     mock_instrument = EnumMock()
 
     mock_instrument.a = 'aa'
-    eq_(mock_instrument.value, 'MOCK:A=aa\n')
+    assert mock_instrument.value ==  'MOCK:A=aa\n'
 
 
 def test_enum_property_input_decoration():
@@ -86,7 +85,7 @@ def test_enum_property_input_decoration():
 
     mock_instrument = EnumMock({'MOCK:A?': 'garbage'})
 
-    eq_(mock_instrument.a, SillyEnum.a)
+    assert mock_instrument.a ==  SillyEnum.a
 
 
 def test_enum_property_input_decoration_not_a_function():
@@ -103,7 +102,7 @@ def test_enum_property_input_decoration_not_a_function():
 
     mock_instrument = EnumMock({'MOCK:A?': '1'})
 
-    eq_(mock_instrument.a, SillyEnum.a)
+    assert mock_instrument.a ==  SillyEnum.a
 
 
 def test_enum_property_output_decoration():
@@ -125,7 +124,7 @@ def test_enum_property_output_decoration():
 
     mock_instrument.a = SillyEnum.a
 
-    eq_(mock_instrument.value, 'MOCK:A foobar\n')
+    assert mock_instrument.value ==  'MOCK:A foobar\n'
 
 
 def test_enum_property_output_decoration_not_a_function():
@@ -144,7 +143,7 @@ def test_enum_property_output_decoration_not_a_function():
 
     mock_instrument.a = SillyEnum.a
 
-    eq_(mock_instrument.value, 'MOCK:A 0.23\n')
+    assert mock_instrument.value ==  'MOCK:A 0.23\n'
 
 
 def test_enum_property_writeonly_reading_fails():
@@ -170,7 +169,7 @@ def test_enum_property_writeonly_writing_passes():
     mock_instrument = EnumMock()
 
     mock_instrument.a = SillyEnum.a
-    eq_(mock_instrument.value, 'MOCK:A aa\n')
+    assert mock_instrument.value ==  'MOCK:A aa\n'
 
 
 def test_enum_property_readonly_writing_fails():
@@ -195,8 +194,8 @@ def test_enum_property_readonly_reading_passes():
 
     mock_instrument = EnumMock({'MOCK:A?': 'aa'})
 
-    eq_(mock_instrument.a, SillyEnum.a)
-    eq_(mock_instrument.value, 'MOCK:A?\n')
+    assert mock_instrument.a ==  SillyEnum.a
+    assert mock_instrument.value ==  'MOCK:A?\n'
 
 
 def test_enum_property_set_cmd():
@@ -208,7 +207,7 @@ def test_enum_property_set_cmd():
 
     mock_inst = EnumMock({'MOCK:A?': 'aa'})
 
-    eq_(mock_inst.a, SillyEnum.a)
+    assert mock_inst.a ==  SillyEnum.a
     mock_inst.a = SillyEnum.a
 
-    eq_(mock_inst.value, 'MOCK:A?\nFOOBAR:A aa\n')
+    assert mock_inst.value ==  'MOCK:A?\nFOOBAR:A aa\n'

--- a/instruments/tests/test_property_factories/test_enum_property.py
+++ b/instruments/tests/test_property_factories/test_enum_property.py
@@ -30,15 +30,15 @@ def test_enum_property():
 
     mock_inst = EnumMock({'MOCK:A?': 'aa', 'MOCK:B?': 'bb'})
 
-    assert mock_inst.a ==  SillyEnum.a
-    assert mock_inst.b ==  SillyEnum.b
+    assert mock_inst.a == SillyEnum.a
+    assert mock_inst.b == SillyEnum.b
 
     # Test EnumValues, string values and string names.
     mock_inst.a = SillyEnum.b
     mock_inst.b = 'a'
     mock_inst.b = 'bb'
 
-    assert mock_inst.value ==  'MOCK:A?\nMOCK:B?\nMOCK:A bb\nMOCK:B aa\nMOCK:B bb\n'
+    assert mock_inst.value == 'MOCK:A?\nMOCK:B?\nMOCK:A bb\nMOCK:B aa\nMOCK:B bb\n'
 
 
 def test_enum_property_invalid():
@@ -65,7 +65,7 @@ def test_enum_property_set_fmt():
     mock_instrument = EnumMock()
 
     mock_instrument.a = 'aa'
-    assert mock_instrument.value ==  'MOCK:A=aa\n'
+    assert mock_instrument.value == 'MOCK:A=aa\n'
 
 
 def test_enum_property_input_decoration():
@@ -85,7 +85,7 @@ def test_enum_property_input_decoration():
 
     mock_instrument = EnumMock({'MOCK:A?': 'garbage'})
 
-    assert mock_instrument.a ==  SillyEnum.a
+    assert mock_instrument.a == SillyEnum.a
 
 
 def test_enum_property_input_decoration_not_a_function():
@@ -102,7 +102,7 @@ def test_enum_property_input_decoration_not_a_function():
 
     mock_instrument = EnumMock({'MOCK:A?': '1'})
 
-    assert mock_instrument.a ==  SillyEnum.a
+    assert mock_instrument.a == SillyEnum.a
 
 
 def test_enum_property_output_decoration():
@@ -124,7 +124,7 @@ def test_enum_property_output_decoration():
 
     mock_instrument.a = SillyEnum.a
 
-    assert mock_instrument.value ==  'MOCK:A foobar\n'
+    assert mock_instrument.value == 'MOCK:A foobar\n'
 
 
 def test_enum_property_output_decoration_not_a_function():
@@ -143,7 +143,7 @@ def test_enum_property_output_decoration_not_a_function():
 
     mock_instrument.a = SillyEnum.a
 
-    assert mock_instrument.value ==  'MOCK:A 0.23\n'
+    assert mock_instrument.value == 'MOCK:A 0.23\n'
 
 
 def test_enum_property_writeonly_reading_fails():
@@ -169,7 +169,7 @@ def test_enum_property_writeonly_writing_passes():
     mock_instrument = EnumMock()
 
     mock_instrument.a = SillyEnum.a
-    assert mock_instrument.value ==  'MOCK:A aa\n'
+    assert mock_instrument.value == 'MOCK:A aa\n'
 
 
 def test_enum_property_readonly_writing_fails():
@@ -194,8 +194,8 @@ def test_enum_property_readonly_reading_passes():
 
     mock_instrument = EnumMock({'MOCK:A?': 'aa'})
 
-    assert mock_instrument.a ==  SillyEnum.a
-    assert mock_instrument.value ==  'MOCK:A?\n'
+    assert mock_instrument.a == SillyEnum.a
+    assert mock_instrument.value == 'MOCK:A?\n'
 
 
 def test_enum_property_set_cmd():
@@ -207,7 +207,7 @@ def test_enum_property_set_cmd():
 
     mock_inst = EnumMock({'MOCK:A?': 'aa'})
 
-    assert mock_inst.a ==  SillyEnum.a
+    assert mock_inst.a == SillyEnum.a
     mock_inst.a = SillyEnum.a
 
-    assert mock_inst.value ==  'MOCK:A?\nFOOBAR:A aa\n'
+    assert mock_inst.value == 'MOCK:A?\nFOOBAR:A aa\n'

--- a/instruments/tests/test_property_factories/test_int_property.py
+++ b/instruments/tests/test_property_factories/test_int_property.py
@@ -8,7 +8,6 @@ Module containing tests for the int property factories
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 
 from instruments.util_fns import int_property
@@ -34,10 +33,10 @@ def test_int_property_valid_set():
 
     mock_inst = IntMock({'MOCK?': '1'})
 
-    eq_(mock_inst.int_property, 1)
+    assert mock_inst.int_property ==  1
 
     mock_inst.int_property = 2
-    eq_(mock_inst.value, 'MOCK?\nMOCK 2\n')
+    assert mock_inst.value ==  'MOCK?\nMOCK 2\n'
 
 
 def test_int_property_no_set():
@@ -48,7 +47,7 @@ def test_int_property_no_set():
 
     mock_inst.int_property = 1
 
-    eq_(mock_inst.value, 'MOCK 1\n')
+    assert mock_inst.value ==  'MOCK 1\n'
 
 
 def test_int_property_writeonly_reading_fails():
@@ -68,7 +67,7 @@ def test_int_property_writeonly_writing_passes():
     mock_inst = IntMock()
 
     mock_inst.int_property = 1
-    eq_(mock_inst.value, 'MOCK {:d}\n'.format(1))
+    assert mock_inst.value ==  'MOCK {:d}\n'.format(1)
 
 
 def test_int_property_readonly_writing_fails():
@@ -87,7 +86,7 @@ def test_int_property_readonly_reading_passes():
 
     mock_inst = IntMock({'MOCK?': '1'})
 
-    eq_(mock_inst.int_property, 1)
+    assert mock_inst.int_property ==  1
 
 
 def test_int_property_format_code():
@@ -97,7 +96,7 @@ def test_int_property_format_code():
     mock_inst = IntMock()
 
     mock_inst.int_property = 1
-    eq_(mock_inst.value, 'MOCK {:e}\n'.format(1))
+    assert mock_inst.value ==  'MOCK {:e}\n'.format(1)
 
 
 def test_int_property_set_cmd():
@@ -106,7 +105,7 @@ def test_int_property_set_cmd():
 
     mock_inst = IntMock({'MOCK?': '1'})
 
-    eq_(mock_inst.int_property, 1)
+    assert mock_inst.int_property ==  1
     mock_inst.int_property = 1
 
-    eq_(mock_inst.value, 'MOCK?\nFOOBAR 1\n')
+    assert mock_inst.value ==  'MOCK?\nFOOBAR 1\n'

--- a/instruments/tests/test_property_factories/test_int_property.py
+++ b/instruments/tests/test_property_factories/test_int_property.py
@@ -33,10 +33,10 @@ def test_int_property_valid_set():
 
     mock_inst = IntMock({'MOCK?': '1'})
 
-    assert mock_inst.int_property ==  1
+    assert mock_inst.int_property == 1
 
     mock_inst.int_property = 2
-    assert mock_inst.value ==  'MOCK?\nMOCK 2\n'
+    assert mock_inst.value == 'MOCK?\nMOCK 2\n'
 
 
 def test_int_property_no_set():
@@ -47,7 +47,7 @@ def test_int_property_no_set():
 
     mock_inst.int_property = 1
 
-    assert mock_inst.value ==  'MOCK 1\n'
+    assert mock_inst.value == 'MOCK 1\n'
 
 
 def test_int_property_writeonly_reading_fails():
@@ -67,7 +67,7 @@ def test_int_property_writeonly_writing_passes():
     mock_inst = IntMock()
 
     mock_inst.int_property = 1
-    assert mock_inst.value ==  'MOCK {:d}\n'.format(1)
+    assert mock_inst.value == 'MOCK {:d}\n'.format(1)
 
 
 def test_int_property_readonly_writing_fails():
@@ -86,7 +86,7 @@ def test_int_property_readonly_reading_passes():
 
     mock_inst = IntMock({'MOCK?': '1'})
 
-    assert mock_inst.int_property ==  1
+    assert mock_inst.int_property == 1
 
 
 def test_int_property_format_code():
@@ -96,7 +96,7 @@ def test_int_property_format_code():
     mock_inst = IntMock()
 
     mock_inst.int_property = 1
-    assert mock_inst.value ==  'MOCK {:e}\n'.format(1)
+    assert mock_inst.value == 'MOCK {:e}\n'.format(1)
 
 
 def test_int_property_set_cmd():
@@ -105,7 +105,7 @@ def test_int_property_set_cmd():
 
     mock_inst = IntMock({'MOCK?': '1'})
 
-    assert mock_inst.int_property ==  1
+    assert mock_inst.int_property == 1
     mock_inst.int_property = 1
 
-    assert mock_inst.value ==  'MOCK?\nFOOBAR 1\n'
+    assert mock_inst.value == 'MOCK?\nFOOBAR 1\n'

--- a/instruments/tests/test_property_factories/test_int_property.py
+++ b/instruments/tests/test_property_factories/test_int_property.py
@@ -8,7 +8,8 @@ Module containing tests for the int property factories
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 
 from instruments.util_fns import int_property
 from . import MockInstrument
@@ -18,13 +19,13 @@ from . import MockInstrument
 # pylint: disable=missing-docstring
 
 
-@raises(ValueError)
 def test_int_property_outside_valid_set():
-    class IntMock(MockInstrument):
-        mock_property = int_property('MOCK', valid_set=set([1, 2]))
+    with pytest.raises(ValueError):
+        class IntMock(MockInstrument):
+            mock_property = int_property('MOCK', valid_set=set([1, 2]))
 
-    mock_inst = IntMock()
-    mock_inst.mock_property = 3
+        mock_inst = IntMock()
+        mock_inst.mock_property = 3
 
 
 def test_int_property_valid_set():
@@ -50,14 +51,14 @@ def test_int_property_no_set():
     eq_(mock_inst.value, 'MOCK 1\n')
 
 
-@raises(AttributeError)
 def test_int_property_writeonly_reading_fails():
-    class IntMock(MockInstrument):
-        int_property = int_property('MOCK', writeonly=True)
+    with pytest.raises(AttributeError):
+        class IntMock(MockInstrument):
+            int_property = int_property('MOCK', writeonly=True)
 
-    mock_inst = IntMock()
+        mock_inst = IntMock()
 
-    _ = mock_inst.int_property
+        _ = mock_inst.int_property
 
 
 def test_int_property_writeonly_writing_passes():
@@ -70,14 +71,14 @@ def test_int_property_writeonly_writing_passes():
     eq_(mock_inst.value, 'MOCK {:d}\n'.format(1))
 
 
-@raises(AttributeError)
 def test_int_property_readonly_writing_fails():
-    class IntMock(MockInstrument):
-        int_property = int_property('MOCK', readonly=True)
+    with pytest.raises(AttributeError):
+        class IntMock(MockInstrument):
+            int_property = int_property('MOCK', readonly=True)
 
-    mock_inst = IntMock({'MOCK?': '1'})
+        mock_inst = IntMock({'MOCK?': '1'})
 
-    mock_inst.int_property = 1
+        mock_inst.int_property = 1
 
 
 def test_int_property_readonly_reading_passes():

--- a/instruments/tests/test_property_factories/test_rproperty.py
+++ b/instruments/tests/test_property_factories/test_rproperty.py
@@ -8,7 +8,6 @@ Module containing tests for the property factories
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 
 from instruments.util_fns import rproperty
@@ -36,7 +35,7 @@ def test_rproperty_basic():
 
     mock_inst = Mock()
     mock_inst.mockproperty = 1
-    eq_(mock_inst.mockproperty, 1)
+    assert mock_inst.mockproperty ==  1
 
 
 def test_rproperty_readonly_writing_fails():
@@ -67,7 +66,7 @@ def test_rproperty_readonly_reading_passes():
         mockproperty = rproperty(fget=mockget, fset=None, readonly=True)
 
     mock_inst = Mock()
-    eq_(mock_inst.mockproperty, 0)
+    assert mock_inst.mockproperty ==  0
 
 
 def test_rproperty_writeonly_reading_fails():
@@ -83,7 +82,7 @@ def test_rproperty_writeonly_reading_fails():
             mockproperty = rproperty(fget=mockget, fset=None, writeonly=True)
 
         mock_inst = Mock()
-        eq_(mock_inst.mockproperty, 0)
+        assert mock_inst.mockproperty ==  0
 
 
 def test_rproperty_writeonly_writing_passes():

--- a/instruments/tests/test_property_factories/test_rproperty.py
+++ b/instruments/tests/test_property_factories/test_rproperty.py
@@ -35,7 +35,7 @@ def test_rproperty_basic():
 
     mock_inst = Mock()
     mock_inst.mockproperty = 1
-    assert mock_inst.mockproperty ==  1
+    assert mock_inst.mockproperty == 1
 
 
 def test_rproperty_readonly_writing_fails():
@@ -66,7 +66,7 @@ def test_rproperty_readonly_reading_passes():
         mockproperty = rproperty(fget=mockget, fset=None, readonly=True)
 
     mock_inst = Mock()
-    assert mock_inst.mockproperty ==  0
+    assert mock_inst.mockproperty == 0
 
 
 def test_rproperty_writeonly_reading_fails():
@@ -82,7 +82,7 @@ def test_rproperty_writeonly_reading_fails():
             mockproperty = rproperty(fget=mockget, fset=None, writeonly=True)
 
         mock_inst = Mock()
-        assert mock_inst.mockproperty ==  0
+        assert mock_inst.mockproperty == 0
 
 
 def test_rproperty_writeonly_writing_passes():

--- a/instruments/tests/test_property_factories/test_rproperty.py
+++ b/instruments/tests/test_property_factories/test_rproperty.py
@@ -8,7 +8,8 @@ Module containing tests for the property factories
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 
 from instruments.util_fns import rproperty
 from . import MockInstrument
@@ -38,20 +39,20 @@ def test_rproperty_basic():
     eq_(mock_inst.mockproperty, 1)
 
 
-@raises(AttributeError)
 def test_rproperty_readonly_writing_fails():
-    class Mock(MockInstrument):
+    with pytest.raises(AttributeError):
+        class Mock(MockInstrument):
 
-        def __init__(self):
-            super(Mock, self).__init__()
-            self._value = 0
+            def __init__(self):
+                super(Mock, self).__init__()
+                self._value = 0
 
-        def mockset(self, newval):  # pragma: no cover
-            self._value = newval
-        mockproperty = rproperty(fget=None, fset=mockset, readonly=True)
+            def mockset(self, newval):  # pragma: no cover
+                self._value = newval
+            mockproperty = rproperty(fget=None, fset=mockset, readonly=True)
 
-    mock_inst = Mock()
-    mock_inst.mockproperty = 1
+        mock_inst = Mock()
+        mock_inst.mockproperty = 1
 
 
 def test_rproperty_readonly_reading_passes():
@@ -69,20 +70,20 @@ def test_rproperty_readonly_reading_passes():
     eq_(mock_inst.mockproperty, 0)
 
 
-@raises(AttributeError)
 def test_rproperty_writeonly_reading_fails():
-    class Mock(MockInstrument):
+    with pytest.raises(AttributeError):
+        class Mock(MockInstrument):
 
-        def __init__(self):
-            super(Mock, self).__init__()
-            self._value = 0
+            def __init__(self):
+                super(Mock, self).__init__()
+                self._value = 0
 
-        def mockget(self):  # pragma: no cover
-            return self._value
-        mockproperty = rproperty(fget=mockget, fset=None, writeonly=True)
+            def mockget(self):  # pragma: no cover
+                return self._value
+            mockproperty = rproperty(fget=mockget, fset=None, writeonly=True)
 
-    mock_inst = Mock()
-    eq_(mock_inst.mockproperty, 0)
+        mock_inst = Mock()
+        eq_(mock_inst.mockproperty, 0)
 
 
 def test_rproperty_writeonly_writing_passes():
@@ -100,6 +101,6 @@ def test_rproperty_writeonly_writing_passes():
     mock_inst.mockproperty = 1
 
 
-@raises(ValueError)
 def test_rproperty_readonly_and_writeonly():
-    _ = rproperty(readonly=True, writeonly=True)
+    with pytest.raises(ValueError):
+        _ = rproperty(readonly=True, writeonly=True)

--- a/instruments/tests/test_property_factories/test_string_property.py
+++ b/instruments/tests/test_property_factories/test_string_property.py
@@ -8,8 +8,6 @@ Module containing tests for the string property factories
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
-
 from instruments.util_fns import string_property
 from . import MockInstrument
 
@@ -24,10 +22,10 @@ def test_string_property_basics():
 
     mock_inst = StringMock({'MOCK?': '"foobar"'})
 
-    eq_(mock_inst.mock_property, 'foobar')
+    assert mock_inst.mock_property ==  'foobar'
 
     mock_inst.mock_property = 'foo'
-    eq_(mock_inst.value, 'MOCK?\nMOCK "foo"\n')
+    assert mock_inst.value ==  'MOCK?\nMOCK "foo"\n'
 
 
 def test_string_property_different_bookmark_symbol():
@@ -36,10 +34,10 @@ def test_string_property_different_bookmark_symbol():
 
     mock_inst = StringMock({'MOCK?': '%^foobar%^'})
 
-    eq_(mock_inst.mock_property, 'foobar')
+    assert mock_inst.mock_property ==  'foobar'
 
     mock_inst.mock_property = 'foo'
-    eq_(mock_inst.value, 'MOCK?\nMOCK %^foo%^\n')
+    assert mock_inst.value ==  'MOCK?\nMOCK %^foo%^\n'
 
 
 def test_string_property_no_bookmark_symbol():
@@ -48,10 +46,10 @@ def test_string_property_no_bookmark_symbol():
 
     mock_inst = StringMock({'MOCK?': 'foobar'})
 
-    eq_(mock_inst.mock_property, 'foobar')
+    assert mock_inst.mock_property ==  'foobar'
 
     mock_inst.mock_property = 'foo'
-    eq_(mock_inst.value, 'MOCK?\nMOCK foo\n')
+    assert mock_inst.value ==  'MOCK?\nMOCK foo\n'
 
 
 def test_string_property_set_cmd():
@@ -60,7 +58,7 @@ def test_string_property_set_cmd():
 
     mock_inst = StringMock({'MOCK?': '"derp"'})
 
-    eq_(mock_inst.mock_property, 'derp')
+    assert mock_inst.mock_property ==  'derp'
 
     mock_inst.mock_property = 'qwerty'
-    eq_(mock_inst.value, 'MOCK?\nFOOBAR "qwerty"\n')
+    assert mock_inst.value ==  'MOCK?\nFOOBAR "qwerty"\n'

--- a/instruments/tests/test_property_factories/test_string_property.py
+++ b/instruments/tests/test_property_factories/test_string_property.py
@@ -22,10 +22,10 @@ def test_string_property_basics():
 
     mock_inst = StringMock({'MOCK?': '"foobar"'})
 
-    assert mock_inst.mock_property ==  'foobar'
+    assert mock_inst.mock_property == 'foobar'
 
     mock_inst.mock_property = 'foo'
-    assert mock_inst.value ==  'MOCK?\nMOCK "foo"\n'
+    assert mock_inst.value == 'MOCK?\nMOCK "foo"\n'
 
 
 def test_string_property_different_bookmark_symbol():
@@ -34,10 +34,10 @@ def test_string_property_different_bookmark_symbol():
 
     mock_inst = StringMock({'MOCK?': '%^foobar%^'})
 
-    assert mock_inst.mock_property ==  'foobar'
+    assert mock_inst.mock_property == 'foobar'
 
     mock_inst.mock_property = 'foo'
-    assert mock_inst.value ==  'MOCK?\nMOCK %^foo%^\n'
+    assert mock_inst.value == 'MOCK?\nMOCK %^foo%^\n'
 
 
 def test_string_property_no_bookmark_symbol():
@@ -46,10 +46,10 @@ def test_string_property_no_bookmark_symbol():
 
     mock_inst = StringMock({'MOCK?': 'foobar'})
 
-    assert mock_inst.mock_property ==  'foobar'
+    assert mock_inst.mock_property == 'foobar'
 
     mock_inst.mock_property = 'foo'
-    assert mock_inst.value ==  'MOCK?\nMOCK foo\n'
+    assert mock_inst.value == 'MOCK?\nMOCK foo\n'
 
 
 def test_string_property_set_cmd():
@@ -58,7 +58,7 @@ def test_string_property_set_cmd():
 
     mock_inst = StringMock({'MOCK?': '"derp"'})
 
-    assert mock_inst.mock_property ==  'derp'
+    assert mock_inst.mock_property == 'derp'
 
     mock_inst.mock_property = 'qwerty'
-    assert mock_inst.value ==  'MOCK?\nFOOBAR "qwerty"\n'
+    assert mock_inst.value == 'MOCK?\nFOOBAR "qwerty"\n'

--- a/instruments/tests/test_property_factories/test_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_unitful_property.py
@@ -8,7 +8,8 @@ Module containing tests for the unitful property factories
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 import quantities as pq
 
 from instruments.util_fns import unitful_property
@@ -62,24 +63,24 @@ def test_unitful_property_no_units_on_set():
     eq_(mock_inst.value, 'MOCK {:e}\n'.format(1000))
 
 
-@raises(ValueError)
 def test_unitful_property_wrong_units():
-    class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property('MOCK', pq.hertz)
+    with pytest.raises(ValueError):
+        class UnitfulMock(MockInstrument):
+            unitful_property = unitful_property('MOCK', pq.hertz)
 
-    mock_inst = UnitfulMock()
+        mock_inst = UnitfulMock()
 
-    mock_inst.unitful_property = 1 * pq.volt
+        mock_inst.unitful_property = 1 * pq.volt
 
 
-@raises(AttributeError)
 def test_unitful_property_writeonly_reading_fails():
-    class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property('MOCK', pq.hertz, writeonly=True)
+    with pytest.raises(AttributeError):
+        class UnitfulMock(MockInstrument):
+            unitful_property = unitful_property('MOCK', pq.hertz, writeonly=True)
 
-    mock_inst = UnitfulMock()
+        mock_inst = UnitfulMock()
 
-    _ = mock_inst.unitful_property
+        _ = mock_inst.unitful_property
 
 
 def test_unitful_property_writeonly_writing_passes():
@@ -92,14 +93,14 @@ def test_unitful_property_writeonly_writing_passes():
     eq_(mock_inst.value, 'MOCK {:e}\n'.format(1))
 
 
-@raises(AttributeError)
 def test_unitful_property_readonly_writing_fails():
-    class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property('MOCK', pq.hertz, readonly=True)
+    with pytest.raises(AttributeError):
+        class UnitfulMock(MockInstrument):
+            unitful_property = unitful_property('MOCK', pq.hertz, readonly=True)
 
-    mock_inst = UnitfulMock({'MOCK?': '1'})
+        mock_inst = UnitfulMock({'MOCK?': '1'})
 
-    mock_inst.unitful_property = 1 * pq.hertz
+        mock_inst.unitful_property = 1 * pq.hertz
 
 
 def test_unitful_property_readonly_reading_passes():
@@ -144,26 +145,26 @@ def test_unitful_property_valid_range_functions():
     eq_(mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0, 10))
 
 
-@raises(ValueError)
 def test_unitful_property_minimum_value():
-    class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property(
-            'MOCK', pq.hertz, valid_range=(0, 10))
+    with pytest.raises(ValueError):
+        class UnitfulMock(MockInstrument):
+            unitful_property = unitful_property(
+                'MOCK', pq.hertz, valid_range=(0, 10))
 
-    mock_inst = UnitfulMock()
+        mock_inst = UnitfulMock()
 
-    mock_inst.unitful_property = -1
+        mock_inst.unitful_property = -1
 
 
-@raises(ValueError)
 def test_unitful_property_maximum_value():
-    class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property(
-            'MOCK', pq.hertz, valid_range=(0, 10))
+    with pytest.raises(ValueError):
+        class UnitfulMock(MockInstrument):
+            unitful_property = unitful_property(
+                'MOCK', pq.hertz, valid_range=(0, 10))
 
-    mock_inst = UnitfulMock()
+        mock_inst = UnitfulMock()
 
-    mock_inst.unitful_property = 11
+        mock_inst.unitful_property = 11
 
 
 def test_unitful_property_input_decoration():

--- a/instruments/tests/test_property_factories/test_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_unitful_property.py
@@ -8,7 +8,6 @@ Module containing tests for the unitful property factories
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 import quantities as pq
 
@@ -26,10 +25,10 @@ def test_unitful_property_basics():
 
     mock_inst = UnitfulMock({'MOCK?': '1000'})
 
-    eq_(mock_inst.unitful_property, 1000 * pq.hertz)
+    assert mock_inst.unitful_property ==  1000 * pq.hertz
 
     mock_inst.unitful_property = 1000 * pq.hertz
-    eq_(mock_inst.value, 'MOCK?\nMOCK {:e}\n'.format(1000))
+    assert mock_inst.value ==  'MOCK?\nMOCK {:e}\n'.format(1000)
 
 
 def test_unitful_property_format_code():
@@ -40,7 +39,7 @@ def test_unitful_property_format_code():
     mock_inst = UnitfulMock()
 
     mock_inst.unitful_property = 1000 * pq.hertz
-    eq_(mock_inst.value, 'MOCK {:f}\n'.format(1000))
+    assert mock_inst.value ==  'MOCK {:f}\n'.format(1000)
 
 
 def test_unitful_property_rescale_units():
@@ -50,7 +49,7 @@ def test_unitful_property_rescale_units():
     mock_inst = UnitfulMock()
 
     mock_inst.unitful_property = 1 * pq.kilohertz
-    eq_(mock_inst.value, 'MOCK {:e}\n'.format(1000))
+    assert mock_inst.value ==  'MOCK {:e}\n'.format(1000)
 
 
 def test_unitful_property_no_units_on_set():
@@ -60,7 +59,7 @@ def test_unitful_property_no_units_on_set():
     mock_inst = UnitfulMock()
 
     mock_inst.unitful_property = 1000
-    eq_(mock_inst.value, 'MOCK {:e}\n'.format(1000))
+    assert mock_inst.value ==  'MOCK {:e}\n'.format(1000)
 
 
 def test_unitful_property_wrong_units():
@@ -90,7 +89,7 @@ def test_unitful_property_writeonly_writing_passes():
     mock_inst = UnitfulMock()
 
     mock_inst.unitful_property = 1 * pq.hertz
-    eq_(mock_inst.value, 'MOCK {:e}\n'.format(1))
+    assert mock_inst.value ==  'MOCK {:e}\n'.format(1)
 
 
 def test_unitful_property_readonly_writing_fails():
@@ -109,7 +108,7 @@ def test_unitful_property_readonly_reading_passes():
 
     mock_inst = UnitfulMock({'MOCK?': '1'})
 
-    eq_(mock_inst.unitful_property, 1 * pq.hertz)
+    assert mock_inst.unitful_property ==  1 * pq.hertz
 
 
 def test_unitful_property_valid_range():
@@ -122,7 +121,7 @@ def test_unitful_property_valid_range():
     mock_inst.unitful_property = 0
     mock_inst.unitful_property = 10
 
-    eq_(mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0, 10))
+    assert mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0 ==  10)
 
 
 def test_unitful_property_valid_range_functions():
@@ -142,7 +141,7 @@ def test_unitful_property_valid_range_functions():
     mock_inst.unitful_property = 0
     mock_inst.unitful_property = 10
 
-    eq_(mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0, 10))
+    assert mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0 ==  10)
 
 
 def test_unitful_property_minimum_value():
@@ -181,7 +180,7 @@ def test_unitful_property_input_decoration():
 
     mock_instrument = UnitfulMock({'MOCK:A?': 'garbage'})
 
-    eq_(mock_instrument.a, 1 * pq.Hz)
+    assert mock_instrument.a ==  1 * pq.Hz
 
 
 def test_unitful_property_input_decoration_not_a_function():
@@ -195,7 +194,7 @@ def test_unitful_property_input_decoration_not_a_function():
 
     mock_instrument = UnitfulMock({'MOCK:A?': '.123'})
 
-    eq_(mock_instrument.a, 0.123 * pq.Hz)
+    assert mock_instrument.a ==  0.123 * pq.Hz
 
 
 def test_unitful_property_output_decoration():
@@ -214,7 +213,7 @@ def test_unitful_property_output_decoration():
 
     mock_instrument.a = 345 * pq.hertz
 
-    eq_(mock_instrument.value, 'MOCK:A 1\n')
+    assert mock_instrument.value ==  'MOCK:A 1\n'
 
 
 def test_unitful_property_output_decoration_not_a_function():
@@ -230,7 +229,7 @@ def test_unitful_property_output_decoration_not_a_function():
 
     mock_instrument.a = 1 * pq.hertz
 
-    eq_(mock_instrument.value, 'MOCK:A True\n')
+    assert mock_instrument.value ==  'MOCK:A True\n'
 
 
 def test_unitful_property_split_str():
@@ -254,7 +253,7 @@ def test_unitful_property_name_read_not_none():
         )
 
     mock_inst = UnitfulMock({'MOCK?': '1000'})
-    eq_(mock_inst.a, 1000 * pq.hertz)
+    assert mock_inst.a ==  1000 * pq.hertz
     mock_inst.a = 1000 * pq.hertz
 
-    eq_(mock_inst.value, 'MOCK?\nFOOBAR {:e}\n'.format(1000))
+    assert mock_inst.value ==  'MOCK?\nFOOBAR {:e}\n'.format(1000)

--- a/instruments/tests/test_property_factories/test_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_unitful_property.py
@@ -25,10 +25,10 @@ def test_unitful_property_basics():
 
     mock_inst = UnitfulMock({'MOCK?': '1000'})
 
-    assert mock_inst.unitful_property ==  1000 * pq.hertz
+    assert mock_inst.unitful_property == 1000 * pq.hertz
 
     mock_inst.unitful_property = 1000 * pq.hertz
-    assert mock_inst.value ==  'MOCK?\nMOCK {:e}\n'.format(1000)
+    assert mock_inst.value == 'MOCK?\nMOCK {:e}\n'.format(1000)
 
 
 def test_unitful_property_format_code():
@@ -39,7 +39,7 @@ def test_unitful_property_format_code():
     mock_inst = UnitfulMock()
 
     mock_inst.unitful_property = 1000 * pq.hertz
-    assert mock_inst.value ==  'MOCK {:f}\n'.format(1000)
+    assert mock_inst.value == 'MOCK {:f}\n'.format(1000)
 
 
 def test_unitful_property_rescale_units():
@@ -49,7 +49,7 @@ def test_unitful_property_rescale_units():
     mock_inst = UnitfulMock()
 
     mock_inst.unitful_property = 1 * pq.kilohertz
-    assert mock_inst.value ==  'MOCK {:e}\n'.format(1000)
+    assert mock_inst.value == 'MOCK {:e}\n'.format(1000)
 
 
 def test_unitful_property_no_units_on_set():
@@ -59,7 +59,7 @@ def test_unitful_property_no_units_on_set():
     mock_inst = UnitfulMock()
 
     mock_inst.unitful_property = 1000
-    assert mock_inst.value ==  'MOCK {:e}\n'.format(1000)
+    assert mock_inst.value == 'MOCK {:e}\n'.format(1000)
 
 
 def test_unitful_property_wrong_units():
@@ -89,7 +89,7 @@ def test_unitful_property_writeonly_writing_passes():
     mock_inst = UnitfulMock()
 
     mock_inst.unitful_property = 1 * pq.hertz
-    assert mock_inst.value ==  'MOCK {:e}\n'.format(1)
+    assert mock_inst.value == 'MOCK {:e}\n'.format(1)
 
 
 def test_unitful_property_readonly_writing_fails():
@@ -108,7 +108,7 @@ def test_unitful_property_readonly_reading_passes():
 
     mock_inst = UnitfulMock({'MOCK?': '1'})
 
-    assert mock_inst.unitful_property ==  1 * pq.hertz
+    assert mock_inst.unitful_property == 1 * pq.hertz
 
 
 def test_unitful_property_valid_range():
@@ -121,7 +121,7 @@ def test_unitful_property_valid_range():
     mock_inst.unitful_property = 0
     mock_inst.unitful_property = 10
 
-    assert mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0 ==  10)
+    assert mock_inst.value == 'MOCK {:e}\nMOCK {:e}\n'.format(0, 10)
 
 
 def test_unitful_property_valid_range_functions():
@@ -141,7 +141,7 @@ def test_unitful_property_valid_range_functions():
     mock_inst.unitful_property = 0
     mock_inst.unitful_property = 10
 
-    assert mock_inst.value, 'MOCK {:e}\nMOCK {:e}\n'.format(0 ==  10)
+    assert mock_inst.value == 'MOCK {:e}\nMOCK {:e}\n'.format(0, 10)
 
 
 def test_unitful_property_minimum_value():
@@ -180,7 +180,7 @@ def test_unitful_property_input_decoration():
 
     mock_instrument = UnitfulMock({'MOCK:A?': 'garbage'})
 
-    assert mock_instrument.a ==  1 * pq.Hz
+    assert mock_instrument.a == 1 * pq.Hz
 
 
 def test_unitful_property_input_decoration_not_a_function():
@@ -194,7 +194,7 @@ def test_unitful_property_input_decoration_not_a_function():
 
     mock_instrument = UnitfulMock({'MOCK:A?': '.123'})
 
-    assert mock_instrument.a ==  0.123 * pq.Hz
+    assert mock_instrument.a == 0.123 * pq.Hz
 
 
 def test_unitful_property_output_decoration():
@@ -213,7 +213,7 @@ def test_unitful_property_output_decoration():
 
     mock_instrument.a = 345 * pq.hertz
 
-    assert mock_instrument.value ==  'MOCK:A 1\n'
+    assert mock_instrument.value == 'MOCK:A 1\n'
 
 
 def test_unitful_property_output_decoration_not_a_function():
@@ -229,7 +229,7 @@ def test_unitful_property_output_decoration_not_a_function():
 
     mock_instrument.a = 1 * pq.hertz
 
-    assert mock_instrument.value ==  'MOCK:A True\n'
+    assert mock_instrument.value == 'MOCK:A True\n'
 
 
 def test_unitful_property_split_str():
@@ -253,7 +253,7 @@ def test_unitful_property_name_read_not_none():
         )
 
     mock_inst = UnitfulMock({'MOCK?': '1000'})
-    assert mock_inst.a ==  1000 * pq.hertz
+    assert mock_inst.a == 1000 * pq.hertz
     mock_inst.a = 1000 * pq.hertz
 
-    assert mock_inst.value ==  'MOCK?\nFOOBAR {:e}\n'.format(1000)
+    assert mock_inst.value == 'MOCK?\nFOOBAR {:e}\n'.format(1000)

--- a/instruments/tests/test_property_factories/test_unitless_property.py
+++ b/instruments/tests/test_property_factories/test_unitless_property.py
@@ -25,10 +25,10 @@ def test_unitless_property_basics():
 
     mock_inst = UnitlessMock({'MOCK?': '1'})
 
-    assert mock_inst.mock_property ==  1
+    assert mock_inst.mock_property == 1
 
     mock_inst.mock_property = 1
-    assert mock_inst.value ==  'MOCK?\nMOCK {:e}\n'.format(1)
+    assert mock_inst.value == 'MOCK?\nMOCK {:e}\n'.format(1)
 
 
 def test_unitless_property_units():
@@ -48,7 +48,7 @@ def test_unitless_property_format_code():
     mock_inst = UnitlessMock()
 
     mock_inst.mock_property = 1
-    assert mock_inst.value ==  'MOCK {:f}\n'.format(1)
+    assert mock_inst.value == 'MOCK {:f}\n'.format(1)
 
 
 def test_unitless_property_writeonly_reading_fails():
@@ -68,7 +68,7 @@ def test_unitless_property_writeonly_writing_passes():
     mock_inst = UnitlessMock()
 
     mock_inst.mock_property = 1
-    assert mock_inst.value ==  'MOCK {:e}\n'.format(1)
+    assert mock_inst.value == 'MOCK {:e}\n'.format(1)
 
 
 def test_unitless_property_readonly_writing_fails():
@@ -87,7 +87,7 @@ def test_unitless_property_readonly_reading_passes():
 
     mock_inst = UnitlessMock({'MOCK?': '1'})
 
-    assert mock_inst.mock_property ==  1
+    assert mock_inst.mock_property == 1
 
 
 def test_unitless_property_set_cmd():
@@ -96,7 +96,7 @@ def test_unitless_property_set_cmd():
 
     mock_inst = UnitlessMock({'MOCK?': '1'})
 
-    assert mock_inst.mock_property ==  1
+    assert mock_inst.mock_property == 1
     mock_inst.mock_property = 1
 
-    assert mock_inst.value ==  'MOCK?\nFOOBAR {:e}\n'.format(1)
+    assert mock_inst.value == 'MOCK?\nFOOBAR {:e}\n'.format(1)

--- a/instruments/tests/test_property_factories/test_unitless_property.py
+++ b/instruments/tests/test_property_factories/test_unitless_property.py
@@ -8,7 +8,6 @@ Module containing tests for the unitless property factory
 
 from __future__ import absolute_import
 
-from nose.tools import eq_
 import pytest
 import quantities as pq
 
@@ -26,10 +25,10 @@ def test_unitless_property_basics():
 
     mock_inst = UnitlessMock({'MOCK?': '1'})
 
-    eq_(mock_inst.mock_property, 1)
+    assert mock_inst.mock_property ==  1
 
     mock_inst.mock_property = 1
-    eq_(mock_inst.value, 'MOCK?\nMOCK {:e}\n'.format(1))
+    assert mock_inst.value ==  'MOCK?\nMOCK {:e}\n'.format(1)
 
 
 def test_unitless_property_units():
@@ -49,7 +48,7 @@ def test_unitless_property_format_code():
     mock_inst = UnitlessMock()
 
     mock_inst.mock_property = 1
-    eq_(mock_inst.value, 'MOCK {:f}\n'.format(1))
+    assert mock_inst.value ==  'MOCK {:f}\n'.format(1)
 
 
 def test_unitless_property_writeonly_reading_fails():
@@ -69,7 +68,7 @@ def test_unitless_property_writeonly_writing_passes():
     mock_inst = UnitlessMock()
 
     mock_inst.mock_property = 1
-    eq_(mock_inst.value, 'MOCK {:e}\n'.format(1))
+    assert mock_inst.value ==  'MOCK {:e}\n'.format(1)
 
 
 def test_unitless_property_readonly_writing_fails():
@@ -88,7 +87,7 @@ def test_unitless_property_readonly_reading_passes():
 
     mock_inst = UnitlessMock({'MOCK?': '1'})
 
-    eq_(mock_inst.mock_property, 1)
+    assert mock_inst.mock_property ==  1
 
 
 def test_unitless_property_set_cmd():
@@ -97,7 +96,7 @@ def test_unitless_property_set_cmd():
 
     mock_inst = UnitlessMock({'MOCK?': '1'})
 
-    eq_(mock_inst.mock_property, 1)
+    assert mock_inst.mock_property ==  1
     mock_inst.mock_property = 1
 
-    eq_(mock_inst.value, 'MOCK?\nFOOBAR {:e}\n'.format(1))
+    assert mock_inst.value ==  'MOCK?\nFOOBAR {:e}\n'.format(1)

--- a/instruments/tests/test_property_factories/test_unitless_property.py
+++ b/instruments/tests/test_property_factories/test_unitless_property.py
@@ -8,7 +8,8 @@ Module containing tests for the unitless property factory
 
 from __future__ import absolute_import
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 import quantities as pq
 
 from instruments.util_fns import unitless_property
@@ -31,14 +32,14 @@ def test_unitless_property_basics():
     eq_(mock_inst.value, 'MOCK?\nMOCK {:e}\n'.format(1))
 
 
-@raises(ValueError)
 def test_unitless_property_units():
-    class UnitlessMock(MockInstrument):
-        mock_property = unitless_property('MOCK')
+    with pytest.raises(ValueError):
+        class UnitlessMock(MockInstrument):
+            mock_property = unitless_property('MOCK')
 
-    mock_inst = UnitlessMock({'MOCK?': '1'})
+        mock_inst = UnitlessMock({'MOCK?': '1'})
 
-    mock_inst.mock_property = 1 * pq.volt
+        mock_inst.mock_property = 1 * pq.volt
 
 
 def test_unitless_property_format_code():
@@ -51,14 +52,14 @@ def test_unitless_property_format_code():
     eq_(mock_inst.value, 'MOCK {:f}\n'.format(1))
 
 
-@raises(AttributeError)
 def test_unitless_property_writeonly_reading_fails():
-    class UnitlessMock(MockInstrument):
-        mock_property = unitless_property('MOCK', writeonly=True)
+    with pytest.raises(AttributeError):
+        class UnitlessMock(MockInstrument):
+            mock_property = unitless_property('MOCK', writeonly=True)
 
-    mock_inst = UnitlessMock()
+        mock_inst = UnitlessMock()
 
-    _ = mock_inst.mock_property
+        _ = mock_inst.mock_property
 
 
 def test_unitless_property_writeonly_writing_passes():
@@ -71,14 +72,14 @@ def test_unitless_property_writeonly_writing_passes():
     eq_(mock_inst.value, 'MOCK {:e}\n'.format(1))
 
 
-@raises(AttributeError)
 def test_unitless_property_readonly_writing_fails():
-    class UnitlessMock(MockInstrument):
-        mock_property = unitless_property('MOCK', readonly=True)
+    with pytest.raises(AttributeError):
+        class UnitlessMock(MockInstrument):
+            mock_property = unitless_property('MOCK', readonly=True)
 
-    mock_inst = UnitlessMock({'MOCK?': '1'})
+        mock_inst = UnitlessMock({'MOCK?': '1'})
 
-    mock_inst.mock_property = 1
+        mock_inst.mock_property = 1
 
 
 def test_unitless_property_readonly_reading_passes():

--- a/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
@@ -8,7 +8,7 @@ Module containing tests for the Qubitekk CC1
 
 from __future__ import absolute_import
 
-from nose.tools import raises
+import pytest
 import quantities as pq
 
 import instruments as ik
@@ -56,22 +56,22 @@ def test_cc1_window():
         cc.window = 7
 
 
-@raises(ValueError)
 def test_cc1_window_error():
-    with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            ":WIND 10"
-        ],
-        [
-            "",
-            "Firmware v2.010"
-        ],
-        sep="\n"
-    ) as cc:
-        cc.window = 10
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                ":WIND 10"
+            ],
+            [
+                "",
+                "Firmware v2.010"
+            ],
+            sep="\n"
+        ) as cc:
+            cc.window = 10
 
 
 def test_cc1_delay():
@@ -95,40 +95,40 @@ def test_cc1_delay():
         cc.delay = 2
 
 
-@raises(ValueError)
 def test_cc1_delay_error1():
-    with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            ":DELA -1"
-        ],
-        [
-            "",
-            "Firmware v2.010"
-        ],
-        sep="\n"
-    ) as cc:
-        cc.delay = -1
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                ":DELA -1"
+            ],
+            [
+                "",
+                "Firmware v2.010"
+            ],
+            sep="\n"
+        ) as cc:
+            cc.delay = -1
 
 
-@raises(ValueError)
 def test_cc1_delay_error2():
-    with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            ":DELA 1"
-        ],
-        [
-            "",
-            "Firmware v2.010"
-        ],
-        sep="\n"
-    ) as cc:
-        cc.delay = 1
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                ":DELA 1"
+            ],
+            [
+                "",
+                "Firmware v2.010"
+            ],
+            sep="\n"
+        ) as cc:
+            cc.delay = 1
 
 
 def test_cc1_dwell_old_firmware():
@@ -172,22 +172,22 @@ def test_cc1_dwell_new_firmware():
         cc.dwell_time = 2
 
 
-@raises(ValueError)
 def test_cc1_dwell_time_error():
-    with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            ":DWEL -1"
-        ],
-        [
-            "",
-            "Firmware v2.010"
-        ],
-        sep="\n"
-    ) as cc:
-        cc.dwell_time = -1
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                ":DWEL -1"
+            ],
+            [
+                "",
+                "Firmware v2.010"
+            ],
+            sep="\n"
+        ) as cc:
+            cc.dwell_time = -1
 
 
 def test_cc1_firmware():
@@ -303,22 +303,22 @@ def test_cc1_gate_old_firmware():
         cc.gate = False
 
 
-@raises(TypeError)
 def test_cc1_gate_error():
-    with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            ":GATE blo"
-        ],
-        [
-            "",
-            "Firmware v2.010"
-        ],
-        sep="\n"
-    ) as cc:
-        cc.gate = "blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                ":GATE blo"
+            ],
+            [
+                "",
+                "Firmware v2.010"
+            ],
+            sep="\n"
+        ) as cc:
+            cc.gate = "blo"
 
 
 def test_cc1_subtract_new_firmware():
@@ -345,23 +345,23 @@ def test_cc1_subtract_new_firmware():
         cc.subtract = False
 
 
-@raises(TypeError)
 def test_cc1_subtract_error():
-    with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            ":SUBT blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                ":SUBT blo"
 
-        ],
-        [
-            "",
-            "Firmware v2.010"
-        ],
-        sep="\n"
-    ) as cc:
-        cc.subtract = "blo"
+            ],
+            [
+                "",
+                "Firmware v2.010"
+            ],
+            sep="\n"
+        ) as cc:
+            cc.subtract = "blo"
 
 
 def test_cc1_trigger_mode():
@@ -410,21 +410,21 @@ def test_cc1_trigger_mode_old_firmware():
         cc.trigger_mode = cc.TriggerMode.start_stop
 
 
-@raises(ValueError)
 def test_cc1_trigger_mode_error():
-    with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?"
-        ],
-        [
-            "",
-            "Firmware v2.010"
-        ],
-        sep="\n"
-    ) as cc:
-        cc.trigger_mode = "blo"
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?"
+            ],
+            [
+                "",
+                "Firmware v2.010"
+            ],
+            sep="\n"
+        ) as cc:
+            cc.trigger_mode = "blo"
 
 
 def test_cc1_clear():
@@ -473,37 +473,37 @@ def test_acknowledge():
         cc.clear_counts()
 
 
-@raises(NotImplementedError)
 def test_acknowledge_notimplementederror():
-    with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?"
-        ],
-        [
-            "Unknown Command",
-            "Firmware v2.001"
+    with pytest.raises(NotImplementedError):
+        with expected_protocol(
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?"
+            ],
+            [
+                "Unknown Command",
+                "Firmware v2.001"
 
-        ],
-        sep="\n"
-    ) as cc:
-        cc.acknowledge = True
+            ],
+            sep="\n"
+        ) as cc:
+            cc.acknowledge = True
 
 
-@raises(NotImplementedError)
 def test_acknowledge_not_implemented_error():  # pylint: disable=protected-access
-    with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?"
-        ],
-        [
-            "Unknown Command",
-            "Firmware v2.001"
+    with pytest.raises(NotImplementedError):
+        with expected_protocol(
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?"
+            ],
+            [
+                "Unknown Command",
+                "Firmware v2.001"
 
-        ],
-        sep="\n"
-    ) as cc:
-        cc.acknowledge = True
+            ],
+            sep="\n"
+        ) as cc:
+            cc.acknowledge = True

--- a/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
@@ -8,7 +8,7 @@ Module containing tests for the Qubitekk MC1
 
 from __future__ import absolute_import
 
-from nose.tools import raises
+import pytest
 
 import quantities as pq
 import instruments as ik
@@ -201,12 +201,12 @@ def test_mc1_move():
         mc.move(0)
 
 
-@raises(ValueError)
 def test_mc1_move_value_error():
-    with expected_protocol(
-        ik.qubitekk.MC1,
-        [":MOVE -1000"],
-        [""],
-        sep="\r"
-    ) as mc:
-        mc.move(-1000)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.qubitekk.MC1,
+            [":MOVE -1000"],
+            [""],
+            sep="\r"
+        ) as mc:
+            mc.move(-1000)

--- a/instruments/tests/test_split_str.py
+++ b/instruments/tests/test_split_str.py
@@ -10,7 +10,8 @@ from __future__ import absolute_import
 
 import quantities as pq
 
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 
 from instruments.util_fns import (
     split_unit_str
@@ -108,22 +109,22 @@ def test_split_unit_str_scientific_notation():
     eq_(units, pq.dimensionless)
 
 
-@raises(ValueError)
 def test_split_unit_str_empty_string():
     """
     split_unit_str: Given an empty string, I expect the function to raise
     a ValueError.
     """
-    _ = split_unit_str("")
+    with pytest.raises(ValueError):
+        _ = split_unit_str("")
 
 
-@raises(ValueError)
 def test_split_unit_str_only_exponential():
     """
     split_unit_str: Given a string with only an exponential, I expect the
     function to raise a ValueError.
     """
-    _ = split_unit_str("E3")
+    with pytest.raises(ValueError):
+        _ = split_unit_str("E3")
 
 
 def test_split_unit_str_magnitude_with_decimal():
@@ -141,10 +142,10 @@ def test_split_unit_str_magnitude_with_decimal():
     eq_(units, "foobars")
 
 
-@raises(ValueError)
 def test_split_unit_str_only_units():
     """
     split_unit_str: Given a bad string containing only units (ie, no numbers),
     I expect the function to raise a ValueError.
     """
-    _ = split_unit_str("foobars")
+    with pytest.raises(ValueError):
+        _ = split_unit_str("foobars")

--- a/instruments/tests/test_split_str.py
+++ b/instruments/tests/test_split_str.py
@@ -27,8 +27,8 @@ def test_split_unit_str_magnitude_and_units():
     This checks that "[val] [units]" works where val is a non-scientific number
     """
     mag, units = split_unit_str("42 foobars")
-    assert mag ==  42
-    assert units ==  "foobars"
+    assert mag == 42
+    assert units == "foobars"
 
 
 def test_split_unit_str_magnitude_and_default_units():
@@ -40,8 +40,8 @@ def test_split_unit_str_magnitude_and_default_units():
     default_units as the units.
     """
     mag, units = split_unit_str("42", default_units="foobars")
-    assert mag ==  42
-    assert units ==  "foobars"
+    assert mag == 42
+    assert units == "foobars"
 
 
 def test_split_unit_str_ignore_default_units():
@@ -53,8 +53,8 @@ def test_split_unit_str_ignore_default_units():
     are ignored.
     """
     mag, units = split_unit_str("42 snafus", default_units="foobars")
-    assert mag ==  42
-    assert units ==  "snafus"
+    assert mag == 42
+    assert units == "snafus"
 
 
 def test_split_unit_str_lookups():
@@ -70,8 +70,8 @@ def test_split_unit_str_lookups():
         "SNA": "snafus"
     }
     mag, units = split_unit_str("42 FOO", lookup=unit_dict.__getitem__)
-    assert mag ==  42
-    assert units ==  "foobars"
+    assert mag == 42
+    assert units == "foobars"
 
 
 def test_split_unit_str_scientific_notation():
@@ -84,28 +84,28 @@ def test_split_unit_str_scientific_notation():
     """
     # No signs, no units
     mag, units = split_unit_str("123E1")
-    assert mag ==  1230
-    assert units ==  pq.dimensionless
+    assert mag == 1230
+    assert units == pq.dimensionless
     # Negative exponential, no units
     mag, units = split_unit_str("123E-1")
-    assert mag ==  12.3
-    assert units ==  pq.dimensionless
+    assert mag == 12.3
+    assert units == pq.dimensionless
     # Negative magnitude, no units
     mag, units = split_unit_str("-123E1")
-    assert mag ==  -1230
-    assert units ==  pq.dimensionless
+    assert mag == -1230
+    assert units == pq.dimensionless
     # No signs, with units
     mag, units = split_unit_str("123E1 foobars")
-    assert mag ==  1230
-    assert units ==  "foobars"
+    assert mag == 1230
+    assert units == "foobars"
     # Signs everywhere, with units
     mag, units = split_unit_str("-123E-1 foobars")
-    assert mag ==  -12.3
-    assert units ==  "foobars"
+    assert mag == -12.3
+    assert units == "foobars"
     # Lower case e
     mag, units = split_unit_str("123e1")
-    assert mag ==  1230
-    assert units ==  pq.dimensionless
+    assert mag == 1230
+    assert units == pq.dimensionless
 
 
 def test_split_unit_str_empty_string():
@@ -133,12 +133,12 @@ def test_split_unit_str_magnitude_with_decimal():
     """
     # Decimal and units
     mag, units = split_unit_str("123.4 foobars")
-    assert mag ==  123.4
-    assert units ==  "foobars"
+    assert mag == 123.4
+    assert units == "foobars"
     # Decimal, units, and exponential
     mag, units = split_unit_str("123.4E1 foobars")
-    assert mag ==  1234
-    assert units ==  "foobars"
+    assert mag == 1234
+    assert units == "foobars"
 
 
 def test_split_unit_str_only_units():

--- a/instruments/tests/test_split_str.py
+++ b/instruments/tests/test_split_str.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import
 
 import quantities as pq
 
-from nose.tools import eq_
 import pytest
 
 from instruments.util_fns import (
@@ -28,8 +27,8 @@ def test_split_unit_str_magnitude_and_units():
     This checks that "[val] [units]" works where val is a non-scientific number
     """
     mag, units = split_unit_str("42 foobars")
-    eq_(mag, 42)
-    eq_(units, "foobars")
+    assert mag ==  42
+    assert units ==  "foobars"
 
 
 def test_split_unit_str_magnitude_and_default_units():
@@ -41,8 +40,8 @@ def test_split_unit_str_magnitude_and_default_units():
     default_units as the units.
     """
     mag, units = split_unit_str("42", default_units="foobars")
-    eq_(mag, 42)
-    eq_(units, "foobars")
+    assert mag ==  42
+    assert units ==  "foobars"
 
 
 def test_split_unit_str_ignore_default_units():
@@ -54,8 +53,8 @@ def test_split_unit_str_ignore_default_units():
     are ignored.
     """
     mag, units = split_unit_str("42 snafus", default_units="foobars")
-    eq_(mag, 42)
-    eq_(units, "snafus")
+    assert mag ==  42
+    assert units ==  "snafus"
 
 
 def test_split_unit_str_lookups():
@@ -71,8 +70,8 @@ def test_split_unit_str_lookups():
         "SNA": "snafus"
     }
     mag, units = split_unit_str("42 FOO", lookup=unit_dict.__getitem__)
-    eq_(mag, 42)
-    eq_(units, "foobars")
+    assert mag ==  42
+    assert units ==  "foobars"
 
 
 def test_split_unit_str_scientific_notation():
@@ -85,28 +84,28 @@ def test_split_unit_str_scientific_notation():
     """
     # No signs, no units
     mag, units = split_unit_str("123E1")
-    eq_(mag, 1230)
-    eq_(units, pq.dimensionless)
+    assert mag ==  1230
+    assert units ==  pq.dimensionless
     # Negative exponential, no units
     mag, units = split_unit_str("123E-1")
-    eq_(mag, 12.3)
-    eq_(units, pq.dimensionless)
+    assert mag ==  12.3
+    assert units ==  pq.dimensionless
     # Negative magnitude, no units
     mag, units = split_unit_str("-123E1")
-    eq_(mag, -1230)
-    eq_(units, pq.dimensionless)
+    assert mag ==  -1230
+    assert units ==  pq.dimensionless
     # No signs, with units
     mag, units = split_unit_str("123E1 foobars")
-    eq_(mag, 1230)
-    eq_(units, "foobars")
+    assert mag ==  1230
+    assert units ==  "foobars"
     # Signs everywhere, with units
     mag, units = split_unit_str("-123E-1 foobars")
-    eq_(mag, -12.3)
-    eq_(units, "foobars")
+    assert mag ==  -12.3
+    assert units ==  "foobars"
     # Lower case e
     mag, units = split_unit_str("123e1")
-    eq_(mag, 1230)
-    eq_(units, pq.dimensionless)
+    assert mag ==  1230
+    assert units ==  pq.dimensionless
 
 
 def test_split_unit_str_empty_string():
@@ -134,12 +133,12 @@ def test_split_unit_str_magnitude_with_decimal():
     """
     # Decimal and units
     mag, units = split_unit_str("123.4 foobars")
-    eq_(mag, 123.4)
-    eq_(units, "foobars")
+    assert mag ==  123.4
+    assert units ==  "foobars"
     # Decimal, units, and exponential
     mag, units = split_unit_str("123.4E1 foobars")
-    eq_(mag, 1234)
-    eq_(units, "foobars")
+    assert mag ==  1234
+    assert units ==  "foobars"
 
 
 def test_split_unit_str_only_units():

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 import quantities as pq
 import numpy as np
-from nose.tools import raises
+import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -128,14 +128,14 @@ def test_sample_rate():  # sends index of VALID_SAMPLE_RATES
         inst.sample_rate = "trigger"
 
 
-@raises(ValueError)
 def test_sample_rate_invalid():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        inst.sample_rate = "foobar"
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            inst.sample_rate = "foobar"
 
 
 def test_buffer_mode():
@@ -194,16 +194,16 @@ def test_auto_offset():
         inst.auto_offset("x")
 
 
-@raises(ValueError)
 def test_auto_offset_invalid():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "AOFF 1",
-        ],
-        []
-    ) as inst:
-        inst.auto_offset(inst.Mode.theta)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [
+                "AOFF 1",
+            ],
+            []
+        ) as inst:
+            inst.auto_offset(inst.Mode.theta)
 
 
 def test_auto_phase():
@@ -270,14 +270,14 @@ def test_take_measurement():
         np.testing.assert_array_equal(resp, [[1.234, 5.678], [0.456, 5.321]])
 
 
-@raises(ValueError)
 def test_take_measurement_invalid_num_samples():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        _ = inst.take_measurement(sample_rate=1, num_samples=16384)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            _ = inst.take_measurement(sample_rate=1, num_samples=16384)
 
 
 def test_set_offset_expand():
@@ -302,54 +302,54 @@ def test_set_offset_expand_mode_as_str():
         inst.set_offset_expand(mode="x", offset=0, expand=1)
 
 
-@raises(ValueError)
 def test_set_offset_expand_invalid_mode():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        inst.set_offset_expand(mode=inst.Mode.theta, offset=0, expand=1)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            inst.set_offset_expand(mode=inst.Mode.theta, offset=0, expand=1)
 
 
-@raises(ValueError)
 def test_set_offset_expand_invalid_offset():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        inst.set_offset_expand(mode=inst.Mode.x, offset=106, expand=1)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            inst.set_offset_expand(mode=inst.Mode.x, offset=106, expand=1)
 
 
-@raises(ValueError)
 def test_set_offset_expand_invalid_expand():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        inst.set_offset_expand(mode=inst.Mode.x, offset=0, expand=5)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            inst.set_offset_expand(mode=inst.Mode.x, offset=0, expand=5)
 
 
-@raises(TypeError)
 def test_set_offset_expand_invalid_type_offset():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        inst.set_offset_expand(mode=inst.Mode.x, offset="derp", expand=1)
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            inst.set_offset_expand(mode=inst.Mode.x, offset="derp", expand=1)
 
 
-@raises(TypeError)
 def test_set_offset_expand_invalid_type_expand():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        inst.set_offset_expand(mode=inst.Mode.x, offset=0, expand="derp")
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            inst.set_offset_expand(mode=inst.Mode.x, offset=0, expand="derp")
 
 
 def test_start_scan():
@@ -404,34 +404,34 @@ def test_data_snap_mode_as_str():
         np.testing.assert_array_equal(data, expected)
 
 
-@raises(ValueError)
 def test_data_snap_invalid_snap_mode1():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        _ = inst.data_snap(mode1=inst.Mode.xnoise, mode2=inst.Mode.y)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            _ = inst.data_snap(mode1=inst.Mode.xnoise, mode2=inst.Mode.y)
 
 
-@raises(ValueError)
 def test_data_snap_invalid_snap_mode2():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        _ = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.ynoise)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            _ = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.ynoise)
 
 
-@raises(ValueError)
 def test_data_snap_identical_modes():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        _ = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.x)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            _ = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.x)
 
 
 def test_read_data_buffer():
@@ -468,14 +468,14 @@ def test_read_data_buffer_mode_as_str():
         np.testing.assert_array_equal(data, expected)
 
 
-@raises(ValueError)
 def test_read_data_buffer_invalid_mode():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        _ = inst.read_data_buffer(channel=inst.Mode.x)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            _ = inst.read_data_buffer(channel=inst.Mode.x)
 
 
 def test_clear_data_buffer():
@@ -519,43 +519,43 @@ def test_set_channel_display_params_as_str():
         )
 
 
-@raises(ValueError)
 def test_set_channel_display_invalid_channel():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        inst.set_channel_display(
-            channel=inst.Mode.x,
-            display=inst.Mode.x,
-            ratio=inst.Mode.none
-        )
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            inst.set_channel_display(
+                channel=inst.Mode.x,
+                display=inst.Mode.x,
+                ratio=inst.Mode.none
+            )
 
 
-@raises(ValueError)
 def test_set_channel_display_invalid_display():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        inst.set_channel_display(
-            channel=inst.Mode.ch1,
-            display=inst.Mode.y,  # y is only valid for ch2, not ch1!
-            ratio=inst.Mode.none
-        )
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            inst.set_channel_display(
+                channel=inst.Mode.ch1,
+                display=inst.Mode.y,  # y is only valid for ch2, not ch1!
+                ratio=inst.Mode.none
+            )
 
 
-@raises(ValueError)
 def test_set_channel_display_invalid_ratio():
-    with expected_protocol(
-        ik.srs.SRS830,
-        [],
-        []
-    ) as inst:
-        inst.set_channel_display(
-            channel=inst.Mode.ch1,
-            display=inst.Mode.x,
-            ratio=inst.Mode.xnoise
-        )
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.srs.SRS830,
+            [],
+            []
+        ) as inst:
+            inst.set_channel_display(
+                channel=inst.Mode.ch1,
+                display=inst.Mode.x,
+                ratio=inst.Mode.xnoise
+            )

--- a/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
@@ -8,7 +8,7 @@ Module containing tests for the Thorlabs LCC25
 
 from __future__ import absolute_import
 
-from nose.tools import raises
+import pytest
 import quantities as pq
 
 import instruments as ik
@@ -53,36 +53,36 @@ def test_lcc25_frequency():
         lcc.frequency = 10.0
 
 
-@raises(ValueError)
 def test_lcc25_frequency_lowlimit():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "freq=0.0"
-        ],
-        [
-            "freq=0.0",
-            ">"
-        ],
-        sep="\r"
-    ) as lcc:
-        lcc.frequency = 0.0
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [
+                "freq=0.0"
+            ],
+            [
+                "freq=0.0",
+                ">"
+            ],
+            sep="\r"
+        ) as lcc:
+            lcc.frequency = 0.0
 
 
-@raises(ValueError)
 def test_lcc25_frequency_highlimit():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "freq=160.0"
-        ],
-        [
-            "freq=160.0",
-            ">"
-        ],
-        sep="\r"
-    ) as lcc:
-        lcc.frequency = 160.0
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [
+                "freq=160.0"
+            ],
+            [
+                "freq=160.0",
+                ">"
+            ],
+            sep="\r"
+        ) as lcc:
+            lcc.frequency = 160.0
 
 
 def test_lcc25_mode():
@@ -104,14 +104,14 @@ def test_lcc25_mode():
         lcc.mode = ik.thorlabs.LCC25.Mode.voltage1
 
 
-@raises(ValueError)
 def test_lcc25_mode_invalid():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [],
-        []
-    ) as lcc:
-        lcc.mode = "blo"
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [],
+            []
+        ) as lcc:
+            lcc.mode = "blo"
 
 
 def test_lcc25_enable():
@@ -133,14 +133,14 @@ def test_lcc25_enable():
         lcc.enable = True
 
 
-@raises(TypeError)
 def test_lcc25_enable_invalid_type():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [],
-        []
-    ) as lcc:
-        lcc.enable = "blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [],
+            []
+        ) as lcc:
+            lcc.enable = "blo"
 
 
 def test_lcc25_extern():
@@ -162,14 +162,14 @@ def test_lcc25_extern():
         lcc.extern = True
 
 
-@raises(TypeError)
 def test_tc200_extern_invalid_type():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [],
-        []
-    ) as tc:
-        tc.extern = "blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [],
+            []
+        ) as tc:
+            tc.extern = "blo"
 
 
 def test_lcc25_remote():
@@ -191,14 +191,14 @@ def test_lcc25_remote():
         lcc.remote = True
 
 
-@raises(TypeError)
 def test_tc200_remote_invalid_type():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [],
-        []
-    ) as tc:
-        tc.remote = "blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [],
+            []
+        ) as tc:
+            tc.remote = "blo"
 
 
 def test_lcc25_voltage1():
@@ -302,20 +302,20 @@ def test_lcc25_dwell():
         lcc.dwell = 10
 
 
-@raises(ValueError)
 def test_lcc25_dwell_positive():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "dwell=-10"
-        ],
-        [
-            "dwell=-10",
-            ">"
-        ],
-        sep="\r"
-    ) as lcc:
-        lcc.dwell = -10
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [
+                "dwell=-10"
+            ],
+            [
+                "dwell=-10",
+                ">"
+            ],
+            sep="\r"
+        ) as lcc:
+            lcc.dwell = -10
 
 
 def test_lcc25_increment():
@@ -337,20 +337,20 @@ def test_lcc25_increment():
         lcc.increment = 10.0
 
 
-@raises(ValueError)
 def test_lcc25_increment_positive():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "increment=-10"
-        ],
-        [
-            "increment=-10",
-            ">"
-        ],
-        sep="\r"
-    ) as lcc:
-        lcc.increment = -10
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [
+                "increment=-10"
+            ],
+            [
+                "increment=-10",
+                ">"
+            ],
+            sep="\r"
+        ) as lcc:
+            lcc.increment = -10
 
 
 def test_lcc25_default():
@@ -401,15 +401,15 @@ def test_lcc25_set_settings():
         lcc.set_settings(2)
 
 
-@raises(ValueError)
 def test_lcc25_set_settings_invalid():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [],
-        [],
-        sep="\r"
-    ) as lcc:
-        lcc.set_settings(5)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [],
+            [],
+            sep="\r"
+        ) as lcc:
+            lcc.set_settings(5)
 
 
 def test_lcc25_get_settings():
@@ -428,15 +428,15 @@ def test_lcc25_get_settings():
         lcc.get_settings(2)
 
 
-@raises(ValueError)
 def test_lcc25_get_settings_invalid():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [],
-        [],
-        sep="\r"
-    ) as lcc:
-        lcc.get_settings(5)
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [],
+            [],
+            sep="\r"
+        ) as lcc:
+            lcc.get_settings(5)
 
 
 def test_lcc25_test_mode():
@@ -455,21 +455,21 @@ def test_lcc25_test_mode():
         lcc.test_mode()
 
 
-@raises(TypeError)
 def test_lcc25_remote_invalid_type():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [],
-        []
-    ) as lcc:
-        lcc.remote = "blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [],
+            []
+        ) as lcc:
+            lcc.remote = "blo"
 
 
-@raises(TypeError)
 def test_lcc25_extern_invalid_type():
-    with expected_protocol(
-        ik.thorlabs.LCC25,
-        [],
-        []
-    ) as lcc:
-        lcc.extern = "blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.LCC25,
+            [],
+            []
+        ) as lcc:
+            lcc.extern = "blo"

--- a/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
@@ -8,7 +8,7 @@ Module containing tests for the Thorlabs SC10
 
 from __future__ import absolute_import
 
-from nose.tools import raises
+import pytest
 import quantities as pq
 
 import instruments as ik
@@ -52,15 +52,15 @@ def test_sc10_enable():
         sc.enable = True
 
 
-@raises(TypeError)
 def test_sc10_enable_invalid():
-    with expected_protocol(
-        ik.thorlabs.SC10,
-        [],
-        [],
-        sep="\r"
-    ) as sc:
-        sc.enable = 10
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.SC10,
+            [],
+            [],
+            sep="\r"
+        ) as sc:
+            sc.enable = 10
 
 
 def test_sc10_repeat():
@@ -82,15 +82,15 @@ def test_sc10_repeat():
         sc.repeat = 10
 
 
-@raises(ValueError)
 def test_sc10_repeat_invalid():
-    with expected_protocol(
-        ik.thorlabs.SC10,
-        [],
-        [],
-        sep="\r"
-    ) as sc:
-        sc.repeat = -1
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.SC10,
+            [],
+            [],
+            sep="\r"
+        ) as sc:
+            sc.repeat = -1
 
 
 def test_sc10_mode():
@@ -112,15 +112,15 @@ def test_sc10_mode():
         sc.mode = ik.thorlabs.SC10.Mode.auto
 
 
-@raises(ValueError)
 def test_sc10_mode_invalid():
-    with expected_protocol(
-        ik.thorlabs.SC10,
-        [],
-        [],
-        sep="\r"
-    ) as sc:
-        sc.mode = "blo"
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.SC10,
+            [],
+            [],
+            sep="\r"
+        ) as sc:
+            sc.mode = "blo"
 
 
 def test_sc10_trigger():
@@ -218,15 +218,15 @@ def test_sc10_baud_rate():
         sc.baud_rate = 115200
 
 
-@raises(ValueError)
 def test_sc10_baud_rate_error():
-    with expected_protocol(
-        ik.thorlabs.SC10,
-        [],
-        [],
-        sep="\r"
-    ) as sc:
-        sc.baud_rate = 115201
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.SC10,
+            [],
+            [],
+            sep="\r"
+        ) as sc:
+            sc.baud_rate = 115201
 
 
 def test_sc10_closed():

--- a/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
@@ -9,7 +9,7 @@ Module containing tests for the Thorlabs TC200
 from __future__ import absolute_import
 
 from enum import IntEnum
-from nose.tools import raises
+import pytest
 import quantities as pq
 
 import instruments as ik
@@ -71,29 +71,29 @@ def test_tc200_mode_2():
         tc.mode = ik.thorlabs.TC200.Mode.normal
 
 
-@raises(TypeError)
 def test_tc200_mode_error():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [],
-        [],
-        sep="\r"
-    ) as tc:
-        tc.mode = "blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [],
+            [],
+            sep="\r"
+        ) as tc:
+            tc.mode = "blo"
 
 
-@raises(TypeError)
 def test_tc200_mode_error2():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [],
-        [],
-        sep="\r"
-    ) as tc:
-        class TestEnum(IntEnum):
-            blo = 1
-            beep = 2
-        tc.mode = TestEnum.blo
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [],
+            [],
+            sep="\r"
+        ) as tc:
+            class TestEnum(IntEnum):
+                blo = 1
+                beep = 2
+            tc.mode = TestEnum.blo
 
 
 def test_tc200_enable():
@@ -121,15 +121,15 @@ def test_tc200_enable():
         tc.enable = False
 
 
-@raises(TypeError)
 def test_tc200_enable_type():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [],
-        [],
-        sep="\r"
-    ) as tc:
-        tc.enable = "blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [],
+            [],
+            sep="\r"
+        ) as tc:
+            tc.enable = "blo"
 
 
 def test_tc200_temperature():
@@ -170,21 +170,21 @@ def test_tc200_temperature_set():
         tc.temperature_set = 40 * pq.degC
 
 
-@raises(ValueError)
 def test_tc200_temperature_range():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "tmax?"
-        ],
-        [
-            "tmax?",
-            "40",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.temperature_set = 50 * pq.degC
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "tmax?"
+            ],
+            [
+                "tmax?",
+                "40",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.temperature_set = 50 * pq.degC
 
 
 def test_tc200_pid():
@@ -261,111 +261,111 @@ def test_tc200_pid():
         tc.pid = (2, 0, 220)
 
 
-@raises(TypeError)
 def test_tc200_pid_invalid_type():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [],
-        [],
-        sep="\r"
-    ) as tc:
-        tc.pid = "foo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [],
+            [],
+            sep="\r"
+        ) as tc:
+            tc.pid = "foo"
 
 
-@raises(ValueError)
 def test_tc200_pmin():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "pgain=-1"
-        ],
-        [
-            "pgain=-1",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.p = -1
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "pgain=-1"
+            ],
+            [
+                "pgain=-1",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.p = -1
 
 
-@raises(ValueError)
 def test_tc200_pmax():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "pgain=260"
-        ],
-        [
-            "pgain=260",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.p = 260
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "pgain=260"
+            ],
+            [
+                "pgain=260",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.p = 260
 
 
-@raises(ValueError)
 def test_tc200_imin():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "igain=-1"
-        ],
-        [
-            "igain=-1",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.i = -1
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "igain=-1"
+            ],
+            [
+                "igain=-1",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.i = -1
 
 
-@raises(ValueError)
 def test_tc200_imax():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "igain=260"
-        ],
-        [
-            "igain=260",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.i = 260
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "igain=260"
+            ],
+            [
+                "igain=260",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.i = 260
 
 
-@raises(ValueError)
 def test_tc200_dmin():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "dgain=-1"
-        ],
-        [
-            "dgain=-1",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.d = -1
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "dgain=-1"
+            ],
+            [
+                "dgain=-1",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.d = -1
 
 
-@raises(ValueError)
 def test_tc200_dmax():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "dgain=260"
-        ],
-        [
-            "dgain=260",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.d = 260
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "dgain=260"
+            ],
+            [
+                "dgain=260",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.d = 260
 
 
 def test_tc200_degrees():
@@ -399,16 +399,15 @@ def test_tc200_degrees():
         tc.degrees = pq.degK
 
 
-@raises(TypeError)
 def test_tc200_degrees_invalid():
-
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [],
-        [],
-        sep="\r"
-    ) as tc:
-        tc.degrees = "blo"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [],
+            [],
+            sep="\r"
+        ) as tc:
+            tc.degrees = "blo"
 
 
 def test_tc200_sensor():
@@ -430,27 +429,27 @@ def test_tc200_sensor():
         tc.sensor = tc.Sensor.ptc100
 
 
-@raises(ValueError)
 def test_tc200_sensor_error():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [],
-        []
-    ) as tc:
-        tc.sensor = "blo"
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [],
+            []
+        ) as tc:
+            tc.sensor = "blo"
 
 
-@raises(ValueError)
 def test_tc200_sensor_error2():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [],
-        []
-    ) as tc:
-        class TestEnum(IntEnum):
-            blo = 1
-            beep = 2
-        tc.sensor = TestEnum.blo
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [],
+            []
+        ) as tc:
+            class TestEnum(IntEnum):
+                blo = 1
+                beep = 2
+            tc.sensor = TestEnum.blo
 
 
 def test_tc200_beta():
@@ -472,36 +471,36 @@ def test_tc200_beta():
         tc.beta = 2000
 
 
-@raises(ValueError)
 def test_tc200_beta_min():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "beta=200"
-        ],
-        [
-            "beta=200",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.beta = 200
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "beta=200"
+            ],
+            [
+                "beta=200",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.beta = 200
 
 
-@raises(ValueError)
 def test_tc200_beta_max():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "beta=20000"
-        ],
-        [
-            "beta=20000",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.beta = 20000
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "beta=20000"
+            ],
+            [
+                "beta=20000",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.beta = 20000
 
 
 def test_tc200_max_power():
@@ -523,36 +522,36 @@ def test_tc200_max_power():
         tc.max_power = 12 * pq.W
 
 
-@raises(ValueError)
 def test_tc200_power_min():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "PMAX=-2"
-        ],
-        [
-            "PMAX=-2",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.max_power = -1
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "PMAX=-2"
+            ],
+            [
+                "PMAX=-2",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.max_power = -1
 
 
-@raises(ValueError)
 def test_tc200_power_max():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "PMAX=20000"
-        ],
-        [
-            "PMAX=20000",
-            "> "
-        ],
-        sep="\r"
-    ) as tc:
-        tc.max_power = 20000
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "PMAX=20000"
+            ],
+            [
+                "PMAX=20000",
+                "> "
+            ],
+            sep="\r"
+        ) as tc:
+            tc.max_power = 20000
 
 
 def test_tc200_max_temperature():
@@ -574,33 +573,33 @@ def test_tc200_max_temperature():
         tc.max_temperature = 180 * pq.degC
 
 
-@raises(ValueError)
 def test_tc200_temp_min():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "TMAX=-2"
-        ],
-        [
-            "TMAX=-2",
-            ">"
-        ],
-        sep="\r"
-    ) as tc:
-        tc.max_temperature = -1
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "TMAX=-2"
+            ],
+            [
+                "TMAX=-2",
+                ">"
+            ],
+            sep="\r"
+        ) as tc:
+            tc.max_temperature = -1
 
 
-@raises(ValueError)
 def test_tc200_temp_max():
-    with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "TMAX=20000"
-        ],
-        [
-            "TMAX=20000",
-            ">"
-        ],
-        sep="\r"
-    ) as tc:
-        tc.max_temperature = 20000
+    with pytest.raises(ValueError):
+        with expected_protocol(
+            ik.thorlabs.TC200,
+            [
+                "TMAX=20000"
+            ],
+            [
+                "TMAX=20000",
+                ">"
+            ],
+            sep="\r"
+        ) as tc:
+            tc.max_temperature = 20000

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -8,7 +8,7 @@ Module containing tests for the Toptica Topmode
 
 from __future__ import absolute_import
 from datetime import datetime
-from nose.tools import raises
+import pytest
 import quantities as pq
 
 
@@ -101,44 +101,44 @@ def test_laser_enable():
         tm.laser[0].enable = True
 
 
-@raises(RuntimeError)
 def test_laser_enable_no_laser():
-    with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:serial-number)",
-            "(param-set! 'laser1:enable-emission #t)"
-        ],
-        [
-            "(param-ref 'laser1:serial-number)",
-            "unknown",
-            "> (param-set! 'laser1:enable-emission #t)",
-            "0",
-            "> "
-        ],
-        sep="\r\n"
-    ) as tm:
-        tm.laser[0].enable = True
+    with pytest.raises(RuntimeError):
+        with expected_protocol(
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:serial-number)",
+                "(param-set! 'laser1:enable-emission #t)"
+            ],
+            [
+                "(param-ref 'laser1:serial-number)",
+                "unknown",
+                "> (param-set! 'laser1:enable-emission #t)",
+                "0",
+                "> "
+            ],
+            sep="\r\n"
+        ) as tm:
+            tm.laser[0].enable = True
 
 
-@raises(TypeError)
 def test_laser_enable_error():
-    with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:serial-number)",
-            "(param-set! 'laser1:enable-emission #t)"
-        ],
-        [
-            "(param-ref 'laser1:serial-number)",
-            "bloop1",
-            "> (param-set! 'laser1:enable-emission #t)",
-            "0",
-            "> "
-        ],
-        sep="\n"
-    ) as tm:
-        tm.laser[0].enable = 'True'
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:serial-number)",
+                "(param-set! 'laser1:enable-emission #t)"
+            ],
+            [
+                "(param-ref 'laser1:serial-number)",
+                "bloop1",
+                "> (param-set! 'laser1:enable-emission #t)",
+                "0",
+                "> "
+            ],
+            sep="\n"
+        ) as tm:
+            tm.laser[0].enable = 'True'
 
 
 def test_laser_tec_status():
@@ -208,45 +208,45 @@ def test_laser_lock_start():
         _date = datetime(2012, 12, 1, 1, 2, 1)
         assert tm.laser[0].lock_start == _date
 
-@raises(RuntimeError)
 def test_laser_lock_start_runtime_error():
-    with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:charm:correction-status)",
-            "(param-ref 'laser1:charm:reg:started)"
-        ],
-        [
-            "(param-ref 'laser1:charm:correction-status)",
-            "0",
-            "> (param-ref 'laser1:charm:reg:started)",
-            "\"\"",
-            "> "
-        ],
-        sep="\r\n"
-    ) as tm:
-        _date = datetime(2012, 12, 1, 1, 2, 1)
-        assert tm.laser[0].lock_start == _date
+    with pytest.raises(RuntimeError):
+        with expected_protocol(
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:charm:correction-status)",
+                "(param-ref 'laser1:charm:reg:started)"
+            ],
+            [
+                "(param-ref 'laser1:charm:correction-status)",
+                "0",
+                "> (param-ref 'laser1:charm:reg:started)",
+                "\"\"",
+                "> "
+            ],
+            sep="\r\n"
+        ) as tm:
+            _date = datetime(2012, 12, 1, 1, 2, 1)
+            assert tm.laser[0].lock_start == _date
 
 
-@raises(RuntimeError)
 def test_laser_first_mode_hop_time_runtime_error():
-    with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)",
-            "(param-ref 'laser1:charm:reg:first-mh)"
-        ],
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)",
-            "#f",
-            "> (param-ref 'laser1:charm:reg:first-mh)",
-            "\"\"",
-            "> "
-        ],
-        sep="\r\n"
-    ) as tm:
-        assert tm.laser[0].first_mode_hop_time is None
+    with pytest.raises(RuntimeError):
+        with expected_protocol(
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)",
+                "(param-ref 'laser1:charm:reg:first-mh)"
+            ],
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)",
+                "#f",
+                "> (param-ref 'laser1:charm:reg:first-mh)",
+                "\"\"",
+                "> "
+            ],
+            sep="\r\n"
+        ) as tm:
+            assert tm.laser[0].first_mode_hop_time is None
 
 
 def test_laser_first_mode_hop_time():
@@ -269,24 +269,24 @@ def test_laser_first_mode_hop_time():
         assert tm.laser[0].first_mode_hop_time == _date
 
 
-@raises(RuntimeError)
 def test_laser_latest_mode_hop_time_none():
-    with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)",
-            "(param-ref 'laser1:charm:reg:latest-mh)"
-        ],
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)",
-            "#f",
-            "> (param-ref 'laser1:charm:reg:latest-mh)",
-            "\"\"",
-            "> "
-        ],
-        sep="\r\n"
-    ) as tm:
-        assert tm.laser[0].latest_mode_hop_time is None
+    with pytest.raises(RuntimeError):
+        with expected_protocol(
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)",
+                "(param-ref 'laser1:charm:reg:latest-mh)"
+            ],
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)",
+                "#f",
+                "> (param-ref 'laser1:charm:reg:latest-mh)",
+                "\"\"",
+                "> "
+            ],
+            sep="\r\n"
+        ) as tm:
+            assert tm.laser[0].latest_mode_hop_time is None
 
 
 def test_laser_latest_mode_hop_time():
@@ -559,20 +559,20 @@ def test_serial_number():
         assert tm.serial_number == '010101'
 
 
-@raises(TypeError)
 def test_enable_error():
-    with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-set! 'enable-emission #f)"
-        ],
-        [
-            "(param-set! 'enable-emission #f)",
-            ">"
-        ],
-        sep="\r\n"
-    ) as tm:
-        tm.enable = "False"
+    with pytest.raises(TypeError):
+        with expected_protocol(
+            ik.toptica.TopMode,
+            [
+                "(param-set! 'enable-emission #f)"
+            ],
+            [
+                "(param-set! 'enable-emission #f)",
+                ">"
+            ],
+            sep="\r\n"
+        ) as tm:
+            tm.enable = "False"
 
 
 def test_front_key():

--- a/instruments/tests/test_toptica/test_toptica_utils.py
+++ b/instruments/tests/test_toptica/test_toptica_utils.py
@@ -9,7 +9,7 @@ Module containing tests for Topical util functions
 from __future__ import absolute_import
 import datetime
 
-from nose.tools import raises
+import pytest
 
 from instruments.toptica import toptica_utils
 
@@ -22,9 +22,9 @@ def test_convert_boolean():
     assert toptica_utils.convert_toptica_boolean("Error: -3") is None
 
 
-@raises(ValueError)
 def test_convert_boolean_value():
-    toptica_utils.convert_toptica_boolean("blo")
+    with pytest.raises(ValueError):
+        toptica_utils.convert_toptica_boolean("blo")
 
 
 def test_convert_toptica_datetime():

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -12,7 +12,8 @@ from builtins import range
 
 from enum import Enum
 import quantities as pq
-from nose.tools import raises, eq_
+from nose.tools import eq_
+import pytest
 
 from instruments.util_fns import (
     ProxyList,
@@ -91,38 +92,38 @@ def test_ProxyList_iterator():
         i = i + 1
 
 
-@raises(IndexError)
 def test_ProxyList_invalid_idx_enum():
-    class ProxyChild(object):
+    with pytest.raises(IndexError):
+        class ProxyChild(object):
 
-        def __init__(self, parent, name):
-            self._parent = parent
-            self._name = name
+            def __init__(self, parent, name):
+                self._parent = parent
+                self._name = name
 
-    class MockEnum(Enum):
-        a = "aa"
-        b = "bb"
+        class MockEnum(Enum):
+            a = "aa"
+            b = "bb"
 
-    parent = object()
+        parent = object()
 
-    proxy_list = ProxyList(parent, ProxyChild, MockEnum)
+        proxy_list = ProxyList(parent, ProxyChild, MockEnum)
 
-    _ = proxy_list['c']  # Should raise IndexError
+        _ = proxy_list['c']  # Should raise IndexError
 
 
-@raises(IndexError)
 def test_ProxyList_invalid_idx():
-    class ProxyChild(object):
+    with pytest.raises(IndexError):
+        class ProxyChild(object):
 
-        def __init__(self, parent, name):
-            self._parent = parent
-            self._name = name
+            def __init__(self, parent, name):
+                self._parent = parent
+                self._name = name
 
-    parent = object()
+        parent = object()
 
-    proxy_list = ProxyList(parent, ProxyChild, range(5))
+        proxy_list = ProxyList(parent, ProxyChild, range(5))
 
-    _ = proxy_list[10]  # Should raise IndexError
+        _ = proxy_list[10]  # Should raise IndexError
 
 
 def test_assume_units_correct():
@@ -161,15 +162,15 @@ def test_temperature_conversion():
     eq_(out.magnitude, 270)
 
 
-@raises(ValueError)
 def test_temperater_conversion_failure():
-    blo = 70.0 * pq.degF
-    convert_temperature(blo, pq.V)
+    with pytest.raises(ValueError):
+        blo = 70.0 * pq.degF
+        convert_temperature(blo, pq.V)
 
 
-@raises(ValueError)
 def test_assume_units_failures():
-    assume_units(1, 'm').rescale('s')
+    with pytest.raises(ValueError):
+        assume_units(1, 'm').rescale('s')
 
 def test_setattr_expression_simple():
     class A(object):

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -12,7 +12,6 @@ from builtins import range
 
 from enum import Enum
 import quantities as pq
-from nose.tools import eq_
 import pytest
 
 from instruments.util_fns import (
@@ -72,7 +71,7 @@ def test_ProxyList_length():
 
     proxy_list = ProxyList(parent, ProxyChild, range(10))
 
-    eq_(len(proxy_list), 10)
+    assert len(proxy_list) ==  10
 
 
 def test_ProxyList_iterator():
@@ -88,7 +87,7 @@ def test_ProxyList_iterator():
 
     i = 0
     for item in proxy_list:
-        eq_(item._name, i)
+        assert item._name ==  i
         i = i + 1
 
 
@@ -130,36 +129,36 @@ def test_assume_units_correct():
     m = pq.Quantity(1, 'm')
 
     # Check that unitful quantities are kept unitful.
-    eq_(assume_units(m, 'mm').rescale('mm').magnitude, 1000)
+    assert assume_units(m, 'mm').rescale('mm').magnitude ==  1000
 
     # Check that raw scalars are made unitful.
-    eq_(assume_units(1, 'm').rescale('mm').magnitude, 1000)
+    assert assume_units(1, 'm').rescale('mm').magnitude ==  1000
 
 
 def test_temperature_conversion():
     blo = 70.0 * pq.degF
     out = convert_temperature(blo, pq.degC)
-    eq_(out.magnitude, 21.11111111111111)
+    assert out.magnitude ==  21.11111111111111
     out = convert_temperature(blo, pq.degK)
-    eq_(out.magnitude, 294.2055555555555)
+    assert out.magnitude ==  294.2055555555555
     out = convert_temperature(blo, pq.degF)
-    eq_(out.magnitude, 70.0)
+    assert out.magnitude ==  70.0
 
     blo = 20.0 * pq.degC
     out = convert_temperature(blo, pq.degF)
-    eq_(out.magnitude, 68)
+    assert out.magnitude ==  68
     out = convert_temperature(blo, pq.degC)
-    eq_(out.magnitude, 20.0)
+    assert out.magnitude ==  20.0
     out = convert_temperature(blo, pq.degK)
-    eq_(out.magnitude, 293.15)
+    assert out.magnitude ==  293.15
 
     blo = 270 * pq.degK
     out = convert_temperature(blo, pq.degC)
-    eq_(out.magnitude, -3.1499999999999773)
+    assert out.magnitude ==  -3.1499999999999773
     out = convert_temperature(blo, pq.degF)
-    eq_(out.magnitude, 141.94736842105263)
+    assert out.magnitude ==  141.94736842105263
     out = convert_temperature(blo, pq.K)
-    eq_(out.magnitude, 270)
+    assert out.magnitude ==  270
 
 
 def test_temperater_conversion_failure():

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -71,7 +71,7 @@ def test_ProxyList_length():
 
     proxy_list = ProxyList(parent, ProxyChild, range(10))
 
-    assert len(proxy_list) ==  10
+    assert len(proxy_list) == 10
 
 
 def test_ProxyList_iterator():
@@ -87,7 +87,7 @@ def test_ProxyList_iterator():
 
     i = 0
     for item in proxy_list:
-        assert item._name ==  i
+        assert item._name == i
         i = i + 1
 
 
@@ -129,36 +129,36 @@ def test_assume_units_correct():
     m = pq.Quantity(1, 'm')
 
     # Check that unitful quantities are kept unitful.
-    assert assume_units(m, 'mm').rescale('mm').magnitude ==  1000
+    assert assume_units(m, 'mm').rescale('mm').magnitude == 1000
 
     # Check that raw scalars are made unitful.
-    assert assume_units(1, 'm').rescale('mm').magnitude ==  1000
+    assert assume_units(1, 'm').rescale('mm').magnitude == 1000
 
 
 def test_temperature_conversion():
     blo = 70.0 * pq.degF
     out = convert_temperature(blo, pq.degC)
-    assert out.magnitude ==  21.11111111111111
+    assert out.magnitude == 21.11111111111111
     out = convert_temperature(blo, pq.degK)
-    assert out.magnitude ==  294.2055555555555
+    assert out.magnitude == 294.2055555555555
     out = convert_temperature(blo, pq.degF)
-    assert out.magnitude ==  70.0
+    assert out.magnitude == 70.0
 
     blo = 20.0 * pq.degC
     out = convert_temperature(blo, pq.degF)
-    assert out.magnitude ==  68
+    assert out.magnitude == 68
     out = convert_temperature(blo, pq.degC)
-    assert out.magnitude ==  20.0
+    assert out.magnitude == 20.0
     out = convert_temperature(blo, pq.degK)
-    assert out.magnitude ==  293.15
+    assert out.magnitude == 293.15
 
     blo = 270 * pq.degK
     out = convert_temperature(blo, pq.degC)
-    assert out.magnitude ==  -3.1499999999999773
+    assert out.magnitude == -3.1499999999999773
     out = convert_temperature(blo, pq.degF)
-    assert out.magnitude ==  141.94736842105263
+    assert out.magnitude == 141.94736842105263
     out = convert_temperature(blo, pq.K)
-    assert out.magnitude ==  270
+    assert out.magnitude == 270
 
 
 def test_temperater_conversion_failure():

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = [
     "numpy",
-    "pyserial",
+    "pyserial>=3.3",
     "quantities",
     "enum34",
     "future",

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,4 @@
 envlist = py27,py34,py35,py36
 [testenv]
 deps = -rdev-requirements.txt
-commands = nosetests
+commands = pytest


### PR DESCRIPTION
Move from nose to pytest. Fixes #58.

The commit messages have some explanations, basically this was more or less tedious copy/paste. A lot of code was touched because the transition to `pytest.raises` necessitates increasing indentation for a whole block. (You can inspect changes without considering whitespace by appending `?w=1` to the URL)

Pytest tests all pass, the same number as before with nose. Let's see what the CI says.