### PR TITLE
Fix: SyntaxWarning: "is" with a literal. Did you mean "=="?

### DIFF
--- a/instruments/thorlabs/tc200.py
+++ b/instruments/thorlabs/tc200.py
@@ -111,7 +111,7 @@ class TC200(Instrument):
         :type: `bool`
         """
         response = self.status
-        return True if int(response) % 2 is 1 else False
+        return True if int(response) % 2 == 1 else False
 
     @enable.setter
     def enable(self, newval):


### PR DESCRIPTION
```
<>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
<ipython-input-14-4720703b9261>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
  int(response) % 2 is 1.0
```

> The == operator compares the values of both the operands and checks for value equality. Whereas is operator checks whether both the operands refer to the same object or not.
> - https://www.geeksforgeeks.org/difference-operator-python/