### PR TITLE
Update srsdg645.py

### DIFF
--- a/instruments/srs/srsdg645.py
+++ b/instruments/srs/srsdg645.py
@@ -220,6 +220,24 @@ class SRSDG645(SCPIInstrument):
             newval = assume_units(newval, 'V').magnitude
             self._parent.sendcmd("LAMP {},{}".format(self._idx, newval))
 
+        @property
+        def level_offset(self):
+            """
+            Amplitude offset (in voltage) of the output level for this output.
+
+            :type: `float` or :class:`~quantities.Quantity`
+            :units: As specified, or :math:`\\text{V}` by default.
+            """
+            return pq.Quantity(
+                float(self._parent.query('LOFF? {}'.format(self._idx))),
+                'V'
+            )
+
+        @level_offset.setter
+        def level_offset(self, newval):
+            newval = assume_units(newval, 'V').magnitude
+            self._parent.sendcmd("LOFF {},{}".format(self._idx, newval))
+
     # PROPERTIES #
 
     @property

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -36,6 +36,24 @@ def test_srsdg645_output_level():
         ddg.output['AB'].level_amplitude = 4.0
 
 
+def test_srsdg645_output_offset():
+    """
+    SRSDG645: Checks getting/setting unitful ouput level.
+    """
+    with expected_protocol(
+        ik.srs.SRSDG645,
+        [
+            "LOFF? 1",
+            "LOFF 1,2.0",
+        ],
+        [
+            "1.2"
+        ]
+    ) as ddg:
+        unit_eq(ddg.output['AB'].level_offset, pq.Quantity(1.2, "V"))
+        ddg.output['AB'].level_offset = 2.0
+
+
 def test_srsdg645_output_polarity():
     """
     SRSDG645: Checks getting/setting

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -20,7 +20,7 @@ test_srsdg645_name = make_name_test(ik.srs.SRSDG645)
 
 def test_srsdg645_output_level():
     """
-    SRSDG645: Checks getting/setting unitful ouput level.
+    SRSDG645: Checks getting/setting unitful output level.
     """
     with expected_protocol(
         ik.srs.SRSDG645,
@@ -38,7 +38,7 @@ def test_srsdg645_output_level():
 
 def test_srsdg645_output_offset():
     """
-    SRSDG645: Checks getting/setting unitful ouput level.
+    SRSDG645: Checks getting/setting unitful output offset.
     """
     with expected_protocol(
         ik.srs.SRSDG645,


### PR DESCRIPTION
Added capabilities to SRS DG645 instrument:
Added the capability to set the level offset for each output. Used the exact same formalism as in level_amplitude subroutine.