### PR TITLE
Officially drop Py2.7 and Py3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: xenial
 sudo: false
 language: python
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
   - "3.7"
 install:

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ send, one can use the following functions to do so:
 Python Version Compatibility
 ----------------------------
 
-At this time, Python 2.7, 3.5, 3.6, and 3.7 are supported. Should you encounter
+At this time, Python 3.6, and 3.7 are supported. Should you encounter
 any problems with this library that occur in one version or another, please
 do not hesitate to let us know.
 
@@ -134,7 +134,7 @@ To run the tests against all supported version of Python, you will need to
 have the binary for each installed, as well as any requirements needed to
 install ``numpy`` under each Python version. On Debian/Ubuntu systems this means
 you will need to install the ``python-dev`` package for each version of Python
-supported (``python2.7-dev``, ``python3.7-dev``, etc).
+supported (``python3.7-dev``, etc).
 
 With the required system packages installed, all tests can be run with ``tox``:
 

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,7 @@ META_PATH = os.path.join("instruments", "__init__.py")
 CLASSIFIERS = [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37
+envlist = py36,py37
 [testenv]
 deps = -rdev-requirements.txt
 commands = pytest


### PR DESCRIPTION
First step to fulfilling #199 

This PR drops support for Py2.7 which is now EOL

Also drops support of Py3.5, which while not EOL, is not supported by other projects such as `scipy`. Mostly though, I want to use f-strings.