### PR TITLE
Fix socket.shutdown function call (issue #189)

### DIFF
--- a/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/instruments/abstract_instruments/comm/socket_communicator.py
@@ -91,7 +91,7 @@ class SocketCommunicator(io.IOBase, AbstractCommunicator):
         Shutdown and close the `socket.socket` connection.
         """
         try:
-            self._conn.shutdown()
+            self._conn.shutdown(socket.SHUT_RDWR)
         finally:
             self._conn.close()
 

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -88,7 +88,7 @@ def test_socketcomm_close():
     comm._conn = mock.MagicMock()
 
     comm.close()
-    comm._conn.shutdown.assert_called_with()
+    comm._conn.shutdown.assert_called_with(socket.SHUT_RDWR)
     comm._conn.close.assert_called_with()
 
 


### PR DESCRIPTION
Addresses issue #189 by correctly passing `socket.SHUT_RDWR` into the socket shutdown method.