### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ send, one can use the following functions to do so:
 Python Version Compatibility
 ----------------------------
 
-At this time, Python 2.7, 3.4, 3.5, 3.6, and 3.7 are supported. Should you encounter
+At this time, Python 2.7, 3.5, 3.6, and 3.7 are supported. Should you encounter
 any problems with this library that occur in one version or another, please
 do not hesitate to let us know.
 
@@ -134,7 +134,7 @@ To run the tests against all supported version of Python, you will need to
 have the binary for each installed, as well as any requirements needed to
 install ``numpy`` under each Python version. On Debian/Ubuntu systems this means
 you will need to install the ``python-dev`` package for each version of Python
-supported (``python2.7-dev``, ``python3.4-dev``, etc).
+supported (``python2.7-dev``, ``python3.7-dev``, etc).
 
 With the required system packages installed, all tests can be run with ``tox``:
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py27,py35,py36,py37
 [testenv]
 deps = -rdev-requirements.txt
 commands = pytest


### PR DESCRIPTION
Address issue #198 

This will remove Python 3.4 as a supported version for v0.5