### PR TITLE
[WIP] Optical spectrum analyzers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ Thumbs.db
 ## Build directories ##
 doc/_build
 
+## Venv
+.venv/
+
+
 ## setup.py generated files ##
 MANIFEST
 
@@ -20,6 +24,7 @@ MANIFEST
 *.so
 
 # Packages
+.egg/
 *.egg
 *.egg-info
 dist

--- a/instruments/abstract_instruments/__init__.py
+++ b/instruments/abstract_instruments/__init__.py
@@ -19,3 +19,9 @@ from .power_supply import (
     PowerSupplyChannel,
     PowerSupply,
 )
+
+from .optical_spectrum_analyzer import (
+    OSAChannel,
+    OpticalSpectrumAnalyzer,
+)
+

--- a/instruments/abstract_instruments/comm/abstract_comm.py
+++ b/instruments/abstract_instruments/comm/abstract_comm.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 
 import abc
 import logging
+import struct
 
 from future.utils import with_metaclass
 
@@ -202,7 +203,14 @@ class AbstractCommunicator(with_metaclass(abc.ABCMeta, object)):
         :return: The read string from the connection
         :rtype: `str`
         """
-        return self.read_raw(size).decode(encoding)
+        if encoding == 'utf-8':
+            return self.read_raw(size).decode(encoding)
+
+        elif encoding == 'IEEE-754/64':
+            return struct.unpack('>d', self.read_raw(size))[0]
+
+        else:
+            raise ValueError("Encoding {} is not currently supported.".format(encoding))
 
     def sendcmd(self, msg):
         """

--- a/instruments/abstract_instruments/comm/visa_communicator.py
+++ b/instruments/abstract_instruments/comm/visa_communicator.py
@@ -124,14 +124,11 @@ class VisaCommunicator(io.IOBase, AbstractCommunicator):
         :rtype: `bytes`
         """
         if size >= 0:
-            while len(self._buf) < size:
-                data = self._conn.read()
-                if data == "":
-                    break
-                self._buf += data
+            self._buf += self._conn.read_bytes(size)
             msg = self._buf[:size]
             # Remove the front of the buffer.
             del self._buf[:size]
+
         elif size == -1:
             # Read the whole contents, appending the buffer we've already read.
             msg = self._buf + self._conn.read()
@@ -193,4 +190,4 @@ class VisaCommunicator(io.IOBase, AbstractCommunicator):
         :rtype: `str`
         """
         msg += self._terminator
-        return self._conn.ask(msg)
+        return self._conn.query(msg)

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -151,7 +151,7 @@ class Instrument(object):
                 )
         return value
 
-    def read(self, size=-1):
+    def read(self, size=-1, encoding="utf-8"):
         """
         Read the last line.
 
@@ -161,7 +161,7 @@ class Instrument(object):
             connected instrument.
         :rtype: `str`
         """
-        return self._file.read(size)
+        return self._file.read(size, encoding)
 
     # PROPERTIES #
 

--- a/instruments/abstract_instruments/optical_spectrum_analyzer.py
+++ b/instruments/abstract_instruments/optical_spectrum_analyzer.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Provides an abstract base class for optical spectrum analyzer instruments
+"""
+
+# IMPORTS #####################################################################
+
+from __future__ import absolute_import
+from __future__ import division
+
+import abc
+
+from future.utils import with_metaclass
+
+from instruments.abstract_instruments import Instrument
+
+# CLASSES #####################################################################
+
+
+class OSAChannel(with_metaclass(abc.ABCMeta, object)):
+
+    """
+    Abstract base class for physical channels on an optical spectrum analyzer.
+
+    All applicable concrete instruments should inherit from this ABC to
+    provide a consistent interface to the user.
+    """
+
+    # METHODS #
+
+    @abc.abstractmethod
+    def wavelength(self, bin_format=True):
+        """
+        Gets the x-axis of the specified data source channel. This is an
+        abstract property.
+
+        :param bool bin_format: If the waveform should be transfered in binary
+            (``True``) or ASCII (``False``) formats.
+        :return: The wavelength component of the waveform.
+        :rtype: `numpy.ndarray`
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def data(self, bin_format=True):
+        """
+        Gets the y-axis of the specified data source channel. This is an
+        abstract property.
+
+        :param bool bin_format: If the waveform should be transfered in binary
+            (``True``) or ASCII (``False``) formats.
+        :return: The y-component of the waveform.
+        :rtype: `numpy.ndarray`
+        """
+        raise NotImplementedError
+
+
+class OpticalSpectrumAnalyzer(with_metaclass(abc.ABCMeta, Instrument)):
+
+    """
+    Abstract base class for optical spectrum analyzer instruments.
+
+    All applicable concrete instruments should inherit from this ABC to
+    provide a consistent interface to the user.
+    """
+
+    # PROPERTIES #
+
+    @abc.abstractproperty
+    def channel(self):
+        """
+        Gets an iterator or list for easy Pythonic access to the various
+        channel objects on the OSA instrument. Typically generated
+        by the `~instruments.util_fns.ProxyList` helper.
+        """
+        raise NotImplementedError
+
+
+    @property
+    @abc.abstractmethod
+    def start_wl(self):
+        """
+        Gets/sets the the start wavelength of the OSA. This is
+        an abstract property.
+
+        :type: `~quantities.Quantity`
+        """
+        raise NotImplementedError
+
+    @start_wl.setter
+    @abc.abstractmethod
+    def start_wl(self, newval):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def stop_wl(self):
+        """
+        Gets/sets the the stop wavelength of the OSA. This is
+        an abstract property.
+
+        :type: `~quantities.Quantity`
+        """
+        raise NotImplementedError
+
+    @stop_wl.setter
+    @abc.abstractmethod
+    def stop_wl(self, newval):
+        raise NotImplementedError
+
+    @property
+    @abc.abstractmethod
+    def bandwidth(self):
+        """
+        Gets/sets the the bandwidth of the OSA. This is
+        an abstract property.
+
+        :type: `~quantities.Quantity`
+        """
+        raise NotImplementedError
+
+    @bandwidth.setter
+    @abc.abstractmethod
+    def bandwidth(self, newval):
+        raise NotImplementedError
+
+
+    # METHODS #
+
+    @abc.abstractmethod
+    def start_sweep(self):
+        """
+        Forces a start sweep on the attached OSA.
+        """
+        raise NotImplementedError

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -710,13 +710,13 @@ def test_instrument_read():
     inst._file.read.return_value = "foobar"
 
     assert inst.read() == "foobar"
-    inst._file.read.assert_called_with(-1)
+    inst._file.read.assert_called_with(-1, 'utf-8')
 
     inst._file = mock.MagicMock()
     inst._file.read.return_value = "foobar"
 
     assert inst.read(6) == "foobar"
-    inst._file.read.assert_called_with(6)
+    inst._file.read.assert_called_with(6, 'utf-8')
 
 
 def test_instrument_write():

--- a/instruments/thorlabs/pm100usb.py
+++ b/instruments/thorlabs/pm100usb.py
@@ -222,7 +222,7 @@ class PM100USB(SCPIInstrument):
 
     })
 
-    def read(self, size=-1):
+    def read(self, size=-1, encoding='utf-8'):
         """
         Reads a measurement from this instrument, according to its current
         configuration mode.

--- a/instruments/yokogawa/__init__.py
+++ b/instruments/yokogawa/__init__.py
@@ -7,3 +7,4 @@ Module containing Yokogawa instruments
 from __future__ import absolute_import
 
 from .yokogawa7651 import Yokogawa7651
+from .yokogawa6370 import Yokogawa6370

--- a/instruments/yokogawa/yokogawa6370.py
+++ b/instruments/yokogawa/yokogawa6370.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Provides support for the Yokogawa 6370 optical spectrum analyzer.
+"""
+
+# IMPORTS #####################################################################
+
+from __future__ import absolute_import
+from __future__ import division
+
+from enum import IntEnum,Enum
+
+import quantities as pq
+
+from instruments.abstract_instruments import (
+    OpticalSpectrumAnalyzer,
+    OSAChannel,
+)
+from instruments.abstract_instruments import Instrument
+from instruments.util_fns import (
+    enum_property, string_property, int_property, unitful_property,
+    unitless_property, bounded_unitful_property, ProxyList, assume_units
+)
+
+# CLASSES #####################################################################
+
+
+# import instruments as ik
+# import quantities as pq
+# 
+# 
+# 
+# 
+# inst = ik.yokogawa.Yokogawa6370.open_tcpip('192.168.0.35',10001)
+# inst.start_wl = 1030e-9 * pq.m
+# inst.sendcmd(':FORMat:DATA REAL,64')
+# a = inst.channel[1].data()
+
+class Yokogawa6370(OpticalSpectrumAnalyzer, Instrument):
+
+    """
+    The Yokogawa 6370 is a optical spectrum analyzer.
+
+    Example usage:
+
+    >>> import instruments as ik
+    >>> import quantities as pq
+    >>> inst = ik.yokogawa.Yokogawa6370.open_visa('TCPIP0:192.168.0.35')
+    >>> inst.start_wl = 1030e-9 * pq.m
+    """
+
+
+
+ ####       def __init__(self):
+    #     # super(Yokogawa6370, self).__init__()
+    #     # Set data Format to binary
+    #     self.sendcmd(':FORMat:DATA REAL,64')
+        
+    # INNER CLASSES #
+
+    class Channel(OSAChannel):
+
+        """
+        Class representing the channels on the Yokogawa 6370.
+
+        This class inherits from `OSAChannel`.
+
+        .. warning:: This class should NOT be manually created by the user. It
+            is designed to be initialized by the `Yokogawa6370` class.
+        """
+        _trace_names = ['TRA','TRB','TRC','TRD','TRE','TRF','TRG']
+        
+        def __init__(self, parent, idx):
+            self._parent = parent
+            self._name = self._trace_names[idx]
+
+        # METHODS #
+        
+        def data(self, bin_format=True):
+            cmd = ':TRAC:Y? '+self._name  
+            self._parent.sendcmd(cmd)
+            data = self._parent.binblockread(data_width = 4,fmt = '<d')
+            self._parent._file.read_raw(1)
+            return data
+            
+        def wavelength(self, bin_format=True):
+            cmd = ':TRAC:X? '+self._name  
+            self._parent.sendcmd(cmd)
+            data = self._parent.binblockread(data_width = 4,fmt = '<d')
+            self._parent._file.read_raw(1)
+            return data
+
+    
+
+    # ENUMS #
+
+    class SweepModes(IntEnum):
+        """
+        Enum containing valid output modes for the Yokogawa 7651
+        """
+        AUTO   = 3
+        SINGLE = 1
+        REPEAT = 2
+        
+    class Traces(Enum):
+        """
+        Enum containing valid Traces for the Yokogawa 7651
+        """
+        A = 'TRA'
+        B = 'TRB'
+        C = 'TRC'
+        D = 'TRD'
+        E = 'TRE'
+        F = 'TRF'
+        G = 'TRG'
+        
+        
+    # PROPERTIES #
+
+    @property
+    def channel(self):
+        """
+        Gets the specific channel object.
+        This channel is accessed as a list in the following manner::
+
+        >>> import instruments as ik
+        >>> yoko = ik.yokogawa.Yokogawa7630.open_gpibusb('/dev/ttyUSB0')
+        >>> dat = yoko.channel[0].data # Gets the data of channel 0
+
+        :rtype: `~Yokogawa6370.Channel`
+        """
+        return ProxyList(self, Yokogawa6370.Channel, range(6))
+
+
+
+    start_wl, start_wl_min, start_wl_max = bounded_unitful_property(
+        ":SENS:WAV:STAR",
+        pq.meter,
+        doc="""
+        The start wavelength in m.
+        """,
+        valid_range = (600e-9,1700e-9)
+    )
+    
+    stop_wl, stop_wl_min, stop_wl_max = bounded_unitful_property(
+        ":SENS:WAV:STOP",
+        pq.meter,
+        doc="""
+        The stop wavelength in m.
+        """,
+        valid_range = (600e-9,1700e-9)
+    )
+    
+    bandwidth = unitful_property(
+        ":SENS:BAND:RES",
+        pq.meter,
+        doc="""
+        The bandwidth in m.
+        """
+    )
+    
+    span = unitful_property(
+        ":SENS:WAV:SPAN",
+        pq.meter,
+        doc="""
+        A floating point property that controls the wavelength span in m.
+        """)
+   
+    center_wl = unitful_property(
+        ":SENS:WAV:CENT",
+        pq.meter,
+        doc="""
+         A floating point property that controls the center wavelength m.
+        """)
+    
+    points = unitless_property( 
+       ":SENS:SWE:POIN",
+       doc="""
+        An integer property that controls the number of points in a trace.
+        """)
+        
+    sweep_mode = enum_property(
+        ":INIT:SMOD",
+        SweepModes,
+        input_decoration = lambda val: int(val),
+        doc = """
+        A property to control the Sweep Mode as oe of Yokogawa6370.SweepMode. 
+        Effective only after a self.start_sweep()."""
+        )
+    
+    active_trace = enum_property(
+    ":TRAC:ACTIVE",
+    Traces,
+    doc = """
+    The active trace of the OSA of enum Yokogawa6370.Traces. Determines the 
+    result of Yokogawa6370.data() and Yokogawa6370.wavelength()."""
+    )
+    
+
+    # METHODS #
+    
+    
+    
+    def data(self):
+        """
+        Function to query the active Trace data of the OSA.
+        """
+        cmd = ':TRAC:Y? '+ self.active_trace.value
+        self.sendcmd(cmd)
+        data = self.binblockread(data_width = 4,fmt = '<d')
+        self._file.read_raw(1)
+        return data
+        
+    def wavelength(self):
+        """
+        Query the wavelength axis of the active trace.
+        """
+        cmd = ':TRAC:X? '+  self.active_trace.value    
+        self.sendcmd(cmd)
+        data = self.binblockread(data_width = 4,fmt = '<d')
+        self._file.read_raw(1)
+        return data
+
+    def start_sweep(self):
+        """
+        Triggering function for the Yokogawa 7630.
+
+        After changing the sweep mode, the device needs to be triggered before it will update.
+        """
+        self.sendcmd('*CLS;:init')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 pyserial
+pyvisa==1.9.0
 quantities>=0.12.1
 future>=0.15
 enum34

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ CLASSIFIERS = [
 INSTALL_REQUIRES = [
     "numpy",
     "pyserial>=3.3",
+    "pyvisa>=1.9.0",
     "quantities",
     "enum34",
     "future",
@@ -45,9 +46,7 @@ INSTALL_REQUIRES = [
     "pyusb",
     "ruamel.yaml"
 ]
-EXTRAS_REQUIRE = {
-    'VISA': ["pyvisa"]
-}
+
 
 # HELPER FUNCTONS ############################################################
 
@@ -61,6 +60,7 @@ def read(*parts):
     """
     with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:
         return f.read()
+
 
 META_FILE = read(META_PATH)
 
@@ -77,18 +77,22 @@ def find_meta(meta):
         return meta_match.group(1)
     raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
 
+
 # MAIN #######################################################################
 
-if __name__ == "__main__":
-    setup(
-        name=find_meta("title"),
-        version=find_meta("version"),
-        url=find_meta("uri"),
-        author=find_meta("author"),
-        author_email=find_meta("email"),
-        packages=PACKAGES,
-        install_requires=INSTALL_REQUIRES,
-        extras_require=EXTRAS_REQUIRE,
-        description=find_meta("description"),
-        classifiers=CLASSIFIERS
-    )
+
+setup(
+    name=find_meta("title"),
+    version=find_meta("version"),
+    url=find_meta("uri"),
+    author=find_meta("author"),
+    author_email=find_meta("email"),
+    packages=PACKAGES,
+    install_requires=INSTALL_REQUIRES,
+    tests_require=[
+        'pytest >= 2.9.1',
+        'hypothesis'
+    ],
+    description=find_meta("description"),
+    classifiers=CLASSIFIERS
+)


### PR DESCRIPTION
I started this pull request as a discussion point for implementing a new class of devices: Optical Spectrum Analyzers (OSA). They usually come as multi-channel devices and I started implementing an abstract base class as well as the first device from our lab.

In the past I started using my own [homebrew version ](https://github.com/timhellwig/sci_instr) for instrument control and then switched to [pymeasure](https://github.com/ralph-group/pymeasure), which i really liked with regards to its simplicity and still powerful options, e.g. like strict_discrete_set validators for inputs. 

However, as it seems that the consens there was to push instrument implementation to somewhere else ralph-group/pymeasure#143 I am now moving to InstrumentKit and working on understanding how everything is organized.

Maybe someone more familiar with the project can review the [abstract base class](https://github.com/Galvant/InstrumentKit/blob/b033724852dca0ac81c92da1691d95b04b6cbfc6/instruments/abstract_instruments/optical_spectrum_analyzer.py).  If everything is looking fine, I will proceed in the future in implementing the rest of our OSA devices.

Best regards,
Tim