### PR TITLE
Remove enum34 from dependencies

### DIFF
--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -30,7 +30,6 @@ $ pip install -r requirements.txt
 - NumPy
 - `PySerial`_
 - `quantities`_
-- `enum34`_
 - `future`_
 - `python-vxi11`_
 - `PyUSB`_ (version 1.0a or higher, required for raw USB support)
@@ -43,7 +42,6 @@ Optional Dependencies
 
 .. _PySerial: http://pyserial.sourceforge.net/
 .. _quantities: http://pythonhosted.org/quantities/
-.. _enum34: https://pypi.python.org/pypi/enum34
 .. _future: https://pypi.python.org/pypi/future
 .. _ruamel.yaml: http://yaml.readthedocs.io
 .. _PyUSB: http://sourceforge.net/apps/trac/pyusb/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ pyserial
 pyvisa>=1.9
 quantities>=0.12.1
 future>=0.15
-enum34
 python-vxi11>=0.8
 pyusb
 python-usbtmc

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ INSTALL_REQUIRES = [
     "pyserial>=3.3",
     "pyvisa>=1.9",
     "quantities>=0.12.1",
-    "enum34",
     "future>=0.15",
     "python-vxi11>=0.8",
     "python-usbtmc",


### PR DESCRIPTION
Without Py2 being supported anymore, the `enum34` is no longer needed. And its apparently keeping pyinstaller from working #199 