### PR TITLE
Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - pylint --version
 script:
   - pytest --cov=instruments
-  - pylint --py3k instruments
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.7 ]]; then pylint --py3k instruments; fi
   - if [[ $TRAVIS_PYTHON_VERSION != 3.7 ]]; then pylint --disable=I instruments; fi
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 install:
   - "pip install -r requirements.txt"
   - "pip install -r dev-requirements.txt"
@@ -35,3 +36,4 @@ deploy:
   distributions: "sdist bdist_wheel"
   on:
     tags: true
+    condition: "$TRAVIS_PYTHON_VERSION == 3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 script:
   - pytest --cov=instruments
   - pylint --py3k instruments
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.7 ]]; pylint --disable=I instruments; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.7 ]]; then pylint --disable=I instruments; fi
 after_success:
   - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 script:
   - pytest --cov=instruments
   - pylint --py3k instruments
-  - pylint --disable=I instruments
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.7 ]]; pylint --disable=I instruments; fi
 after_success:
   - coveralls
 deploy:

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ send, one can use the following functions to do so:
 Python Version Compatibility
 ----------------------------
 
-At this time, Python 2.7, 3.4, 3.5, and 3.6 are supported. Should you encounter
+At this time, Python 2.7, 3.4, 3.5, 3.6, and 3.7 are supported. Should you encounter
 any problems with this library that occur in one version or another, please
 do not hesitate to let us know.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ enum34
 python-vxi11>=0.8
 pyusb
 python-usbtmc
-ruamel.yaml~=0.14.12
+ruamel.yaml~=0.15.37

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,8 @@ def find_meta(meta):
 
 # MAIN #######################################################################
 
+with open("README.rst", "r") as fh:
+    long_description = fh.read()
 
 setup(
     name=find_meta("title"),
@@ -95,5 +97,7 @@ setup(
         'hypothesis'
     ],
     description=find_meta("description"),
+    long_description=long_description,
+    long_description_content_type="text/restructedtext",
     classifiers=CLASSIFIERS
 )

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,13 @@ INSTALL_REQUIRES = [
     "numpy",
     "pyserial>=3.3",
     "pyvisa>=1.9",
-    "quantities",
+    "quantities>=0.12.1",
     "enum34",
-    "future",
-    "python-vxi11",
+    "future>=0.15",
+    "python-vxi11>=0.8",
     "python-usbtmc",
     "pyusb",
-    "ruamel.yaml"
+    "ruamel.yaml~=0.15.37"
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Intended Audience :: Science/Research",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py37
 [testenv]
 deps = -rdev-requirements.txt
 commands = pytest


### PR DESCRIPTION
Changes
------------
- Adds Python 3.7 to the list of supported versions. Soon after this Py34 will be removed due to EOL.
- This also (hopefully) fixes the PyPI project description rendering
- Changes Travis to only publish to PyPI if it is the latest version of Python running the final build on the tagged release