### PR TITLE
Fix checking if value is in IntEnum (issue #197)

### DIFF
--- a/instruments/hp/hp6632b.py
+++ b/instruments/hp/hp6632b.py
@@ -468,6 +468,9 @@ class HP6632b(SCPIInstrument, HP6652a):
                 done = True
             else:
                 result.append(
-                    self.ErrorCodes(err) if err in self.ErrorCodes else err)
+                    self.ErrorCodes(err)
+                    if any(err == item.value for item in self.ErrorCodes)
+                    else err
+                )
 
         return result


### PR DESCRIPTION
Fixes `DeprecationWarning` from Py37 where checking if value is in enum will raise `ValueError` in Py38