### PR TITLE
Update pylint 2.4

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -144,7 +144,7 @@ spelling-store-unknown-words=no
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
 script:
   - pytest --cov=instruments
   - if [[ $TRAVIS_PYTHON_VERSION != 3.7 ]]; then pylint --py3k instruments; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.7 ]]; then pylint --disable=I instruments; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != 3.7 ]]; then pylint --disable=I,R instruments; fi
 after_success:
   - coveralls
 deploy:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,5 +2,4 @@ mock
 pytest
 pytest-mock
 hypothesis==4.28.2
-pylint==1.7.1
-astroid==1.5.3
+pylint==2.4.4

--- a/instruments/abstract_instruments/comm/abstract_comm.py
+++ b/instruments/abstract_instruments/comm/abstract_comm.py
@@ -126,7 +126,6 @@ class AbstractCommunicator(with_metaclass(abc.ABCMeta, object)):
         :return: The read bytes
         :rtype: `bytes`
         """
-        pass
 
     @abc.abstractmethod
     def write_raw(self, msg):
@@ -136,7 +135,6 @@ class AbstractCommunicator(with_metaclass(abc.ABCMeta, object)):
         :param bytes msg: Bytes to be sent to the instrument over the
             connection.
         """
-        pass
 
     @abc.abstractmethod
     def _sendcmd(self, msg):
@@ -147,7 +145,6 @@ class AbstractCommunicator(with_metaclass(abc.ABCMeta, object)):
         Note that this is called by :class:`AbstractCommunicator.sendcmd`,
         which also handles debug, event and capture support.
         """
-        pass
 
     @abc.abstractmethod
     def _query(self, msg, size=-1):
@@ -164,7 +161,6 @@ class AbstractCommunicator(with_metaclass(abc.ABCMeta, object)):
         Note that this is called by :class:`AbstractCommunicator.query`,
         which also handles debug, event and capture support.
         """
-        pass
 
     @abc.abstractmethod
     def flush_input(self):
@@ -208,10 +204,10 @@ class AbstractCommunicator(with_metaclass(abc.ABCMeta, object)):
             codecs.lookup(encoding)
             return self.read_raw(size).decode(encoding)
         except LookupError:
-            if encoding == 'IEEE-754/64':
-                return struct.unpack('>d', self.read_raw(size))[0]
+            if encoding == "IEEE-754/64":
+                return struct.unpack(">d", self.read_raw(size))[0]
             else:
-                raise ValueError("Encoding {} is not currently supported.".format(encoding))
+                raise ValueError(f"Encoding {encoding} is not currently supported.")
 
     def sendcmd(self, msg):
         """

--- a/instruments/abstract_instruments/comm/loopback_communicator.py
+++ b/instruments/abstract_instruments/comm/loopback_communicator.py
@@ -140,7 +140,7 @@ class LoopbackCommunicator(io.IOBase, AbstractCommunicator):
         if self._stdout is not None:
             self._stdout.write(msg)
         else:
-            print(" <- {} ".format(repr(msg)))
+            print(f" <- {repr(msg)} ")
 
     def seek(self, offset):  # pylint: disable=unused-argument,no-self-use
         """
@@ -164,7 +164,6 @@ class LoopbackCommunicator(io.IOBase, AbstractCommunicator):
 
         For the loopback communicator, this will do nothing and just `pass`.
         """
-        pass
 
     # METHODS #
 
@@ -177,8 +176,8 @@ class LoopbackCommunicator(io.IOBase, AbstractCommunicator):
 
         :param str msg: The command message to send to the instrument
         """
-        if msg != '':
-            msg = "{}{}".format(msg, self._terminator)
+        if msg != "":
+            msg = f"{msg}{self._terminator}"
             self.write(msg)
 
     def _query(self, msg, size=-1):

--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -150,7 +150,6 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
         For a USBTMC connection, this function does not actually do anything
         and simply returns.
         """
-        pass
 
     # METHODS #
 

--- a/instruments/abstract_instruments/comm/visa_communicator.py
+++ b/instruments/abstract_instruments/comm/visa_communicator.py
@@ -160,7 +160,6 @@ class VisaCommunicator(io.IOBase, AbstractCommunicator):
         entirety of its contents.
         """
         # TODO: Find out how to flush with pyvisa
-        pass
 
     # METHODS #
 

--- a/instruments/abstract_instruments/electrometer.py
+++ b/instruments/abstract_instruments/electrometer.py
@@ -37,7 +37,6 @@ class Electrometer(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `~enum.Enum`
         """
-        pass
 
     @mode.setter
     @abc.abstractmethod
@@ -53,7 +52,6 @@ class Electrometer(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `~quantities.UnitQuantity`
         """
-        pass
 
     @property
     @abc.abstractmethod
@@ -64,7 +62,6 @@ class Electrometer(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `~enum.Enum`
         """
-        pass
 
     @trigger_mode.setter
     @abc.abstractmethod
@@ -80,7 +77,6 @@ class Electrometer(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `~enum.Enum`
         """
-        pass
 
     @input_range.setter
     @abc.abstractmethod
@@ -96,7 +92,6 @@ class Electrometer(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `bool`
         """
-        pass
 
     @zero_check.setter
     @abc.abstractmethod
@@ -112,7 +107,6 @@ class Electrometer(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `bool`
         """
-        pass
 
     @zero_correct.setter
     @abc.abstractmethod

--- a/instruments/abstract_instruments/function_generator.py
+++ b/instruments/abstract_instruments/function_generator.py
@@ -215,21 +215,36 @@ class FunctionGenerator(with_metaclass(abc.ABCMeta, Instrument)):
         """
         Enum containg valid output function modes for many function generators
         """
-        sinusoid = 'SIN'
-        square = 'SQU'
-        triangle = 'TRI'
-        ramp = 'RAMP'
-        noise = 'NOIS'
-        arbitrary = 'ARB'
+        sinusoid = "SIN"
+        square = "SQU"
+        triangle = "TRI"
+        ramp = "RAMP"
+        noise = "NOIS"
+        arbitrary = "ARB"
 
     @property
     def channel(self):
+        """
+        Gets a channel object for the function generator. This should use
+        `~instruments.util_fns.ProxyList` to achieve this.
+
+        The number of channels accessable depends on the value
+        of FunctionGenerator._channel_count
+
+        :rtype: `FunctionGenerator.Channel`
+        """
         return ProxyList(self, self.Channel, range(self._channel_count))
 
     # PASSTHROUGH PROPERTIES #
 
     @property
     def amplitude(self):
+        """
+        Gets/sets the output amplitude of the first channel
+        of the function generator
+
+        :type: `~quantities.Quantity`
+        """
         return self.channel[0].amplitude
 
     @amplitude.setter

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -94,7 +94,7 @@ class Instrument(object):
             be sent.
         """
         self._file.sendcmd(str(cmd))
-        ack_expected_list = self._ack_expected(cmd)
+        ack_expected_list = self._ack_expected(cmd)  # pylint: disable=assignment-from-none
         if not isinstance(ack_expected_list, (list, tuple)):
             ack_expected_list = [ack_expected_list]
         for ack_expected in ack_expected_list:
@@ -126,7 +126,7 @@ class Instrument(object):
             connected instrument.
         :rtype: `str`
         """
-        ack_expected_list = self._ack_expected(cmd)
+        ack_expected_list = self._ack_expected(cmd)  # pylint: disable=assignment-from-none
         if not isinstance(ack_expected_list, (list, tuple)):
             ack_expected_list = [ack_expected_list]
 
@@ -138,16 +138,14 @@ class Instrument(object):
                 ack = self.read()
                 if ack != ack_expected:
                     raise AcknowledgementError(
-                        "Incorrect ACK message received: got {} "
-                        "expected {}".format(ack, ack_expected)
+                        f"Incorrect ACK message received: got {ack} expected {ack_expected}"
                     )
             value = self.read(size)  # Now read in our return data
         if self.prompt is not None:
             prompt = self.read(len(self.prompt))
             if prompt != self.prompt:
                 raise PromptError(
-                    "Incorrect prompt message received: got {} "
-                    "expected {}".format(prompt, self.prompt)
+                    f"Incorrect prompt message received: got {prompt} expected {self.prompt}"
                 )
         return value
 

--- a/instruments/abstract_instruments/multimeter.py
+++ b/instruments/abstract_instruments/multimeter.py
@@ -38,7 +38,6 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `~enum.Enum`
         """
-        pass
 
     @mode.setter
     @abc.abstractmethod
@@ -54,7 +53,6 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `~enum.Enum`
         """
-        pass
 
     @trigger_mode.setter
     @abc.abstractmethod
@@ -70,7 +68,6 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `bool`
         """
-        pass
 
     @relative.setter
     @abc.abstractmethod
@@ -86,7 +83,6 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `~quantities.quantity.Quantity` or `~enum.Enum`
         """
-        pass
 
     @input_range.setter
     @abc.abstractmethod
@@ -100,4 +96,3 @@ class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
         """
         Perform a measurement as specified by mode parameter.
         """
-        pass

--- a/instruments/abstract_instruments/power_supply.py
+++ b/instruments/abstract_instruments/power_supply.py
@@ -38,7 +38,6 @@ class PowerSupplyChannel(with_metaclass(abc.ABCMeta, object)):
 
         :type: `~enum.Enum`
         """
-        pass
 
     @mode.setter
     @abc.abstractmethod
@@ -54,7 +53,6 @@ class PowerSupplyChannel(with_metaclass(abc.ABCMeta, object)):
 
         :type: `~quantities.quantity.Quantity`
         """
-        pass
 
     @voltage.setter
     @abc.abstractmethod
@@ -70,7 +68,6 @@ class PowerSupplyChannel(with_metaclass(abc.ABCMeta, object)):
 
         :type: `~quantities.quantity.Quantity`
         """
-        pass
 
     @current.setter
     @abc.abstractmethod
@@ -86,7 +83,6 @@ class PowerSupplyChannel(with_metaclass(abc.ABCMeta, object)):
 
         :type: `bool`
         """
-        pass
 
     @output.setter
     @abc.abstractmethod
@@ -127,7 +123,6 @@ class PowerSupply(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `~quantities.quantity.Quantity`
         """
-        pass
 
     @voltage.setter
     @abc.abstractmethod
@@ -143,7 +138,6 @@ class PowerSupply(with_metaclass(abc.ABCMeta, Instrument)):
 
         :type: `~quantities.quantity.Quantity`
         """
-        pass
 
     @current.setter
     @abc.abstractmethod

--- a/instruments/abstract_instruments/signal_generator/channel.py
+++ b/instruments/abstract_instruments/signal_generator/channel.py
@@ -36,7 +36,6 @@ class SGChannel(with_metaclass(abc.ABCMeta, object)):
 
         :type: `~quantities.quantity.Quantity`
         """
-        pass
 
     @frequency.setter
     @abc.abstractmethod
@@ -51,7 +50,6 @@ class SGChannel(with_metaclass(abc.ABCMeta, object)):
 
         :type: `~quantities.quantity.Quantity`
         """
-        pass
 
     @power.setter
     @abc.abstractmethod
@@ -66,7 +64,6 @@ class SGChannel(with_metaclass(abc.ABCMeta, object)):
 
         :type: `~quantities.quantity.Quantity`
         """
-        pass
 
     @phase.setter
     @abc.abstractmethod
@@ -81,7 +78,6 @@ class SGChannel(with_metaclass(abc.ABCMeta, object)):
 
         :type: `bool`
         """
-        pass
 
     @output.setter
     @abc.abstractmethod

--- a/instruments/abstract_instruments/signal_generator/signal_generator.py
+++ b/instruments/abstract_instruments/signal_generator/signal_generator.py
@@ -31,7 +31,8 @@ class SignalGenerator(with_metaclass(abc.ABCMeta, Instrument)):
 
     # PROPERTIES #
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def channel(self):
         """
         Gets a specific channel object for the SignalGenerator.

--- a/instruments/errors.py
+++ b/instruments/errors.py
@@ -16,7 +16,6 @@ class AcknowledgementError(IOError):
     This error is raised when an instrument fails to send the expected
     acknowledgement string.
     """
-    pass
 
 
 class PromptError(IOError):
@@ -26,4 +25,3 @@ class PromptError(IOError):
     these characters, but some do in a misguided attempt to be more "user
     friendly".
     """
-    pass

--- a/instruments/named_struct.py
+++ b/instruments/named_struct.py
@@ -36,7 +36,7 @@ from future.utils import with_metaclass
 # CLASSES #####################################################################
 
 
-class Field(object):
+class Field:
     """
     A named field within a C-style structure.
 
@@ -66,12 +66,14 @@ class Field(object):
         if self._fmt[:-1] and int(self._fmt[:-1]) < 0:
             raise TypeError("Field is specified with negative length.")
 
-
     def is_significant(self):
         return not self._fmt.endswith('x')
 
     @property
     def fmt_char(self):
+        """
+        Gets the format character
+        """
         return self._fmt[-1]
 
     def __len__(self):
@@ -132,6 +134,7 @@ class Field(object):
     def __set__(self, obj, value):
         obj._values[self._name] = value
 
+
 class StringField(Field):
     """
     Represents a field that is interpreted as a Python string.
@@ -178,7 +181,11 @@ class Padding(Field):
     def __init__(self, n_bytes=1):
         super(Padding, self).__init__('{}x'.format(n_bytes))
 
+
 class HasFields(type):
+    """
+    Metaclass used for NamedStruct
+    """
     def __new__(mcs, name, bases, attrs):
         # Since this is a metaclass, the __new__ method observes
         # creation of new *classes* and not new instances.

--- a/instruments/named_struct.py
+++ b/instruments/named_struct.py
@@ -85,7 +85,7 @@ class Field:
         raise TypeError("Field is scalar and has no len().")
 
     def __repr__(self):
-        if self._owner_type:
+        if self._owner_type:  # pylint: disable=using-constant-test
             return "<Field {} of {}, fmt={}>".format(
                 self._name, self._owner_type, self._fmt
             )

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -461,7 +461,6 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
 
         self.sendcmd("DATA:WIDTH {}".format(newval))
 
-    @property
     def force_trigger(self):
         raise NotImplementedError
 

--- a/instruments/tests/test_abstract_inst/test_function_generator.py
+++ b/instruments/tests/test_abstract_inst/test_function_generator.py
@@ -16,6 +16,8 @@ import instruments as ik
 
 # TESTS ######################################################################
 
+# pylint: disable=missing-function-docstring,redefined-outer-name,protected-access
+
 @pytest.fixture
 def fg():
     return ik.abstract_instruments.FunctionGenerator.open_test()

--- a/instruments/tests/test_agilent/test_agilent_33220a.py
+++ b/instruments/tests/test_agilent/test_agilent_33220a.py
@@ -20,18 +20,18 @@ test_scpi_func_gen_name = make_name_test(ik.agilent.Agilent33220a)
 
 def test_agilent33220a_amplitude():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "VOLT:UNIT?",
-            "VOLT?",
-            "VOLT:UNIT VPP",
-            "VOLT 2.0",
-            "VOLT:UNIT DBM",
-            "VOLT 1.5"
-        ], [
-            "VPP",
-            "+1.000000E+00"
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "VOLT:UNIT?",
+                "VOLT?",
+                "VOLT:UNIT VPP",
+                "VOLT 2.0",
+                "VOLT:UNIT DBM",
+                "VOLT 1.5"
+            ], [
+                "VPP",
+                "+1.000000E+00"
+            ]
     ) as fg:
         assert fg.amplitude == (1 * pq.V, fg.VoltageMode.peak_to_peak)
         fg.amplitude = 2 * pq.V
@@ -40,13 +40,13 @@ def test_agilent33220a_amplitude():
 
 def test_agilent33220a_frequency():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "FREQ?",
-            "FREQ 1.005000e+02"
-        ], [
-            "+1.234000E+03"
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "FREQ?",
+                "FREQ 1.005000e+02"
+            ], [
+                "+1.234000E+03"
+            ]
     ) as fg:
         assert fg.frequency == 1234 * pq.Hz
         fg.frequency = 100.5 * pq.Hz
@@ -54,13 +54,13 @@ def test_agilent33220a_frequency():
 
 def test_agilent33220a_function():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "FUNC?",
-            "FUNC:SQU"
-        ], [
-            "SIN"
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "FUNC?",
+                "FUNC:SQU"
+            ], [
+                "SIN"
+            ]
     ) as fg:
         assert fg.function == fg.Function.sinusoid
         fg.function = fg.Function.square
@@ -68,13 +68,13 @@ def test_agilent33220a_function():
 
 def test_agilent33220a_offset():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "VOLT:OFFS?",
-            "VOLT:OFFS 4.321000e-01"
-        ], [
-            "+1.234000E+01",
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "VOLT:OFFS?",
+                "VOLT:OFFS 4.321000e-01"
+            ], [
+                "+1.234000E+01",
+            ]
     ) as fg:
         assert fg.offset == 12.34 * pq.V
         fg.offset = 0.4321 * pq.V
@@ -82,13 +82,13 @@ def test_agilent33220a_offset():
 
 def test_agilent33220a_duty_cycle():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "FUNC:SQU:DCYC?",
-            "FUNC:SQU:DCYC 75"
-        ], [
-            "53",
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "FUNC:SQU:DCYC?",
+                "FUNC:SQU:DCYC 75"
+            ], [
+                "53",
+            ]
     ) as fg:
         assert fg.duty_cycle == 53
         fg.duty_cycle = 75
@@ -96,13 +96,13 @@ def test_agilent33220a_duty_cycle():
 
 def test_agilent33220a_ramp_symmetry():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "FUNC:RAMP:SYMM?",
-            "FUNC:RAMP:SYMM 75"
-        ], [
-            "53",
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "FUNC:RAMP:SYMM?",
+                "FUNC:RAMP:SYMM 75"
+            ], [
+                "53",
+            ]
     ) as fg:
         assert fg.ramp_symmetry == 53
         fg.ramp_symmetry = 75
@@ -110,13 +110,13 @@ def test_agilent33220a_ramp_symmetry():
 
 def test_agilent33220a_output():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "OUTP?",
-            "OUTP OFF"
-        ], [
-            "ON",
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "OUTP?",
+                "OUTP OFF"
+            ], [
+                "ON",
+            ]
     ) as fg:
         assert fg.output is True
         fg.output = False
@@ -124,13 +124,13 @@ def test_agilent33220a_output():
 
 def test_agilent33220a_output_sync():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "OUTP:SYNC?",
-            "OUTP:SYNC OFF"
-        ], [
-            "ON",
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "OUTP:SYNC?",
+                "OUTP:SYNC OFF"
+            ], [
+                "ON",
+            ]
     ) as fg:
         assert fg.output_sync is True
         fg.output_sync = False
@@ -138,13 +138,13 @@ def test_agilent33220a_output_sync():
 
 def test_agilent33220a_output_polarity():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "OUTP:POL?",
-            "OUTP:POL NORM"
-        ], [
-            "INV",
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "OUTP:POL?",
+                "OUTP:POL NORM"
+            ], [
+                "INV",
+            ]
     ) as fg:
         assert fg.output_polarity == fg.OutputPolarity.inverted
         fg.output_polarity = fg.OutputPolarity.normal
@@ -152,16 +152,16 @@ def test_agilent33220a_output_polarity():
 
 def test_agilent33220a_load_resistance():
     with expected_protocol(
-        ik.agilent.Agilent33220a,
-        [
-            "OUTP:LOAD?",
-            "OUTP:LOAD?",
-            "OUTP:LOAD 100.0",
-            "OUTP:LOAD MAX"
-        ], [
-            "50",
-            "INF"
-        ]
+            ik.agilent.Agilent33220a,
+            [
+                "OUTP:LOAD?",
+                "OUTP:LOAD?",
+                "OUTP:LOAD 100.0",
+                "OUTP:LOAD MAX"
+            ], [
+                "50",
+                "INF"
+            ]
     ) as fg:
         assert fg.load_resistance == 50 * pq.Ohm
         assert fg.load_resistance == fg.LoadResistance.high_impedance

--- a/instruments/tests/test_agilent/test_agilent_34410a.py
+++ b/instruments/tests/test_agilent/test_agilent_34410a.py
@@ -22,56 +22,56 @@ test_agilent_34410a_name = make_name_test(ik.agilent.Agilent34410a)
 
 def test_agilent34410a_read():
     with expected_protocol(
-        ik.agilent.Agilent34410a,
-        [
-            "CONF?",
-            "READ?"
-        ], [
-            "VOLT +1.000000E+01,+3.000000E-06",
-            "+1.86850000E-03"
-        ]
+            ik.agilent.Agilent34410a,
+            [
+                "CONF?",
+                "READ?"
+            ], [
+                "VOLT +1.000000E+01,+3.000000E-06",
+                "+1.86850000E-03"
+            ]
     ) as dmm:
         unit_eq(dmm.read_meter(), +1.86850000E-03 * pq.volt)
 
 
 def test_agilent34410a_data_point_count():
     with expected_protocol(
-        ik.agilent.Agilent34410a,
-        [
-            "DATA:POIN?",
-        ], [
-            "+215",
-        ]
+            ik.agilent.Agilent34410a,
+            [
+                "DATA:POIN?",
+            ], [
+                "+215",
+            ]
     ) as dmm:
         assert dmm.data_point_count == 215
 
 
 def test_agilent34410a_r():
     with expected_protocol(
-        ik.agilent.Agilent34410a,
-        [
-            "CONF?",
-            "FORM:DATA REAL,64",
-            "R? 1"
-        ], [
-            "VOLT +1.000000E+01,+3.000000E-06",
-            # pylint: disable=no-member
-            b"#18" + bytes.fromhex("3FF0000000000000")
-        ]
+            ik.agilent.Agilent34410a,
+            [
+                "CONF?",
+                "FORM:DATA REAL,64",
+                "R? 1"
+            ], [
+                "VOLT +1.000000E+01,+3.000000E-06",
+                # pylint: disable=no-member
+                b"#18" + bytes.fromhex("3FF0000000000000")
+            ]
     ) as dmm:
         unit_eq(dmm.r(1), np.array([1]) * pq.volt)
 
 
 def test_agilent34410a_fetch():
     with expected_protocol(
-        ik.agilent.Agilent34410a,
-        [
-            "CONF?",
-            "FETC?"
-        ], [
-            "VOLT +1.000000E+01,+3.000000E-06",
-            "+4.27150000E-03,5.27150000E-03"
-        ]
+            ik.agilent.Agilent34410a,
+            [
+                "CONF?",
+                "FETC?"
+            ], [
+                "VOLT +1.000000E+01,+3.000000E-06",
+                "+4.27150000E-03,5.27150000E-03"
+            ]
     ) as dmm:
         data = dmm.fetch()
         unit_eq(data[0], 4.27150000E-03 * pq.volt)
@@ -80,15 +80,15 @@ def test_agilent34410a_fetch():
 
 def test_agilent34410a_read_data():
     with expected_protocol(
-        ik.agilent.Agilent34410a,
-        [
-            "CONF?",
-            "FORM:DATA ASC",
-            "DATA:REM? 2"
-        ], [
-            "VOLT +1.000000E+01,+3.000000E-06",
-            "+4.27150000E-03,5.27150000E-03"
-        ]
+            ik.agilent.Agilent34410a,
+            [
+                "CONF?",
+                "FORM:DATA ASC",
+                "DATA:REM? 2"
+            ], [
+                "VOLT +1.000000E+01,+3.000000E-06",
+                "+4.27150000E-03,5.27150000E-03"
+            ]
     ) as dmm:
         data = dmm.read_data(2)
         unit_eq(data[0], 4.27150000E-03 * pq.volt)
@@ -97,14 +97,14 @@ def test_agilent34410a_read_data():
 
 def test_agilent34410a_read_data_nvmem():
     with expected_protocol(
-        ik.agilent.Agilent34410a,
-        [
-            "CONF?",
-            "DATA:DATA? NVMEM",
-        ], [
-            "VOLT +1.000000E+01,+3.000000E-06",
-            "+4.27150000E-03,5.27150000E-03"
-        ]
+            ik.agilent.Agilent34410a,
+            [
+                "CONF?",
+                "DATA:DATA? NVMEM",
+            ], [
+                "VOLT +1.000000E+01,+3.000000E-06",
+                "+4.27150000E-03,5.27150000E-03"
+            ]
     ) as dmm:
         data = dmm.read_data_nvmem()
         unit_eq(data[0], 4.27150000E-03 * pq.volt)
@@ -113,11 +113,11 @@ def test_agilent34410a_read_data_nvmem():
 
 def test_agilent34410a_read_last_data():
     with expected_protocol(
-        ik.agilent.Agilent34410a,
-        [
-            "DATA:LAST?",
-        ], [
-            "+1.73730000E-03 VDC",
-        ]
+            ik.agilent.Agilent34410a,
+            [
+                "DATA:LAST?",
+            ], [
+                "+1.73730000E-03 VDC",
+            ]
     ) as dmm:
         unit_eq(dmm.read_last_data(), 1.73730000E-03 * pq.volt)

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -39,12 +39,12 @@ from . import mock
 
 def test_instrument_binblockread():
     with expected_protocol(
-        ik.Instrument,
-        [],
-        [
-            b"#210" + bytes.fromhex("00000001000200030004") + b"0",
-        ],
-        sep="\n"
+            ik.Instrument,
+            [],
+            [
+                b"#210" + bytes.fromhex("00000001000200030004") + b"0",
+            ],
+            sep="\n"
     ) as inst:
         np.testing.assert_array_equal(inst.binblockread(2), [0, 1, 2, 3, 4])
 

--- a/instruments/tests/test_fluke/test_fluke3000.py
+++ b/instruments/tests/test_fluke/test_fluke3000.py
@@ -64,46 +64,46 @@ init_response = [
 
 def test_mode():
     with expected_protocol(
-        ik.fluke.Fluke3000,
-        init_sequence +
-        [
-            "rfemd 01 1",   # 1
-            "rfemd 01 2"    # 2
-        ],
-        init_response +
-        [
-            "CR:Ack=0:RFEMD",   # 1.1
-            "ME:R:S#=01:DCC=010:PH=00000006020C0600",   # 1.2
-            "CR:Ack=0:RFEMD"    # 2
-        ],
-        "\r"
+            ik.fluke.Fluke3000,
+            init_sequence +
+            [
+                "rfemd 01 1",   # 1
+                "rfemd 01 2"    # 2
+            ],
+            init_response +
+            [
+                "CR:Ack=0:RFEMD",   # 1.1
+                "ME:R:S#=01:DCC=010:PH=00000006020C0600",   # 1.2
+                "CR:Ack=0:RFEMD"    # 2
+            ],
+            "\r"
     ) as inst:
         assert inst.mode == inst.Mode.voltage_dc
 
 
 def test_connect():
     with expected_protocol(
-        ik.fluke.Fluke3000,
-        none_sequence +
-        [
-            "ri",   # 1
-            "rfsm 1",   # 2
-            "rfdis",    # 3
-        ] +
-        init_sequence,
-        none_response +
-        [
-            "CR:Ack=0:RI",  # 1.1
-            "SI:PON=Power On",  # 1.2
-            "RE:O",  # 1.3
-            "CR:Ack=0:RFSM:Radio On Master",    # 2.1
-            "RE:M",  # 2.2
-            "CR:Ack=0:RFDIS",   # 3.1
-            "ME:S",  # 3.2
-            "ME:D:010200000000",  # 3.3
-        ] +
-        init_response,
-        "\r"
+            ik.fluke.Fluke3000,
+            none_sequence +
+            [
+                "ri",   # 1
+                "rfsm 1",   # 2
+                "rfdis",    # 3
+            ] +
+            init_sequence,
+            none_response +
+            [
+                "CR:Ack=0:RI",  # 1.1
+                "SI:PON=Power On",  # 1.2
+                "RE:O",  # 1.3
+                "CR:Ack=0:RFSM:Radio On Master",    # 2.1
+                "RE:M",  # 2.2
+                "CR:Ack=0:RFDIS",   # 3.1
+                "ME:S",  # 3.2
+                "ME:D:010200000000",  # 3.3
+            ] +
+            init_response,
+            "\r"
     ) as inst:
         assert inst.positions[ik.fluke.Fluke3000.Module.m3000] == 1
         assert inst.positions[ik.fluke.Fluke3000.Module.t3000] == 2
@@ -111,10 +111,10 @@ def test_connect():
 
 def test_scan():
     with expected_protocol(
-        ik.fluke.Fluke3000,
-        init_sequence,
-        init_response,
-        "\r"
+            ik.fluke.Fluke3000,
+            init_sequence,
+            init_response,
+            "\r"
     ) as inst:
         assert inst.positions[ik.fluke.Fluke3000.Module.m3000] == 1
         assert inst.positions[ik.fluke.Fluke3000.Module.t3000] == 2
@@ -122,43 +122,43 @@ def test_scan():
 
 def test_reset():
     with expected_protocol(
-        ik.fluke.Fluke3000,
-        init_sequence +
-        [
-            "ri",   # 1
-            "rfsm 1"   # 2
-        ],
-        init_response +
-        [
-            "CR:Ack=0:RI",  # 1.1
-            "SI:PON=Power On",  # 1.2
-            "RE:O",  # 1.3
-            "CR:Ack=0:RFSM:Radio On Master",    # 2.1
-            "RE:M"  # 2.2
-        ],
-        "\r"
+            ik.fluke.Fluke3000,
+            init_sequence +
+            [
+                "ri",   # 1
+                "rfsm 1"   # 2
+            ],
+            init_response +
+            [
+                "CR:Ack=0:RI",  # 1.1
+                "SI:PON=Power On",  # 1.2
+                "RE:O",  # 1.3
+                "CR:Ack=0:RFSM:Radio On Master",    # 2.1
+                "RE:M"  # 2.2
+            ],
+            "\r"
     ) as inst:
         inst.reset()
 
 
 def test_measure():
     with expected_protocol(
-        ik.fluke.Fluke3000,
-        init_sequence +
-        [
-            "rfemd 01 1",   # 1
-            "rfemd 01 2",   # 2
-            "rfemd 02 0"    # 3
-        ],
-        init_response +
-        [
-            "CR:Ack=0:RFEMD",   # 1.1
-            "ME:R:S#=01:DCC=010:PH=FD010006020C0600",   # 1.2
-            "CR:Ack=0:RFEMD",   # 2
-            "CR:Ack=0:RFEMD",   # 3.1
-            "ME:R:S#=02:DCC=010:PH=FD00C08207220000"    # 3.2
-        ],
-        "\r"
+            ik.fluke.Fluke3000,
+            init_sequence +
+            [
+                "rfemd 01 1",   # 1
+                "rfemd 01 2",   # 2
+                "rfemd 02 0"    # 3
+            ],
+            init_response +
+            [
+                "CR:Ack=0:RFEMD",   # 1.1
+                "ME:R:S#=01:DCC=010:PH=FD010006020C0600",   # 1.2
+                "CR:Ack=0:RFEMD",   # 2
+                "CR:Ack=0:RFEMD",   # 3.1
+                "ME:R:S#=02:DCC=010:PH=FD00C08207220000"    # 3.2
+            ],
+            "\r"
     ) as inst:
         assert inst.measure(inst.Mode.voltage_dc) == 0.509 * pq.volt
         assert inst.measure(inst.Mode.temperature) == -25.3 * pq.celsius

--- a/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
@@ -20,19 +20,19 @@ test_scpi_func_gen_name = make_name_test(ik.generic_scpi.SCPIFunctionGenerator)
 
 def test_scpi_func_gen_amplitude():
     with expected_protocol(
-        ik.generic_scpi.SCPIFunctionGenerator,
-        [
-            "VOLT:UNIT?",
-            "VOLT?",
-            "VOLT:UNIT VPP",
-            "VOLT 2.0",
-            "VOLT:UNIT DBM",
-            "VOLT 1.5"
-        ], [
-            "VPP",
-            "+1.000000E+00"
-        ],
-        repeat=2
+            ik.generic_scpi.SCPIFunctionGenerator,
+            [
+                "VOLT:UNIT?",
+                "VOLT?",
+                "VOLT:UNIT VPP",
+                "VOLT 2.0",
+                "VOLT:UNIT DBM",
+                "VOLT 1.5"
+            ], [
+                "VPP",
+                "+1.000000E+00"
+            ],
+            repeat=2
     ) as fg:
         assert fg.amplitude == (1 * pq.V, fg.VoltageMode.peak_to_peak)
         fg.amplitude = 2 * pq.V
@@ -45,14 +45,14 @@ def test_scpi_func_gen_amplitude():
 
 def test_scpi_func_gen_frequency():
     with expected_protocol(
-        ik.generic_scpi.SCPIFunctionGenerator,
-        [
-            "FREQ?",
-            "FREQ 1.005000e+02"
-        ], [
-            "+1.234000E+03"
-        ],
-        repeat=2
+            ik.generic_scpi.SCPIFunctionGenerator,
+            [
+                "FREQ?",
+                "FREQ 1.005000e+02"
+            ], [
+                "+1.234000E+03"
+            ],
+            repeat=2
     ) as fg:
         assert fg.frequency == 1234 * pq.Hz
         fg.frequency = 100.5 * pq.Hz
@@ -63,14 +63,14 @@ def test_scpi_func_gen_frequency():
 
 def test_scpi_func_gen_function():
     with expected_protocol(
-        ik.generic_scpi.SCPIFunctionGenerator,
-        [
-            "FUNC?",
-            "FUNC SQU"
-        ], [
-            "SIN"
-        ],
-        repeat=2
+            ik.generic_scpi.SCPIFunctionGenerator,
+            [
+                "FUNC?",
+                "FUNC SQU"
+            ], [
+                "SIN"
+            ],
+            repeat=2
     ) as fg:
         assert fg.function == fg.Function.sinusoid
         fg.function = fg.Function.square
@@ -81,14 +81,14 @@ def test_scpi_func_gen_function():
 
 def test_scpi_func_gen_offset():
     with expected_protocol(
-        ik.generic_scpi.SCPIFunctionGenerator,
-        [
-            "VOLT:OFFS?",
-            "VOLT:OFFS 4.321000e-01"
-        ], [
-            "+1.234000E+01",
-        ],
-        repeat=2
+            ik.generic_scpi.SCPIFunctionGenerator,
+            [
+                "VOLT:OFFS?",
+                "VOLT:OFFS 4.321000e-01"
+            ], [
+                "+1.234000E+01",
+            ],
+            repeat=2
     ) as fg:
         assert fg.offset == 12.34 * pq.V
         fg.offset = 0.4321 * pq.V

--- a/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
@@ -20,13 +20,13 @@ test_scpi_multimeter_name = make_name_test(ik.generic_scpi.SCPIMultimeter)
 
 def test_scpi_multimeter_mode():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "CONF?",
-            "CONF:CURR:AC"
-        ], [
-            "FRES +1.000000E+01,+3.000000E-06"
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "CONF?",
+                "CONF:CURR:AC"
+            ], [
+                "FRES +1.000000E+01,+3.000000E-06"
+            ]
     ) as dmm:
         assert dmm.mode == dmm.Mode.fourpt_resistance
         dmm.mode = dmm.Mode.current_ac
@@ -34,13 +34,13 @@ def test_scpi_multimeter_mode():
 
 def test_scpi_multimeter_trigger_mode():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "TRIG:SOUR?",
-            "TRIG:SOUR EXT"
-        ], [
-            "BUS"
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "TRIG:SOUR?",
+                "TRIG:SOUR EXT"
+            ], [
+                "BUS"
+            ]
     ) as dmm:
         assert dmm.trigger_mode == dmm.TriggerMode.bus
         dmm.trigger_mode = dmm.TriggerMode.external
@@ -48,20 +48,20 @@ def test_scpi_multimeter_trigger_mode():
 
 def test_scpi_multimeter_input_range():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "CONF?",  # 1
-            "CONF?",  # 2
-            "CONF?",  # 3.1
-            "CONF:FRES MIN",  # 3.2
-            "CONF?",  # 4.1
-            "CONF:CURR:DC 1.0"  # 4.2
-        ], [
-            "CURR:AC +1.000000E+01,+3.000000E-06",  # 1
-            "CURR:AC AUTO,+3.000000E-06",  # 2
-            "FRES +1.000000E+01,+3.000000E-06",  # 3
-            "CURR:DC +1.000000E+01,+3.000000E-06"  # 4
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "CONF?",  # 1
+                "CONF?",  # 2
+                "CONF?",  # 3.1
+                "CONF:FRES MIN",  # 3.2
+                "CONF?",  # 4.1
+                "CONF:CURR:DC 1.0"  # 4.2
+            ], [
+                "CURR:AC +1.000000E+01,+3.000000E-06",  # 1
+                "CURR:AC AUTO,+3.000000E-06",  # 2
+                "FRES +1.000000E+01,+3.000000E-06",  # 3
+                "CURR:DC +1.000000E+01,+3.000000E-06"  # 4
+            ]
     ) as dmm:
         unit_eq(dmm.input_range, 1e1 * pq.amp)
         assert dmm.input_range == dmm.InputRange.automatic
@@ -71,20 +71,20 @@ def test_scpi_multimeter_input_range():
 
 def test_scpi_multimeter_resolution():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "CONF?",  # 1
-            "CONF?",  # 2
-            "CONF?",  # 3.1
-            "CONF:FRES +1.000000E+01,MIN",  # 3.2
-            "CONF?",  # 4.1
-            "CONF:CURR:DC +1.000000E+01,3e-06"  # 4.2
-        ], [
-            "VOLT +1.000000E+01,+3.000000E-06",  # 1
-            "VOLT +1.000000E+01,MAX",  # 2
-            "FRES +1.000000E+01,+3.000000E-06",  # 3
-            "CURR:DC +1.000000E+01,+3.000000E-06"  # 4
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "CONF?",  # 1
+                "CONF?",  # 2
+                "CONF?",  # 3.1
+                "CONF:FRES +1.000000E+01,MIN",  # 3.2
+                "CONF?",  # 4.1
+                "CONF:CURR:DC +1.000000E+01,3e-06"  # 4.2
+            ], [
+                "VOLT +1.000000E+01,+3.000000E-06",  # 1
+                "VOLT +1.000000E+01,MAX",  # 2
+                "FRES +1.000000E+01,+3.000000E-06",  # 3
+                "CURR:DC +1.000000E+01,+3.000000E-06"  # 4
+            ]
     ) as dmm:
         assert dmm.resolution == 3e-06
         assert dmm.resolution == dmm.Resolution.maximum
@@ -94,16 +94,16 @@ def test_scpi_multimeter_resolution():
 
 def test_scpi_multimeter_trigger_count():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "TRIG:COUN?",
-            "TRIG:COUN?",
-            "TRIG:COUN MIN",
-            "TRIG:COUN 10"
-        ], [
-            "+10",
-            "INF",
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "TRIG:COUN?",
+                "TRIG:COUN?",
+                "TRIG:COUN MIN",
+                "TRIG:COUN 10"
+            ], [
+                "+10",
+                "INF",
+            ]
     ) as dmm:
         assert dmm.trigger_count == 10
         assert dmm.trigger_count == dmm.TriggerCount.infinity
@@ -113,16 +113,16 @@ def test_scpi_multimeter_trigger_count():
 
 def test_scpi_multimeter_sample_count():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "SAMP:COUN?",
-            "SAMP:COUN?",
-            "SAMP:COUN MIN",
-            "SAMP:COUN 10"
-        ], [
-            "+10",
-            "MAX",
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "SAMP:COUN?",
+                "SAMP:COUN?",
+                "SAMP:COUN MIN",
+                "SAMP:COUN 10"
+            ], [
+                "+10",
+                "MAX",
+            ]
     ) as dmm:
         assert dmm.sample_count == 10
         assert dmm.sample_count == dmm.SampleCount.maximum
@@ -132,13 +132,13 @@ def test_scpi_multimeter_sample_count():
 
 def test_scpi_multimeter_trigger_delay():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "TRIG:DEL?",
-            "TRIG:DEL {:e}".format(1),
-        ], [
-            "+1",
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "TRIG:DEL?",
+                f"TRIG:DEL {1:e}",
+            ], [
+                "+1",
+            ]
     ) as dmm:
         unit_eq(dmm.trigger_delay, 1 * pq.second)
         dmm.trigger_delay = 1000 * pq.millisecond
@@ -146,13 +146,13 @@ def test_scpi_multimeter_trigger_delay():
 
 def test_scpi_multimeter_sample_source():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "SAMP:SOUR?",
-            "SAMP:SOUR TIM",
-        ], [
-            "IMM",
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "SAMP:SOUR?",
+                "SAMP:SOUR TIM",
+            ], [
+                "IMM",
+            ]
     ) as dmm:
         assert dmm.sample_source == dmm.SampleSource.immediate
         dmm.sample_source = dmm.SampleSource.timer
@@ -160,13 +160,13 @@ def test_scpi_multimeter_sample_source():
 
 def test_scpi_multimeter_sample_timer():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "SAMP:TIM?",
-            "SAMP:TIM {:e}".format(1),
-        ], [
-            "+1",
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "SAMP:TIM?",
+                f"SAMP:TIM {1:e}",
+            ], [
+                "+1",
+            ]
     ) as dmm:
         unit_eq(dmm.sample_timer, 1 * pq.second)
         dmm.sample_timer = 1000 * pq.millisecond
@@ -174,11 +174,11 @@ def test_scpi_multimeter_sample_timer():
 
 def test_scpi_multimeter_measure():
     with expected_protocol(
-        ik.generic_scpi.SCPIMultimeter,
-        [
-            "MEAS:VOLT:DC?",
-        ], [
-            "+4.23450000E-03",
-        ]
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "MEAS:VOLT:DC?",
+            ], [
+                "+4.23450000E-03",
+            ]
     ) as dmm:
         unit_eq(dmm.measure(dmm.Mode.voltage_dc), 4.2345e-03 * pq.volt)

--- a/instruments/tests/test_glassman/test_glassmanfr.py
+++ b/instruments/tests/test_glassman/test_glassmanfr.py
@@ -29,10 +29,10 @@ def set_defaults(inst):
 
 def test_channel():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [],
-        [],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [],
+            [],
+            "\r"
     ) as inst:
         assert len(inst.channel) == 1
         assert inst.channel[0] == inst
@@ -40,16 +40,16 @@ def test_channel():
 
 def test_voltage():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01Q51",
-            "\x01S3330000000001CD"
-        ],
-        [
-            "R00000000000040",
-            "A"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01Q51",
+                "\x01S3330000000001CD"
+            ],
+            [
+                "R00000000000040",
+                "A"
+            ],
+            "\r"
     ) as inst:
         set_defaults(inst)
         inst.voltage = 10.0 * pq.kilovolt
@@ -58,16 +58,16 @@ def test_voltage():
 
 def test_current():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01Q51",
-            "\x01S0003330000001CD"
-        ],
-        [
-            "R00000000000040",
-            "A"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01Q51",
+                "\x01S0003330000001CD"
+            ],
+            [
+                "R00000000000040",
+                "A"
+            ],
+            "\r"
     ) as inst:
         set_defaults(inst)
         inst.current = 1.2 * pq.milliamp
@@ -76,14 +76,14 @@ def test_current():
 
 def test_voltage_sense():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01Q51"
-        ],
-        [
-            "R10A00000010053"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01Q51"
+            ],
+            [
+                "R10A00000010053"
+            ],
+            "\r"
     ) as inst:
         set_defaults(inst)
         assert round(inst.voltage_sense) == 13.0 * pq.kilovolt
@@ -91,14 +91,14 @@ def test_voltage_sense():
 
 def test_current_sense():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01Q51"
-        ],
-        [
-            "R0001550001004C"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01Q51"
+            ],
+            [
+                "R0001550001004C"
+            ],
+            "\r"
     ) as inst:
         set_defaults(inst)
         assert inst.current_sense == 2.0 * pq.milliamp
@@ -106,16 +106,16 @@ def test_current_sense():
 
 def test_mode():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01Q51",
-            "\x01Q51"
-        ],
-        [
-            "R00000000000040",
-            "R00000000010041"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01Q51",
+                "\x01Q51"
+            ],
+            [
+                "R00000000000040",
+                "R00000000010041"
+            ],
+            "\r"
     ) as inst:
         assert inst.mode == inst.Mode.voltage
         assert inst.mode == inst.Mode.current
@@ -123,20 +123,20 @@ def test_mode():
 
 def test_output():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01S0000000000001C4",
-            "\x01Q51",
-            "\x01S0000000000002C5",
-            "\x01Q51"
-        ],
-        [
-            "A",
-            "R00000000000040",
-            "A",
-            "R00000000040044"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01S0000000000001C4",
+                "\x01Q51",
+                "\x01S0000000000002C5",
+                "\x01Q51"
+            ],
+            [
+                "A",
+                "R00000000000040",
+                "A",
+                "R00000000040044"
+            ],
+            "\r"
     ) as inst:
         inst.output = False
         assert not inst.output
@@ -146,30 +146,30 @@ def test_output():
 
 def test_version():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01V56"
-        ],
-        [
-            "B1465"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01V56"
+            ],
+            [
+                "B1465"
+            ],
+            "\r"
     ) as inst:
         assert inst.version == "14"
 
 
 def test_device_timeout():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01C073",
-            "\x01C174"
-        ],
-        [
-            "A",
-            "A"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01C073",
+                "\x01C174"
+            ],
+            [
+                "A",
+                "A"
+            ],
+            "\r"
     ) as inst:
         inst.device_timeout = True
         assert inst.device_timeout
@@ -179,56 +179,56 @@ def test_device_timeout():
 
 def test_sendcmd():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01123ABC5C"
-        ],
-        [],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01123ABC5C"
+            ],
+            [],
+            "\r"
     ) as inst:
         inst.sendcmd("123ABC")
 
 
 def test_query():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01Q123ABCAD"
-        ],
-        [
-            "R123ABC5C"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01Q123ABCAD"
+            ],
+            [
+                "R123ABC5C"
+            ],
+            "\r"
     ) as inst:
         inst.query("Q123ABC")
 
 
 def test_reset():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01S0000000000004C7"
-        ],
-        [
-            "A"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01S0000000000004C7"
+            ],
+            [
+                "A"
+            ],
+            "\r"
     ) as inst:
         inst.reset()
 
 
 def test_set_status():
     with expected_protocol(
-        ik.glassman.GlassmanFR,
-        [
-            "\x01S3333330000002D7",
-            "\x01Q51"
-        ],
-        [
-            "A",
-            "R00000000040044"
-        ],
-        "\r"
+            ik.glassman.GlassmanFR,
+            [
+                "\x01S3333330000002D7",
+                "\x01Q51"
+            ],
+            [
+                "A",
+                "R00000000040044"
+            ],
+            "\r"
     ) as inst:
         set_defaults(inst)
         inst.set_status(voltage=10*pq.kilovolt, current=1.2*pq.milliamp, output=True)

--- a/instruments/tests/test_holzworth/test_holzworth_hs9000.py
+++ b/instruments/tests/test_holzworth/test_holzworth_hs9000.py
@@ -22,44 +22,44 @@ from .. import mock
 
 def test_hs9000_name():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-            ":CH1:IDN?"
-        ],
-        [
-            ":CH1:CH2:FOO",
-            "Foobar name"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+                ":CH1:IDN?"
+            ],
+            [
+                ":CH1:CH2:FOO",
+                "Foobar name"
+            ],
+            sep="\n"
     ) as hs:
         assert hs.name == "Foobar name"
 
 
 def test_channel_idx_list():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-        ],
-        [
-            ":CH1:CH2:FOO"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+            ],
+            [
+                ":CH1:CH2:FOO"
+            ],
+            sep="\n"
     ) as hs:
         assert hs._channel_idxs() == [0, 1, "FOO"]
 
 
 def test_channel_returns_inner_class():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-        ],
-        [
-            ":CH1:CH2:FOO"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+            ],
+            [
+                ":CH1:CH2:FOO"
+            ],
+            sep="\n"
     ) as hs:
         channel = hs.channel[0]
         assert isinstance(channel, hs.Channel) is True
@@ -107,16 +107,16 @@ def test_channel_save_state():
 
 def test_channel_temperature():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-            ":CH1:TEMP?"
-        ],
-        [
-            ":CH1:CH2:FOO",
-            "10 C"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+                ":CH1:TEMP?"
+            ],
+            [
+                ":CH1:CH2:FOO",
+                "10 C"
+            ],
+            sep="\n"
     ) as hs:
         channel = hs.channel[0]
         assert channel.temperature == 10 * pq.degC
@@ -124,20 +124,20 @@ def test_channel_temperature():
 
 def test_channel_frequency_getter():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-            ":CH1:FREQ?",
-            ":CH1:FREQ:MIN?",
-            ":CH1:FREQ:MAX?"
-        ],
-        [
-            ":CH1:CH2:FOO",
-            "1000 MHz",
-            "100 MHz",
-            "10 GHz"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+                ":CH1:FREQ?",
+                ":CH1:FREQ:MIN?",
+                ":CH1:FREQ:MAX?"
+            ],
+            [
+                ":CH1:CH2:FOO",
+                "1000 MHz",
+                "100 MHz",
+                "10 GHz"
+            ],
+            sep="\n"
     ) as hs:
         channel = hs.channel[0]
         assert channel.frequency == 1 * pq.GHz
@@ -147,19 +147,19 @@ def test_channel_frequency_getter():
 
 def test_channel_frequency_setter():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-            ":CH1:FREQ:MIN?",
-            ":CH1:FREQ:MAX?",
-            ":CH1:FREQ {:e}".format(1)
-        ],
-        [
-            ":CH1:CH2:FOO",
-            "100 MHz",
-            "10 GHz"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+                ":CH1:FREQ:MIN?",
+                ":CH1:FREQ:MAX?",
+                ":CH1:FREQ {:e}".format(1)
+            ],
+            [
+                ":CH1:CH2:FOO",
+                "100 MHz",
+                "10 GHz"
+            ],
+            sep="\n"
     ) as hs:
         channel = hs.channel[0]
         channel.frequency = 1 * pq.GHz
@@ -167,20 +167,20 @@ def test_channel_frequency_setter():
 
 def test_channel_power_getter():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-            ":CH1:PWR?",
-            ":CH1:PWR:MIN?",
-            ":CH1:PWR:MAX?"
-        ],
-        [
-            ":CH1:CH2:FOO",
-            "0",
-            "-100",
-            "20"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+                ":CH1:PWR?",
+                ":CH1:PWR:MIN?",
+                ":CH1:PWR:MAX?"
+            ],
+            [
+                ":CH1:CH2:FOO",
+                "0",
+                "-100",
+                "20"
+            ],
+            sep="\n"
     ) as hs:
         channel = hs.channel[0]
         assert channel.power == 0 * dBm
@@ -190,19 +190,19 @@ def test_channel_power_getter():
 
 def test_channel_power_setter():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-            ":CH1:PWR:MIN?",
-            ":CH1:PWR:MAX?",
-            ":CH1:PWR {:e}".format(0)
-        ],
-        [
-            ":CH1:CH2:FOO",
-            "-100",
-            "20"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+                ":CH1:PWR:MIN?",
+                ":CH1:PWR:MAX?",
+                ":CH1:PWR {:e}".format(0)
+            ],
+            [
+                ":CH1:CH2:FOO",
+                "-100",
+                "20"
+            ],
+            sep="\n"
     ) as hs:
         channel = hs.channel[0]
         channel.power = 0 * dBm
@@ -210,20 +210,20 @@ def test_channel_power_setter():
 
 def test_channel_phase_getter():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-            ":CH1:PHASE?",
-            ":CH1:PHASE:MIN?",
-            ":CH1:PHASE:MAX?"
-        ],
-        [
-            ":CH1:CH2:FOO",
-            "0",
-            "-180",
-            "+180"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+                ":CH1:PHASE?",
+                ":CH1:PHASE:MIN?",
+                ":CH1:PHASE:MAX?"
+            ],
+            [
+                ":CH1:CH2:FOO",
+                "0",
+                "-180",
+                "+180"
+            ],
+            sep="\n"
     ) as hs:
         channel = hs.channel[0]
         assert channel.phase == 0 * pq.degree
@@ -233,19 +233,19 @@ def test_channel_phase_getter():
 
 def test_channel_phase_setter():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-            ":CH1:PHASE:MIN?",
-            ":CH1:PHASE:MAX?",
-            ":CH1:PHASE {:e}".format(0)
-        ],
-        [
-            ":CH1:CH2:FOO",
-            "-180",
-            "+180"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+                ":CH1:PHASE:MIN?",
+                ":CH1:PHASE:MAX?",
+                ":CH1:PHASE {:e}".format(0)
+            ],
+            [
+                ":CH1:CH2:FOO",
+                "-180",
+                "+180"
+            ],
+            sep="\n"
     ) as hs:
         channel = hs.channel[0]
         channel.phase = 0 * pq.degree
@@ -253,18 +253,18 @@ def test_channel_phase_setter():
 
 def test_channel_output():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":ATTACH?",
-            ":CH1:PWR:RF?",
-            ":CH1:PWR:RF:ON",
-            ":CH1:PWR:RF:OFF"
-        ],
-        [
-            ":CH1:CH2:FOO",
-            "OFF"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":ATTACH?",
+                ":CH1:PWR:RF?",
+                ":CH1:PWR:RF:ON",
+                ":CH1:PWR:RF:OFF"
+            ],
+            [
+                ":CH1:CH2:FOO",
+                "OFF"
+            ],
+            sep="\n"
     ) as hs:
         channel = hs.channel[0]
         assert channel.output is False
@@ -274,16 +274,16 @@ def test_channel_output():
 
 def test_hs9000_is_ready():
     with expected_protocol(
-        ik.holzworth.HS9000,
-        [
-            ":COMM:READY?",
-            ":COMM:READY?"
-        ],
-        [
-            "Ready",
-            "DANGER DANGER"
-        ],
-        sep="\n"
+            ik.holzworth.HS9000,
+            [
+                ":COMM:READY?",
+                ":COMM:READY?"
+            ],
+            [
+                "Ready",
+                "DANGER DANGER"
+            ],
+            sep="\n"
     ) as hs:
         assert hs.ready is True
         assert hs.ready is False

--- a/instruments/tests/test_hp/test_hp3456a.py
+++ b/instruments/tests/test_hp/test_hp3456a.py
@@ -22,21 +22,20 @@ from instruments.tests import expected_protocol
 
 def test_hp3456a_trigger_mode():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "T4",
-        ], [
-            ""
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "T4",
+            ], [
+                ""
+            ],
+            sep="\r"
     ) as dmm:
         dmm.trigger_mode = dmm.TriggerMode.hold
 
 
 def test_hp3456a_number_of_digits():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.hp.HP3456a,
             [
                 "HO0T4SO1",
@@ -46,21 +45,21 @@ def test_hp3456a_number_of_digits():
                 "+06.00000E+0"
             ],
             sep="\r"
-        ) as dmm:
-            dmm.number_of_digits = 7
+    ) as dmm:
+        dmm.number_of_digits = 7
 
 
 def test_hp3456a_number_of_digits_invalid():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "W6STG",
-            "REG"
-        ], [
-            "+06.00000E+0"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "W6STG",
+                "REG"
+            ], [
+                "+06.00000E+0"
+            ],
+            sep="\r"
     ) as dmm:
         dmm.number_of_digits = 6
         assert dmm.number_of_digits == 6
@@ -68,29 +67,29 @@ def test_hp3456a_number_of_digits_invalid():
 
 def test_hp3456a_auto_range():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "R1W",
-        ], [
-            ""
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "R1W",
+            ], [
+                ""
+            ],
+            sep="\r"
     ) as dmm:
         dmm.auto_range()
 
 
 def test_hp3456a_number_of_readings():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "W10STN",
-            "REN"
-        ], [
-            "+10.00000E+0"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "W10STN",
+                "REN"
+            ], [
+                "+10.00000E+0"
+            ],
+            sep="\r"
     ) as dmm:
         dmm.number_of_readings = 10
         assert dmm.number_of_readings == 10
@@ -98,23 +97,6 @@ def test_hp3456a_number_of_readings():
 
 def test_hp3456a_nplc():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "W1STI",
-            "REI"
-        ], [
-            "+1.00000E+0"
-        ],
-        sep="\r"
-    ) as dmm:
-        dmm.nplc = 1
-        assert dmm.nplc == 1
-
-
-def test_hp3456a_nplc_invalid():
-    with pytest.raises(ValueError):
-        with expected_protocol(
             ik.hp.HP3456a,
             [
                 "HO0T4SO1",
@@ -124,63 +106,79 @@ def test_hp3456a_nplc_invalid():
                 "+1.00000E+0"
             ],
             sep="\r"
-        ) as dmm:
-            dmm.nplc = 0
+    ) as dmm:
+        dmm.nplc = 1
+        assert dmm.nplc == 1
+
+
+def test_hp3456a_nplc_invalid():
+    with pytest.raises(ValueError), expected_protocol(
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "W1STI",
+                "REI"
+            ], [
+                "+1.00000E+0"
+            ],
+            sep="\r"
+    ) as dmm:
+        dmm.nplc = 0
 
 
 def test_hp3456a_mode():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "S0F4",
-        ], [
-            ""
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "S0F4",
+            ], [
+                ""
+            ],
+            sep="\r"
     ) as dmm:
         dmm.mode = dmm.Mode.resistance_2wire
 
 
 def test_hp3456a_math_mode():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "M2",
-        ], [
-            ""
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "M2",
+            ], [
+                ""
+            ],
+            sep="\r"
     ) as dmm:
         dmm.math_mode = dmm.MathMode.statistic
 
 
 def test_hp3456a_trigger():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "T3",
-        ], [
-            ""
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "T3",
+            ], [
+                ""
+            ],
+            sep="\r"
     ) as dmm:
         dmm.trigger()
 
 
 def test_hp3456a_fetch():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1"
-        ],
-        [
-            "+000.1055E+0,+000.1043E+0,+000.1005E+0,+000.1014E+0",
-            "+000.1055E+0,+000.1043E+0,+000.1005E+0,+000.1014E+0"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1"
+            ],
+            [
+                "+000.1055E+0,+000.1043E+0,+000.1005E+0,+000.1014E+0",
+                "+000.1055E+0,+000.1043E+0,+000.1005E+0,+000.1014E+0"
+            ],
+            sep="\r"
     ) as dmm:
         v = dmm.fetch(dmm.Mode.resistance_2wire)
         np.testing.assert_array_equal(
@@ -196,57 +194,57 @@ def test_hp3456a_fetch():
 
 def test_hp3456a_variance():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "REV",
-        ], [
-            "+04.93111E-6"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "REV",
+            ], [
+                "+04.93111E-6"
+            ],
+            sep="\r"
     ) as dmm:
         assert dmm.variance == +04.93111E-6
 
 
 def test_hp3456a_count():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "REC",
-        ], [
-            "+10.00000E+0"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "REC",
+            ], [
+                "+10.00000E+0"
+            ],
+            sep="\r"
     ) as dmm:
         assert dmm.count == +10
 
 
 def test_hp3456a_mean():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "REM",
-        ], [
-            "+102.1000E-3"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "REM",
+            ], [
+                "+102.1000E-3"
+            ],
+            sep="\r"
     ) as dmm:
         assert dmm.mean == +102.1000E-3
 
 
 def test_hp3456a_delay():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "RED",
-            "W1.0STD"
-        ], [
-            "-000.0000E+0"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "RED",
+                "W1.0STD"
+            ], [
+                "-000.0000E+0"
+            ],
+            sep="\r"
     ) as dmm:
         assert dmm.delay == 0
         dmm.delay = 1 * pq.sec
@@ -254,15 +252,15 @@ def test_hp3456a_delay():
 
 def test_hp3456a_lower():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "REL",
-            "W0.0993STL"
-        ], [
-            "+099.3000E-3"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "REL",
+                "W0.0993STL"
+            ], [
+                "+099.3000E-3"
+            ],
+            sep="\r"
     ) as dmm:
         assert dmm.lower == +099.3000E-3
         dmm.lower = +099.3000E-3
@@ -270,15 +268,15 @@ def test_hp3456a_lower():
 
 def test_hp3456a_upper():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "REU",
-            "W0.1055STU"
-        ], [
-            "+105.5000E-3"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "REU",
+                "W0.1055STU"
+            ], [
+                "+105.5000E-3"
+            ],
+            sep="\r"
     ) as dmm:
         assert dmm.upper == +105.5000E-3
         dmm.upper = +105.5000E-3
@@ -286,21 +284,21 @@ def test_hp3456a_upper():
 
 def test_hp3456a_ryz():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "RER",
-            "REY",
-            "REZ",
-            "W600.0STR",
-            "W1.0STY",
-            "W0.1055STZ"
-        ], [
-            "+0600.000E+0",
-            "+1.000000E+0",
-            "+105.5000E-3"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "RER",
+                "REY",
+                "REZ",
+                "W600.0STR",
+                "W1.0STY",
+                "W0.1055STZ"
+            ], [
+                "+0600.000E+0",
+                "+1.000000E+0",
+                "+105.5000E-3"
+            ],
+            sep="\r"
     ) as dmm:
         assert dmm.r == +0600.000E+0
         assert dmm.y == +1.000000E+0
@@ -312,21 +310,21 @@ def test_hp3456a_ryz():
 
 def test_hp3456a_measure():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "S1F1W1STNT3",
-            "S0F4W1STNT3",
-            "S0F1W1STNT3",
-            "W1STNT3"
-        ],
-        [
-            "+00.00000E-3",
-            "+000.1010E+0",
-            "+000.0002E-3",
-            "+000.0002E-3"
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "S1F1W1STNT3",
+                "S0F4W1STNT3",
+                "S0F1W1STNT3",
+                "W1STNT3"
+            ],
+            [
+                "+00.00000E-3",
+                "+000.1010E+0",
+                "+000.0002E-3",
+                "+000.0002E-3"
+            ],
+            sep="\r"
     ) as dmm:
         assert dmm.measure(dmm.Mode.ratio_dcv_dcv) == 0
         assert dmm.measure(dmm.Mode.resistance_2wire) == +000.1010E+0 * pq.ohm
@@ -336,75 +334,71 @@ def test_hp3456a_measure():
 
 def test_hp3456a_input_range():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "R2W",
-            "R3W"
-        ], [
-            ""
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "R2W",
+                "R3W"
+            ], [
+                ""
+            ],
+            sep="\r"
     ) as dmm:
         dmm.input_range = 10 ** -1 * pq.volt
         dmm.input_range = 1e3 * pq.ohm
 
 
 def test_hp3456a_input_range_invalid_str():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.hp.HP3456a,
             [],
             [],
             sep="\r"
-        ) as dmm:
-            dmm.input_range = "derp"
+    ) as dmm:
+        dmm.input_range = "derp"
 
 
 def test_hp3456a_input_range_invalid_range():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.hp.HP3456a,
             [],
             [],
             sep="\r"
-        ) as dmm:
-            dmm.input_range = 1 * pq.ohm
+    ) as dmm:
+        dmm.input_range = 1 * pq.ohm
 
 
 def test_hp3456a_input_range_bad_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.hp.HP3456a,
             [],
             [],
             sep="\r"
-        ) as dmm:
-            dmm.input_range = True
+    ) as dmm:
+        dmm.input_range = True
 
 
 def test_hp3456a_input_range_bad_units():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.hp.HP3456a,
             [],
             [],
             sep="\r"
-        ) as dmm:
-            dmm.input_range = 1 * pq.amp
+    ) as dmm:
+        dmm.input_range = 1 * pq.amp
 
 
 def test_hp3456a_relative():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "M0",
-            "M3",
-        ], [
-            "",
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "M0",
+                "M3",
+            ], [
+                "",
+            ],
+            sep="\r"
     ) as dmm:
         dmm.relative = False
         dmm.relative = True
@@ -412,27 +406,26 @@ def test_hp3456a_relative():
 
 
 def test_hp3456a_relative_bad_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.hp.HP3456a,
             [],
             [],
             sep="\r"
-        ) as dmm:
-            dmm.relative = "derp"
+    ) as dmm:
+        dmm.relative = "derp"
 
 
 def test_hp3456a_auto_zero():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "Z0",
-            "Z1",
-        ], [
-            "",
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "Z0",
+                "Z1",
+            ], [
+                "",
+            ],
+            sep="\r"
     ) as dmm:
         dmm.autozero = False
         dmm.autozero = True
@@ -440,48 +433,45 @@ def test_hp3456a_auto_zero():
 
 def test_hp3456a_filter():
     with expected_protocol(
-        ik.hp.HP3456a,
-        [
-            "HO0T4SO1",
-            "FL0",
-            "FL1",
-        ], [
-            "",
-        ],
-        sep="\r"
+            ik.hp.HP3456a,
+            [
+                "HO0T4SO1",
+                "FL0",
+                "FL1",
+            ], [
+                "",
+            ],
+            sep="\r"
     ) as dmm:
         dmm.filter = False
         dmm.filter = True
 
 
 def test_hp3456a_register_read_bad_name():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.hp.HP3456a,
             [],
             [],
             sep="\r"
-        ) as dmm:
-            dmm._register_read("foobar")
+    ) as dmm:
+        dmm._register_read("foobar")
 
 
 def test_hp3456a_register_write_bad_name():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.hp.HP3456a,
             [],
             [],
             sep="\r"
-        ) as dmm:
-            dmm._register_write("foobar", 1)
+    ) as dmm:
+        dmm._register_write("foobar", 1)
 
 
 def test_hp3456a_register_write_bad_register():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.hp.HP3456a,
             [],
             [],
             sep="\r"
-        ) as dmm:
-            dmm._register_write(dmm.Register.mean, 1)
+    ) as dmm:
+        dmm._register_write(dmm.Register.mean, 1)

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -22,10 +22,10 @@ from .. import mock
 
 def test_channel_returns_inner_class():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [],
-        [],
-        sep="\n"
+            ik.hp.HP6624a,
+            [],
+            [],
+            sep="\n"
     ) as hp:
         channel = hp.channel[0]
         assert isinstance(channel, hp.Channel) is True
@@ -60,15 +60,15 @@ def test_channel_query():
 
 def test_channel_voltage():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "VSET? 1",
-            "VSET 1,{:.1f}".format(5)
-        ],
-        [
-            "2"
-        ],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "VSET? 1",
+                "VSET 1,{:.1f}".format(5)
+            ],
+            [
+                "2"
+            ],
+            sep="\n"
     ) as hp:
         assert hp.channel[0].voltage == 2 * pq.V
         hp.channel[0].voltage = 5 * pq.V
@@ -76,15 +76,15 @@ def test_channel_voltage():
 
 def test_channel_current():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "ISET? 1",
-            "ISET 1,{:.1f}".format(5)
-        ],
-        [
-            "2"
-        ],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "ISET? 1",
+                "ISET 1,{:.1f}".format(5)
+            ],
+            [
+                "2"
+            ],
+            sep="\n"
     ) as hp:
         assert hp.channel[0].current == 2 * pq.amp
         hp.channel[0].current = 5 * pq.amp
@@ -92,43 +92,43 @@ def test_channel_current():
 
 def test_channel_voltage_sense():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "VOUT? 1"
-        ],
-        [
-            "2"
-        ],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "VOUT? 1"
+            ],
+            [
+                "2"
+            ],
+            sep="\n"
     ) as hp:
         assert hp.channel[0].voltage_sense == 2 * pq.V
 
 
 def test_channel_current_sense():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "IOUT? 1",
-        ],
-        [
-            "2"
-        ],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "IOUT? 1",
+            ],
+            [
+                "2"
+            ],
+            sep="\n"
     ) as hp:
         assert hp.channel[0].current_sense == 2 * pq.A
 
 
 def test_channel_overvoltage():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "OVSET? 1",
-            "OVSET 1,{:.1f}".format(5)
-        ],
-        [
-            "2"
-        ],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "OVSET? 1",
+                f"OVSET 1,{5:.1f}"
+            ],
+            [
+                "2"
+            ],
+            sep="\n"
     ) as hp:
         assert hp.channel[0].overvoltage == 2 * pq.V
         hp.channel[0].overvoltage = 5 * pq.V
@@ -136,15 +136,15 @@ def test_channel_overvoltage():
 
 def test_channel_overcurrent():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "OVP? 1",
-            "OVP 1,1"
-        ],
-        [
-            "1"
-        ],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "OVP? 1",
+                "OVP 1,1"
+            ],
+            [
+                "1"
+            ],
+            sep="\n"
     ) as hp:
         assert hp.channel[0].overcurrent is True
         hp.channel[0].overcurrent = True
@@ -152,15 +152,15 @@ def test_channel_overcurrent():
 
 def test_channel_output():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "OUT? 1",
-            "OUT 1,1"
-        ],
-        [
-            "1"
-        ],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "OUT? 1",
+                "OUT 1,1"
+            ],
+            [
+                "1"
+            ],
+            sep="\n"
     ) as hp:
         assert hp.channel[0].output is True
         hp.channel[0].output = True
@@ -176,30 +176,30 @@ def test_channel_reset():
 
 def test_all_voltage():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "VSET? 1",
-            "VSET? 2",
-            "VSET? 3",
-            "VSET? 4",
+            ik.hp.HP6624a,
+            [
+                "VSET? 1",
+                "VSET? 2",
+                "VSET? 3",
+                "VSET? 4",
 
-            "VSET 1,{:.1f}".format(5),
-            "VSET 2,{:.1f}".format(5),
-            "VSET 3,{:.1f}".format(5),
-            "VSET 4,{:.1f}".format(5),
+                "VSET 1,{:.1f}".format(5),
+                "VSET 2,{:.1f}".format(5),
+                "VSET 3,{:.1f}".format(5),
+                "VSET 4,{:.1f}".format(5),
 
-            "VSET 1,{:.1f}".format(1),
-            "VSET 2,{:.1f}".format(2),
-            "VSET 3,{:.1f}".format(3),
-            "VSET 4,{:.1f}".format(4)
-        ],
-        [
-            "2",
-            "3",
-            "4",
-            "5"
-        ],
-        sep="\n"
+                "VSET 1,{:.1f}".format(1),
+                "VSET 2,{:.1f}".format(2),
+                "VSET 3,{:.1f}".format(3),
+                "VSET 4,{:.1f}".format(4)
+            ],
+            [
+                "2",
+                "3",
+                "4",
+                "5"
+            ],
+            sep="\n"
     ) as hp:
         assert sorted(hp.voltage) == sorted((2, 3, 4, 5) * pq.V)
         hp.voltage = 5 * pq.V
@@ -207,42 +207,41 @@ def test_all_voltage():
 
 
 def test_all_voltage_wrong_length():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.hp.HP6624a,
             [],
             [],
             sep="\n"
-        ) as hp:
-            hp.voltage = (1 * pq.volt, 2 * pq.volt)
+    ) as hp:
+        hp.voltage = (1 * pq.volt, 2 * pq.volt)
 
 
 def test_all_current():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "ISET? 1",
-            "ISET? 2",
-            "ISET? 3",
-            "ISET? 4",
+            ik.hp.HP6624a,
+            [
+                "ISET? 1",
+                "ISET? 2",
+                "ISET? 3",
+                "ISET? 4",
 
-            "ISET 1,{:.1f}".format(5),
-            "ISET 2,{:.1f}".format(5),
-            "ISET 3,{:.1f}".format(5),
-            "ISET 4,{:.1f}".format(5),
+                "ISET 1,{:.1f}".format(5),
+                "ISET 2,{:.1f}".format(5),
+                "ISET 3,{:.1f}".format(5),
+                "ISET 4,{:.1f}".format(5),
 
-            "ISET 1,{:.1f}".format(1),
-            "ISET 2,{:.1f}".format(2),
-            "ISET 3,{:.1f}".format(3),
-            "ISET 4,{:.1f}".format(4)
-        ],
-        [
-            "2",
-            "3",
-            "4",
-            "5"
-        ],
-        sep="\n"
+                "ISET 1,{:.1f}".format(1),
+                "ISET 2,{:.1f}".format(2),
+                "ISET 3,{:.1f}".format(3),
+                "ISET 4,{:.1f}".format(4)
+            ],
+            [
+                "2",
+                "3",
+                "4",
+                "5"
+            ],
+            sep="\n"
     ) as hp:
         assert sorted(hp.current) == sorted((2, 3, 4, 5) * pq.A)
         hp.current = 5 * pq.A
@@ -250,96 +249,93 @@ def test_all_current():
 
 
 def test_all_current_wrong_length():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.hp.HP6624a,
             [],
             [],
             sep="\n"
-        ) as hp:
-            hp.current = (1 * pq.amp, 2 * pq.amp)
+    ) as hp:
+        hp.current = (1 * pq.amp, 2 * pq.amp)
 
 
 def test_all_voltage_sense():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "VOUT? 1",
-            "VOUT? 2",
-            "VOUT? 3",
-            "VOUT? 4"
-        ],
-        [
-            "2",
-            "3",
-            "4",
-            "5"
-        ],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "VOUT? 1",
+                "VOUT? 2",
+                "VOUT? 3",
+                "VOUT? 4"
+            ],
+            [
+                "2",
+                "3",
+                "4",
+                "5"
+            ],
+            sep="\n"
     ) as hp:
         assert sorted(hp.voltage_sense) == sorted((2, 3, 4, 5) * pq.V)
 
 
 def test_all_current_sense():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "IOUT? 1",
-            "IOUT? 2",
-            "IOUT? 3",
-            "IOUT? 4"
-        ],
-        [
-            "2",
-            "3",
-            "4",
-            "5"
-        ],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "IOUT? 1",
+                "IOUT? 2",
+                "IOUT? 3",
+                "IOUT? 4"
+            ],
+            [
+                "2",
+                "3",
+                "4",
+                "5"
+            ],
+            sep="\n"
     ) as hp:
         assert sorted(hp.current_sense) == sorted((2, 3, 4, 5) * pq.A)
 
 
 def test_clear():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [
-            "CLR"
-        ],
-        [],
-        sep="\n"
+            ik.hp.HP6624a,
+            [
+                "CLR"
+            ],
+            [],
+            sep="\n"
     ) as hp:
         hp.clear()
 
 
 def test_channel_count():
     with expected_protocol(
-        ik.hp.HP6624a,
-        [],
-        [],
-        sep="\n"
+            ik.hp.HP6624a,
+            [],
+            [],
+            sep="\n"
     ) as hp:
         assert hp.channel_count == 4
         hp.channel_count = 3
 
 
 def test_channel_count_wrong_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.hp.HP6624a,
             [],
             [],
             sep="\n"
-        ) as hp:
-            hp.channel_count = "foobar"
+    ) as hp:
+        hp.channel_count = "foobar"
 
 
 def test_channel_count_too_small():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.hp.HP6624a,
             [],
             [],
             sep="\n"
-        ) as hp:
-            hp.channel_count = 0
+    ) as hp:
+        hp.channel_count = 0

--- a/instruments/tests/test_hp/test_hp6632b.py
+++ b/instruments/tests/test_hp/test_hp6632b.py
@@ -20,13 +20,13 @@ test_scpi_multimeter_name = make_name_test(ik.hp.HP6632b)
 
 def test_hp6632b_display_textmode():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "DISP:MODE?",
-            "DISP:MODE TEXT"
-        ], [
-            "NORM"
-        ]
+            ik.hp.HP6632b,
+            [
+                "DISP:MODE?",
+                "DISP:MODE TEXT"
+            ], [
+                "NORM"
+            ]
     ) as psu:
         assert psu.display_textmode is False
         psu.display_textmode = True
@@ -34,12 +34,12 @@ def test_hp6632b_display_textmode():
 
 def test_hp6632b_display_text():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            'DISP:TEXT "TEST"',
-            'DISP:TEXT "TEST AAAAAAAAAA"'
-        ],
-        []
+            ik.hp.HP6632b,
+            [
+                'DISP:TEXT "TEST"',
+                'DISP:TEXT "TEST AAAAAAAAAA"'
+            ],
+            []
     ) as psu:
         assert psu.display_text("TEST") == "TEST"
         assert psu.display_text("TEST AAAAAAAAAAAAAAAA") == "TEST AAAAAAAAAA"
@@ -47,13 +47,13 @@ def test_hp6632b_display_text():
 
 def test_hp6632b_output():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "OUTP?",
-            "OUTP 1"
-        ], [
-            "0"
-        ]
+            ik.hp.HP6632b,
+            [
+                "OUTP?",
+                "OUTP 1"
+            ], [
+                "0"
+            ]
     ) as psu:
         assert psu.output is False
         psu.output = True
@@ -61,13 +61,13 @@ def test_hp6632b_output():
 
 def test_hp6632b_voltage():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "VOLT?",
-            "VOLT {:e}".format(1)
-        ], [
-            "10.0"
-        ]
+            ik.hp.HP6632b,
+            [
+                "VOLT?",
+                "VOLT {:e}".format(1)
+            ], [
+                "10.0"
+            ]
     ) as psu:
         unit_eq(psu.voltage, 10 * pq.volt)
         psu.voltage = 1.0 * pq.volt
@@ -75,25 +75,25 @@ def test_hp6632b_voltage():
 
 def test_hp6632b_voltage_sense():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "MEAS:VOLT?",
-        ], [
-            "10.0"
-        ]
+            ik.hp.HP6632b,
+            [
+                "MEAS:VOLT?",
+            ], [
+                "10.0"
+            ]
     ) as psu:
         unit_eq(psu.voltage_sense, 10 * pq.volt)
 
 
 def test_hp6632b_overvoltage():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "VOLT:PROT?",
-            "VOLT:PROT {:e}".format(1)
-        ], [
-            "10.0"
-        ]
+            ik.hp.HP6632b,
+            [
+                "VOLT:PROT?",
+                "VOLT:PROT {:e}".format(1)
+            ], [
+                "10.0"
+            ]
     ) as psu:
         unit_eq(psu.overvoltage, 10 * pq.volt)
         psu.overvoltage = 1.0 * pq.volt
@@ -101,13 +101,13 @@ def test_hp6632b_overvoltage():
 
 def test_hp6632b_current():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "CURR?",
-            "CURR {:e}".format(1)
-        ], [
-            "10.0"
-        ]
+            ik.hp.HP6632b,
+            [
+                "CURR?",
+                "CURR {:e}".format(1)
+            ], [
+                "10.0"
+            ]
     ) as psu:
         unit_eq(psu.current, 10 * pq.amp)
         psu.current = 1.0 * pq.amp
@@ -115,25 +115,25 @@ def test_hp6632b_current():
 
 def test_hp6632b_current_sense():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "MEAS:CURR?",
-        ], [
-            "10.0"
-        ]
+            ik.hp.HP6632b,
+            [
+                "MEAS:CURR?",
+            ], [
+                "10.0"
+            ]
     ) as psu:
         unit_eq(psu.current_sense, 10 * pq.amp)
 
 
 def test_hp6632b_overcurrent():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "CURR:PROT:STAT?",
-            "CURR:PROT:STAT 1"
-        ], [
-            "0"
-        ]
+            ik.hp.HP6632b,
+            [
+                "CURR:PROT:STAT?",
+                "CURR:PROT:STAT 1"
+            ], [
+                "0"
+            ]
     ) as psu:
         assert psu.overcurrent is False
         psu.overcurrent = True
@@ -141,13 +141,13 @@ def test_hp6632b_overcurrent():
 
 def test_hp6632b_current_sense_range():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "SENS:CURR:RANGE?",
-            "SENS:CURR:RANGE {:e}".format(1)
-        ], [
-            "0.05"
-        ]
+            ik.hp.HP6632b,
+            [
+                "SENS:CURR:RANGE?",
+                "SENS:CURR:RANGE {:e}".format(1)
+            ], [
+                "0.05"
+            ]
     ) as psu:
         unit_eq(psu.current_sense_range, 0.05 * pq.amp)
         psu.current_sense_range = 1 * pq.amp
@@ -155,13 +155,13 @@ def test_hp6632b_current_sense_range():
 
 def test_hp6632b_output_dfi_source():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "OUTP:DFI:SOUR?",
-            "OUTP:DFI:SOUR QUES"
-        ], [
-            "OPER"
-        ]
+            ik.hp.HP6632b,
+            [
+                "OUTP:DFI:SOUR?",
+                "OUTP:DFI:SOUR QUES"
+            ], [
+                "OPER"
+            ]
     ) as psu:
         assert psu.output_dfi_source == psu.DFISource.operation
         psu.output_dfi_source = psu.DFISource.questionable
@@ -169,13 +169,13 @@ def test_hp6632b_output_dfi_source():
 
 def test_hp6632b_output_remote_inhibit():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "OUTP:RI:MODE?",
-            "OUTP:RI:MODE LATC"
-        ], [
-            "LIVE"
-        ]
+            ik.hp.HP6632b,
+            [
+                "OUTP:RI:MODE?",
+                "OUTP:RI:MODE LATC"
+            ], [
+                "LIVE"
+            ]
     ) as psu:
         assert psu.output_remote_inhibit == psu.RemoteInhibit.live
         psu.output_remote_inhibit = psu.RemoteInhibit.latching
@@ -183,13 +183,13 @@ def test_hp6632b_output_remote_inhibit():
 
 def test_hp6632b_digital_function():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "DIG:FUNC?",
-            "DIG:FUNC DIG"
-        ], [
-            "RIDF"
-        ]
+            ik.hp.HP6632b,
+            [
+                "DIG:FUNC?",
+                "DIG:FUNC DIG"
+            ], [
+                "RIDF"
+            ]
     ) as psu:
         assert psu.digital_function == psu.DigitalFunction.remote_inhibit
         psu.digital_function = psu.DigitalFunction.data
@@ -197,13 +197,13 @@ def test_hp6632b_digital_function():
 
 def test_hp6632b_digital_data():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "DIG:DATA?",
-            "DIG:DATA 1"
-        ], [
-            "5"
-        ]
+            ik.hp.HP6632b,
+            [
+                "DIG:DATA?",
+                "DIG:DATA 1"
+            ], [
+                "5"
+            ]
     ) as psu:
         assert psu.digital_data == 5
         psu.digital_data = 1
@@ -211,13 +211,13 @@ def test_hp6632b_digital_data():
 
 def test_hp6632b_sense_sweep_points():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "SENS:SWE:POIN?",
-            "SENS:SWE:POIN {:e}".format(2048)
-        ], [
-            "5"
-        ]
+            ik.hp.HP6632b,
+            [
+                "SENS:SWE:POIN?",
+                "SENS:SWE:POIN {:e}".format(2048)
+            ], [
+                "5"
+            ]
     ) as psu:
         assert psu.sense_sweep_points == 5
         psu.sense_sweep_points = 2048
@@ -225,13 +225,13 @@ def test_hp6632b_sense_sweep_points():
 
 def test_hp6632b_sense_sweep_interval():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "SENS:SWE:TINT?",
-            "SENS:SWE:TINT {:e}".format(1e-05)
-        ], [
-            "1.56e-05"
-        ]
+            ik.hp.HP6632b,
+            [
+                "SENS:SWE:TINT?",
+                "SENS:SWE:TINT {:e}".format(1e-05)
+            ], [
+                "1.56e-05"
+            ]
     ) as psu:
         unit_eq(psu.sense_sweep_interval, 1.56e-05 * pq.second)
         psu.sense_sweep_interval = 1e-05 * pq.second
@@ -239,13 +239,13 @@ def test_hp6632b_sense_sweep_interval():
 
 def test_hp6632b_sense_window():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "SENS:WIND?",
-            "SENS:WIND RECT"
-        ], [
-            "HANN"
-        ]
+            ik.hp.HP6632b,
+            [
+                "SENS:WIND?",
+                "SENS:WIND RECT"
+            ], [
+                "HANN"
+            ]
     ) as psu:
         assert psu.sense_window == psu.SenseWindow.hanning
         psu.sense_window = psu.SenseWindow.rectangular
@@ -253,13 +253,13 @@ def test_hp6632b_sense_window():
 
 def test_hp6632b_output_protection_delay():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "OUTP:PROT:DEL?",
-            "OUTP:PROT:DEL {:e}".format(5e-02)
-        ], [
-            "8e-02"
-        ]
+            ik.hp.HP6632b,
+            [
+                "OUTP:PROT:DEL?",
+                "OUTP:PROT:DEL {:e}".format(5e-02)
+            ], [
+                "8e-02"
+            ]
     ) as psu:
         unit_eq(psu.output_protection_delay, 8e-02 * pq.second)
         psu.output_protection_delay = 5e-02 * pq.second
@@ -267,25 +267,25 @@ def test_hp6632b_output_protection_delay():
 
 def test_hp6632b_voltage_alc_bandwidth():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "VOLT:ALC:BAND?",
-        ], [
-            "6e4"
-        ]
+            ik.hp.HP6632b,
+            [
+                "VOLT:ALC:BAND?",
+            ], [
+                "6e4"
+            ]
     ) as psu:
         assert psu.voltage_alc_bandwidth == psu.ALCBandwidth.fast
 
 
 def test_hp6632b_voltage_trigger():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "VOLT:TRIG?",
-            "VOLT:TRIG {:e}".format(1)
-        ], [
-            "1e+0"
-        ]
+            ik.hp.HP6632b,
+            [
+                "VOLT:TRIG?",
+                "VOLT:TRIG {:e}".format(1)
+            ], [
+                "1e+0"
+            ]
     ) as psu:
         unit_eq(psu.voltage_trigger, 1 * pq.volt)
         psu.voltage_trigger = 1 * pq.volt
@@ -293,13 +293,13 @@ def test_hp6632b_voltage_trigger():
 
 def test_hp6632b_current_trigger():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "CURR:TRIG?",
-            "CURR:TRIG {:e}".format(0.1)
-        ], [
-            "1e-01"
-        ]
+            ik.hp.HP6632b,
+            [
+                "CURR:TRIG?",
+                "CURR:TRIG {:e}".format(0.1)
+            ], [
+                "1e-01"
+            ]
     ) as psu:
         unit_eq(psu.current_trigger, 0.1 * pq.amp)
         psu.current_trigger = 0.1 * pq.amp
@@ -307,38 +307,38 @@ def test_hp6632b_current_trigger():
 
 def test_hp6632b_init_output_trigger():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "INIT:NAME TRAN",
-        ],
-        []
+            ik.hp.HP6632b,
+            [
+                "INIT:NAME TRAN",
+            ],
+            []
     ) as psu:
         psu.init_output_trigger()
 
 
 def test_hp6632b_abort_output_trigger():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "ABORT",
-        ],
-        []
+            ik.hp.HP6632b,
+            [
+                "ABORT",
+            ],
+            []
     ) as psu:
         psu.abort_output_trigger()
 
 
 def test_hp6632b_check_error_queue():
     with expected_protocol(
-        ik.hp.HP6632b,
-        [
-            "SYST:ERR?",
-            "SYST:ERR?",
-        ], [
-            '-222,"Data out of range"',
-            '+0,"No error"'
-        ]
+            ik.hp.HP6632b,
+            [
+                "SYST:ERR?",
+                "SYST:ERR?",
+            ], [
+                '-222,"Data out of range"',
+                '+0,"No error"'
+            ]
     ) as psu:
         err_queue = psu.check_error_queue()
         assert err_queue == [
             psu.ErrorCodes.data_out_of_range
-        ], "got {}".format(err_queue)
+        ], f"got {err_queue}"

--- a/instruments/tests/test_hp/test_hp6652a.py
+++ b/instruments/tests/test_hp/test_hp6652a.py
@@ -16,38 +16,38 @@ from instruments.tests import expected_protocol
 
 def test_name():
     with expected_protocol(
-        ik.hp.HP6652a,
-        [
-            "*IDN?"
-        ],
-        [
-            "FOO,BAR,AAA,BBBB"
-        ],
-        sep="\n"
+            ik.hp.HP6652a,
+            [
+                "*IDN?"
+            ],
+            [
+                "FOO,BAR,AAA,BBBB"
+            ],
+            sep="\n"
     ) as hp:
         assert hp.name == "FOO BAR"
 
 
 def test_reset():
     with expected_protocol(
-        ik.hp.HP6652a,
-        [
-            "OUTP:PROT:CLE"
-        ],
-        [],
-        sep="\n"
+            ik.hp.HP6652a,
+            [
+                "OUTP:PROT:CLE"
+            ],
+            [],
+            sep="\n"
     ) as hp:
         hp.reset()
 
 
 def test_display_text():
     with expected_protocol(
-        ik.hp.HP6652a,
-        [
-            'DISP:TEXT "TEST"',
-            'DISP:TEXT "TEST AAAAAAAAAA"'
-        ],
-        []
+            ik.hp.HP6652a,
+            [
+                'DISP:TEXT "TEST"',
+                'DISP:TEXT "TEST AAAAAAAAAA"'
+            ],
+            []
     ) as psu:
         assert psu.display_text("TEST") == "TEST"
         assert psu.display_text("TEST AAAAAAAAAAAAAAAA") == "TEST AAAAAAAAAA"
@@ -55,10 +55,10 @@ def test_display_text():
 
 def test_channel():
     with expected_protocol(
-        ik.hp.HP6652a,
-        [],
-        [],
-        sep="\n"
+            ik.hp.HP6652a,
+            [],
+            [],
+            sep="\n"
     ) as hp:
         assert hp.channel[0] == hp
         assert len(hp.channel) == 1

--- a/instruments/tests/test_hp/test_hpe3631a.py
+++ b/instruments/tests/test_hp/test_hpe3631a.py
@@ -18,19 +18,19 @@ from instruments.tests import expected_protocol
 
 def test_channel():
     with expected_protocol(
-        ik.hp.HPe3631a,
-        [
-            "SYST:REM",
-            "INST:NSEL?",
-            "INST:NSEL?",
-            "INST:NSEL 2",
-            "INST:NSEL?"
-        ],
-        [
-            "1",
-            "1",
-            "2"
-        ]
+            ik.hp.HPe3631a,
+            [
+                "SYST:REM",
+                "INST:NSEL?",
+                "INST:NSEL?",
+                "INST:NSEL 2",
+                "INST:NSEL?"
+            ],
+            [
+                "1",
+                "1",
+                "2"
+            ]
     ) as inst:
         assert inst.channelid == 1
         assert inst.channel[2] == inst
@@ -39,17 +39,17 @@ def test_channel():
 
 def test_channelid():
     with expected_protocol(
-        ik.hp.HPe3631a,
-        [
-            "SYST:REM",  # 0
-            "INST:NSEL?",   # 1
-            "INST:NSEL 2",  # 2
-            "INST:NSEL?"    # 3
-        ],
-        [
-            "1",    # 1
-            "2"     # 3
-        ]
+            ik.hp.HPe3631a,
+            [
+                "SYST:REM",  # 0
+                "INST:NSEL?",   # 1
+                "INST:NSEL 2",  # 2
+                "INST:NSEL?"    # 3
+            ],
+            [
+                "1",    # 1
+                "2"     # 3
+            ]
     ) as inst:
         assert inst.channelid == 1
         inst.channelid = 2
@@ -58,25 +58,25 @@ def test_channelid():
 
 def test_voltage():
     with expected_protocol(
-        ik.hp.HPe3631a,
-        [
-            "SYST:REM",  # 0
-            "SOUR:VOLT? MAX",   # 1
-            "SOUR:VOLT? MAX",   # 2
-            "SOUR:VOLT? MAX",   # 3.1
-            "SOUR:VOLT 3.000000e+00",   # 3.2
-            "SOUR:VOLT?",   # 4
-            "SOUR:VOLT? MAX",   # 5
-            "SOUR:VOLT? MAX"    # 6
-        ],
-        [
-            "6.0",  # 1
-            "6.0",  # 2
-            "6.0",  # 3.1
-            "3.0",  # 4
-            "6.0",  # 5
-            "6.0"   # 6
-        ]
+            ik.hp.HPe3631a,
+            [
+                "SYST:REM",  # 0
+                "SOUR:VOLT? MAX",   # 1
+                "SOUR:VOLT? MAX",   # 2
+                "SOUR:VOLT? MAX",   # 3.1
+                "SOUR:VOLT 3.000000e+00",   # 3.2
+                "SOUR:VOLT?",   # 4
+                "SOUR:VOLT? MAX",   # 5
+                "SOUR:VOLT? MAX"    # 6
+            ],
+            [
+                "6.0",  # 1
+                "6.0",  # 2
+                "6.0",  # 3.1
+                "3.0",  # 4
+                "6.0",  # 5
+                "6.0"   # 6
+            ]
     ) as inst:
         assert inst.voltage_min == 0.0 * pq.volt
         assert inst.voltage_max == 6.0 * pq.volt
@@ -94,29 +94,29 @@ def test_voltage():
 
 def test_current():
     with expected_protocol(
-        ik.hp.HPe3631a,
-        [
-            "SYST:REM",  # 0
-            "SOUR:CURR? MIN",   # 1.1
-            "SOUR:CURR? MAX",   # 1.2
-            "SOUR:CURR? MIN",   # 2.1
-            "SOUR:CURR? MAX",   # 2.2
-            "SOUR:CURR 2.000000e+00",   # 3
-            "SOUR:CURR?",   # 4
-            "SOUR:CURR? MIN",   # 5
-            "SOUR:CURR? MIN",   # 6.1
-            "SOUR:CURR? MAX"    # 6.2
-        ],
-        [
-            "0.0",  # 1.1
-            "5.0",  # 1.2
-            "0.0",  # 2.1
-            "5.0",  # 2.2
-            "2.0",  # 4
-            "0.0",  # 5
-            "0.0",  # 6.1
-            "5.0"   # 6.2
-        ]
+            ik.hp.HPe3631a,
+            [
+                "SYST:REM",  # 0
+                "SOUR:CURR? MIN",   # 1.1
+                "SOUR:CURR? MAX",   # 1.2
+                "SOUR:CURR? MIN",   # 2.1
+                "SOUR:CURR? MAX",   # 2.2
+                "SOUR:CURR 2.000000e+00",   # 3
+                "SOUR:CURR?",   # 4
+                "SOUR:CURR? MIN",   # 5
+                "SOUR:CURR? MIN",   # 6.1
+                "SOUR:CURR? MAX"    # 6.2
+            ],
+            [
+                "0.0",  # 1.1
+                "5.0",  # 1.2
+                "0.0",  # 2.1
+                "5.0",  # 2.2
+                "2.0",  # 4
+                "0.0",  # 5
+                "0.0",  # 6.1
+                "5.0"   # 6.2
+            ]
     ) as inst:
         assert inst.current_min == 0.0 * pq.amp
         assert inst.current_max == 5.0 * pq.amp
@@ -134,27 +134,27 @@ def test_current():
 
 def test_voltage_sense():
     with expected_protocol(
-        ik.hp.HPe3631a,
-        [
-            "SYST:REM",  # 0
-            "MEAS:VOLT?"   # 1
-        ],
-        [
-            "1.234"  # 1
-        ]
+            ik.hp.HPe3631a,
+            [
+                "SYST:REM",  # 0
+                "MEAS:VOLT?"   # 1
+            ],
+            [
+                "1.234"  # 1
+            ]
     ) as inst:
         assert inst.voltage_sense == 1.234 * pq.volt
 
 
 def test_current_sense():
     with expected_protocol(
-        ik.hp.HPe3631a,
-        [
-            "SYST:REM",  # 0
-            "MEAS:CURR?"   # 1
-        ],
-        [
-            "1.234"  # 1
-        ]
+            ik.hp.HPe3631a,
+            [
+                "SYST:REM",  # 0
+                "MEAS:CURR?"   # 1
+            ],
+            [
+                "1.234"  # 1
+            ]
     ) as inst:
         assert inst.current_sense == 1.234 * pq.amp

--- a/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/tests/test_keithley/test_keithley2182.py
@@ -25,13 +25,13 @@ def test_channel():
 
 def test_channel_mode():
     with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "SENS:FUNC?",
-        ],
-        [
-            "VOLT",
-        ]
+            ik.keithley.Keithley2182,
+            [
+                "SENS:FUNC?",
+            ],
+            [
+                "VOLT",
+            ]
     ) as inst:
         channel = inst.channel[0]
         assert channel.mode == inst.Mode.voltage_dc
@@ -39,16 +39,16 @@ def test_channel_mode():
 
 def test_channel_measure_voltage():
     with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "SENS:CHAN 1",
-            "SENS:DATA:FRES?",
-            "SENS:FUNC?"
-        ],
-        [
-            "1.234",
-            "VOLT",
-        ]
+            ik.keithley.Keithley2182,
+            [
+                "SENS:CHAN 1",
+                "SENS:DATA:FRES?",
+                "SENS:FUNC?"
+            ],
+            [
+                "1.234",
+                "VOLT",
+            ]
     ) as inst:
         channel = inst.channel[0]
         assert channel.measure() == 1.234 * pq.volt
@@ -56,26 +56,25 @@ def test_channel_measure_voltage():
 
 def test_channel_measure_temperature():
     with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "SENS:CHAN 1",
-            "SENS:DATA:FRES?",
-            "SENS:FUNC?",
-            "UNIT:TEMP?"
-        ],
-        [
-            "1.234",
-            "TEMP",
-            "C"
-        ]
+            ik.keithley.Keithley2182,
+            [
+                "SENS:CHAN 1",
+                "SENS:DATA:FRES?",
+                "SENS:FUNC?",
+                "UNIT:TEMP?"
+            ],
+            [
+                "1.234",
+                "TEMP",
+                "C"
+            ]
     ) as inst:
         channel = inst.channel[0]
         assert channel.measure() == 1.234 * pq.celsius
 
 
 def test_channel_measure_unknown_temperature_units():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.keithley.Keithley2182,
             [
                 "SENS:CHAN 1",
@@ -88,37 +87,37 @@ def test_channel_measure_unknown_temperature_units():
                 "TEMP",
                 "Z"
             ]
-        ) as inst:
-            inst.channel[0].measure()
+    ) as inst:
+        inst.channel[0].measure()
 
 
 def test_units():
     with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "SENS:FUNC?",
-            "UNIT:TEMP?",
+            ik.keithley.Keithley2182,
+            [
+                "SENS:FUNC?",
+                "UNIT:TEMP?",
 
-            "SENS:FUNC?",
-            "UNIT:TEMP?",
+                "SENS:FUNC?",
+                "UNIT:TEMP?",
 
-            "SENS:FUNC?",
-            "UNIT:TEMP?",
+                "SENS:FUNC?",
+                "UNIT:TEMP?",
 
-            "SENS:FUNC?"
-        ],
-        [
-            "TEMP",
-            "C",
+                "SENS:FUNC?"
+            ],
+            [
+                "TEMP",
+                "C",
 
-            "TEMP",
-            "F",
+                "TEMP",
+                "F",
 
-            "TEMP",
-            "K",
+                "TEMP",
+                "K",
 
-            "VOLT"
-        ]
+                "VOLT"
+            ]
     ) as inst:
         units = str(inst.units.units).split()[1]
         assert units == "degC"
@@ -134,15 +133,15 @@ def test_units():
 
 def test_fetch():
     with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "FETC?",
-            "SENS:FUNC?"
-        ],
-        [
-            "1.234,1,5.678",
-            "VOLT",
-        ]
+            ik.keithley.Keithley2182,
+            [
+                "FETC?",
+                "SENS:FUNC?"
+            ],
+            [
+                "1.234,1,5.678",
+                "VOLT",
+            ]
     ) as inst:
         np.testing.assert_array_equal(
             inst.fetch(), [1.234, 1, 5.678] * pq.volt
@@ -151,87 +150,85 @@ def test_fetch():
 
 def test_measure():
     with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "SENS:FUNC?",
-            "MEAS:VOLT?",
-            "SENS:FUNC?",
-        ],
-        [
-            "VOLT",
-            "1.234",
-            "VOLT"
-        ]
+            ik.keithley.Keithley2182,
+            [
+                "SENS:FUNC?",
+                "MEAS:VOLT?",
+                "SENS:FUNC?",
+            ],
+            [
+                "VOLT",
+                "1.234",
+                "VOLT"
+            ]
     ) as inst:
         assert inst.measure() == 1.234 * pq.volt
 
 
 def test_measure_invalid_mode():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.keithley.Keithley2182,
             [],
             []
-        ) as inst:
-            inst.measure("derp")
+    ) as inst:
+        inst.measure("derp")
 
 
 def test_relative_get():
     with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "SENS:FUNC?",
-            "SENS:VOLT:CHAN1:REF:STAT?"
-        ],
-        [
-            "VOLT",
-            "ON"
-        ]
+            ik.keithley.Keithley2182,
+            [
+                "SENS:FUNC?",
+                "SENS:VOLT:CHAN1:REF:STAT?"
+            ],
+            [
+                "VOLT",
+                "ON"
+            ]
     ) as inst:
         assert inst.relative is True
 
 
 def test_relative_set_already_enabled():
     with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "SENS:FUNC?",
-            "SENS:FUNC?",
-            "SENS:VOLT:CHAN1:REF:STAT?",
-            "SENS:VOLT:CHAN1:REF:ACQ"
-        ],
-        [
-            "VOLT",
-            "VOLT",
-            "ON",
-        ]
+            ik.keithley.Keithley2182,
+            [
+                "SENS:FUNC?",
+                "SENS:FUNC?",
+                "SENS:VOLT:CHAN1:REF:STAT?",
+                "SENS:VOLT:CHAN1:REF:ACQ"
+            ],
+            [
+                "VOLT",
+                "VOLT",
+                "ON",
+            ]
     ) as inst:
         inst.relative = True
 
 
 def test_relative_set_start_disabled():
     with expected_protocol(
-        ik.keithley.Keithley2182,
-        [
-            "SENS:FUNC?",
-            "SENS:FUNC?",
-            "SENS:VOLT:CHAN1:REF:STAT?",
-            "SENS:VOLT:CHAN1:REF:STAT ON"
-        ],
-        [
-            "VOLT",
-            "VOLT",
-            "OFF",
-        ]
+            ik.keithley.Keithley2182,
+            [
+                "SENS:FUNC?",
+                "SENS:FUNC?",
+                "SENS:VOLT:CHAN1:REF:STAT?",
+                "SENS:VOLT:CHAN1:REF:STAT ON"
+            ],
+            [
+                "VOLT",
+                "VOLT",
+                "OFF",
+            ]
     ) as inst:
         inst.relative = True
 
 
 def test_relative_set_wrong_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.keithley.Keithley2182,
             [],
             []
-        ) as inst:
-            inst.relative = "derp"
+    ) as inst:
+        inst.relative = "derp"

--- a/instruments/tests/test_keithley/test_keithley485.py
+++ b/instruments/tests/test_keithley/test_keithley485.py
@@ -18,14 +18,14 @@ from instruments.tests import expected_protocol
 
 def test_zero_check():
     with expected_protocol(
-        ik.keithley.Keithley485,
-        [
-            "C0X",
-            "C1X",
-            "U0X"
-        ], [
-            "4851000000000:"
-        ]
+            ik.keithley.Keithley485,
+            [
+                "C0X",
+                "C1X",
+                "U0X"
+            ], [
+                "4851000000000:"
+            ]
     ) as inst:
         inst.zero_check = False
         inst.zero_check = True
@@ -34,14 +34,14 @@ def test_zero_check():
 
 def test_log():
     with expected_protocol(
-        ik.keithley.Keithley485,
-        [
-            "D0X",
-            "D1X",
-            "U0X"
-        ], [
-            "4850100000000:"
-        ]
+            ik.keithley.Keithley485,
+            [
+                "D0X",
+                "D1X",
+                "U0X"
+            ], [
+                "4850100000000:"
+            ]
     ) as inst:
         inst.log = False
         inst.log = True
@@ -50,14 +50,14 @@ def test_log():
 
 def test_input_range():
     with expected_protocol(
-        ik.keithley.Keithley485,
-        [
-            "R0X",
-            "R7X",
-            "U0X"
-        ], [
-            "4850070000000:"
-        ]
+            ik.keithley.Keithley485,
+            [
+                "R0X",
+                "R7X",
+                "U0X"
+            ], [
+                "4850070000000:"
+            ]
     ) as inst:
         inst.input_range = "auto"
         inst.input_range = 2e-3
@@ -66,14 +66,14 @@ def test_input_range():
 
 def test_relative():
     with expected_protocol(
-        ik.keithley.Keithley485,
-        [
-            "Z0X",
-            "Z1X",
-            "U0X"
-        ], [
-            "4850001000000:"
-        ]
+            ik.keithley.Keithley485,
+            [
+                "Z0X",
+                "Z1X",
+                "U0X"
+            ], [
+                "4850001000000:"
+            ]
     ) as inst:
         inst.relative = False
         inst.relative = True
@@ -82,14 +82,14 @@ def test_relative():
 
 def test_eoi_mode():
     with expected_protocol(
-        ik.keithley.Keithley485,
-        [
-            "K0X",
-            "K1X",
-            "U0X"
-        ], [
-            "4850000100000:"
-        ]
+            ik.keithley.Keithley485,
+            [
+                "K0X",
+                "K1X",
+                "U0X"
+            ], [
+                "4850000100000:"
+            ]
     ) as inst:
         inst.eoi_mode = True
         inst.eoi_mode = False
@@ -98,14 +98,14 @@ def test_eoi_mode():
 
 def test_trigger_mode():
     with expected_protocol(
-        ik.keithley.Keithley485,
-        [
-            "T0X",
-            "T5X",
-            "U0X"
-        ], [
-            "4850000050000:"
-        ]
+            ik.keithley.Keithley485,
+            [
+                "T0X",
+                "T5X",
+                "U0X"
+            ], [
+                "4850000050000:"
+            ]
     ) as inst:
         inst.trigger_mode = "continuous_ontalk"
         inst.trigger_mode = "oneshot_onx"
@@ -114,13 +114,13 @@ def test_trigger_mode():
 
 def test_auto_range():
     with expected_protocol(
-        ik.keithley.Keithley485,
-        [
-            "R0X",
-            "U0X"
-        ], [
-            "4850000000000:"
-        ]
+            ik.keithley.Keithley485,
+            [
+                "R0X",
+                "U0X"
+            ], [
+                "4850000000000:"
+            ]
     ) as inst:
         inst.auto_range()
         assert inst.input_range == "auto"
@@ -128,26 +128,26 @@ def test_auto_range():
 
 def test_get_status():
     with expected_protocol(
-        ik.keithley.Keithley485,
-        [
-            "U0X"
-        ], [
-            "4850000000000:"
-        ]
+            ik.keithley.Keithley485,
+            [
+                "U0X"
+            ], [
+                "4850000000000:"
+            ]
     ) as inst:
         inst.get_status()
 
 
 def test_measure():
     with expected_protocol(
-        ik.keithley.Keithley485,
-        [
-            "X",
-            "X"
-        ], [
-            "NDCA+1.2345E-9",
-            "NDCL-9.0000E+0"
-        ]
+            ik.keithley.Keithley485,
+            [
+                "X",
+                "X"
+            ], [
+                "NDCA+1.2345E-9",
+                "NDCL-9.0000E+0"
+            ]
     ) as inst:
         assert inst.measure() == 1.2345 * pq.nanoamp
         assert inst.measure() == 1. * pq.nanoamp

--- a/instruments/tests/test_keithley/test_keithley6220.py
+++ b/instruments/tests/test_keithley/test_keithley6220.py
@@ -23,14 +23,14 @@ def test_channel():
 
 def test_current():
     with expected_protocol(
-        ik.keithley.Keithley6220,
-        [
-            "SOUR:CURR?",
-            "SOUR:CURR {:e}".format(0.05)
-        ],
-        [
-            "0.1",
-        ]
+            ik.keithley.Keithley6220,
+            [
+                "SOUR:CURR?",
+                "SOUR:CURR {:e}".format(0.05)
+            ],
+            [
+                "0.1",
+            ]
     ) as inst:
         assert inst.current == 100 * pq.milliamp
         assert inst.current_min == -105 * pq.milliamp
@@ -40,10 +40,10 @@ def test_current():
 
 def test_disable():
     with expected_protocol(
-        ik.keithley.Keithley6220,
-        [
-            "SOUR:CLE:IMM"
-        ],
-        []
+            ik.keithley.Keithley6220,
+            [
+                "SOUR:CLE:IMM"
+            ],
+            []
     ) as inst:
         inst.disable()

--- a/instruments/tests/test_keithley/test_keithley6514.py
+++ b/instruments/tests/test_keithley/test_keithley6514.py
@@ -23,8 +23,7 @@ def test_valid_range():
     inst = ik.keithley.Keithley6514.open_test()
     assert inst._valid_range(inst.Mode.voltage) == inst.ValidRange.voltage
     assert inst._valid_range(inst.Mode.current) == inst.ValidRange.current
-    assert inst._valid_range(
-        inst.Mode.resistance) == inst.ValidRange.resistance
+    assert inst._valid_range(inst.Mode.resistance) == inst.ValidRange.resistance
     assert inst._valid_range(inst.Mode.charge) == inst.ValidRange.charge
 
 
@@ -36,13 +35,13 @@ def test_valid_range_invalid():
 
 def test_parse_measurement():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "FUNCTION?",
-        ],
-        [
-            '"VOLT:DC"'
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "FUNCTION?",
+            ],
+            [
+                '"VOLT:DC"'
+            ]
     ) as inst:
         reading, timestamp, status = inst._parse_measurement("1.0,1234,5678")
         assert reading == 1.0 * pq.volt
@@ -52,14 +51,14 @@ def test_parse_measurement():
 
 def test_mode():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "FUNCTION?",
-            'FUNCTION "VOLT:DC"'
-        ],
-        [
-            '"VOLT:DC"'
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "FUNCTION?",
+                'FUNCTION "VOLT:DC"'
+            ],
+            [
+                '"VOLT:DC"'
+            ]
     ) as inst:
         assert inst.mode == inst.Mode.voltage
         inst.mode = inst.Mode.voltage
@@ -67,14 +66,14 @@ def test_mode():
 
 def test_trigger_source():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "TRIGGER:SOURCE?",
-            "TRIGGER:SOURCE IMM"
-        ],
-        [
-            "TLINK"
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "TRIGGER:SOURCE?",
+                "TRIGGER:SOURCE IMM"
+            ],
+            [
+                "TLINK"
+            ]
     ) as inst:
         assert inst.trigger_mode == inst.TriggerMode.tlink
         inst.trigger_mode = inst.TriggerMode.immediate
@@ -82,14 +81,14 @@ def test_trigger_source():
 
 def test_arm_source():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "ARM:SOURCE?",
-            "ARM:SOURCE IMM"
-        ],
-        [
-            "TIM"
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "ARM:SOURCE?",
+                "ARM:SOURCE IMM"
+            ],
+            [
+                "TIM"
+            ]
     ) as inst:
         assert inst.arm_source == inst.ArmSource.timer
         inst.arm_source = inst.ArmSource.immediate
@@ -97,14 +96,14 @@ def test_arm_source():
 
 def test_zero_check():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "SYST:ZCH?",
-            "SYST:ZCH ON"
-        ],
-        [
-            "OFF"
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "SYST:ZCH?",
+                "SYST:ZCH ON"
+            ],
+            [
+                "OFF"
+            ]
     ) as inst:
         assert inst.zero_check is False
         inst.zero_check = True
@@ -112,14 +111,14 @@ def test_zero_check():
 
 def test_zero_correct():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "SYST:ZCOR?",
-            "SYST:ZCOR ON"
-        ],
-        [
-            "OFF"
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "SYST:ZCOR?",
+                "SYST:ZCOR ON"
+            ],
+            [
+                "OFF"
+            ]
     ) as inst:
         assert inst.zero_correct is False
         inst.zero_correct = True
@@ -127,31 +126,31 @@ def test_zero_correct():
 
 def test_unit():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "FUNCTION?",
-        ],
-        [
-            '"VOLT:DC"'
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "FUNCTION?",
+            ],
+            [
+                '"VOLT:DC"'
+            ]
     ) as inst:
         assert inst.unit == pq.volt
 
 
 def test_auto_range():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "FUNCTION?",
-            "VOLT:DC:RANGE:AUTO?",
-            "FUNCTION?",
-            "VOLT:DC:RANGE:AUTO 1"
-        ],
-        [
-            '"VOLT:DC"',
-            "0",
-            '"VOLT:DC"'
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "FUNCTION?",
+                "VOLT:DC:RANGE:AUTO?",
+                "FUNCTION?",
+                "VOLT:DC:RANGE:AUTO 1"
+            ],
+            [
+                '"VOLT:DC"',
+                "0",
+                '"VOLT:DC"'
+            ]
     ) as inst:
         assert inst.auto_range is False
         inst.auto_range = True
@@ -159,26 +158,25 @@ def test_auto_range():
 
 def test_input_range():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "FUNCTION?",
-            "VOLT:DC:RANGE:UPPER?",
-            "FUNCTION?",
-            "VOLT:DC:RANGE:UPPER {:e}".format(20)
-        ],
-        [
-            '"VOLT:DC"',
-            "10",
-            '"VOLT:DC"'
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "FUNCTION?",
+                "VOLT:DC:RANGE:UPPER?",
+                "FUNCTION?",
+                "VOLT:DC:RANGE:UPPER {:e}".format(20)
+            ],
+            [
+                '"VOLT:DC"',
+                "10",
+                '"VOLT:DC"'
+            ]
     ) as inst:
         assert inst.input_range == 10 * pq.volt
         inst.input_range = 20 * pq.volt
 
 
 def test_input_range_invalid():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.keithley.Keithley6514,
             [
                 "FUNCTION?"
@@ -186,32 +184,32 @@ def test_input_range_invalid():
             [
                 '"VOLT:DC"'
             ]
-        ) as inst:
-            inst.input_range = 10 * pq.volt
+    ) as inst:
+        inst.input_range = 10 * pq.volt
 
 
 def test_auto_config():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "CONF:VOLT:DC",
-        ],
-        []
+            ik.keithley.Keithley6514,
+            [
+                "CONF:VOLT:DC",
+            ],
+            []
     ) as inst:
         inst.auto_config(inst.Mode.voltage)
 
 
 def test_fetch():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "FETC?",
-            "FUNCTION?",
-        ],
-        [
-            "1.0,1234,5678",
-            '"VOLT:DC"'
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "FETC?",
+                "FUNCTION?",
+            ],
+            [
+                "1.0,1234,5678",
+                '"VOLT:DC"'
+            ]
     ) as inst:
         reading, timestamp = inst.fetch()
         assert reading == 1.0 * pq.volt
@@ -220,15 +218,15 @@ def test_fetch():
 
 def test_read():
     with expected_protocol(
-        ik.keithley.Keithley6514,
-        [
-            "READ?",
-            "FUNCTION?",
-        ],
-        [
-            "1.0,1234,5678",
-            '"VOLT:DC"'
-        ]
+            ik.keithley.Keithley6514,
+            [
+                "READ?",
+                "FUNCTION?",
+            ],
+            [
+                "1.0,1234,5678",
+                '"VOLT:DC"'
+            ]
     ) as inst:
         reading, timestamp = inst.read_measurements()
         assert reading == 1.0 * pq.volt

--- a/instruments/tests/test_minghe/test_minghe_mhs5200a.py
+++ b/instruments/tests/test_minghe/test_minghe_mhs5200a.py
@@ -20,20 +20,20 @@ from instruments.tests import expected_protocol
 
 def test_mhs_amplitude():
     with expected_protocol(
-        ik.minghe.MHS5200,
-        [
-            ":r1a",
-            ":r2a",
-            ":s1a660",
-            ":s2a800"
-        ],
-        [
-            ":r1a330",
-            ":r2a500",
-            "ok",
-            "ok"
-        ],
-        sep="\r\n"
+            ik.minghe.MHS5200,
+            [
+                ":r1a",
+                ":r2a",
+                ":s1a660",
+                ":s2a800"
+            ],
+            [
+                ":r1a330",
+                ":r2a500",
+                "ok",
+                "ok"
+            ],
+            sep="\r\n"
     ) as mhs:
         assert mhs.channel[0].amplitude[0] == 3.3*pq.V
         assert mhs.channel[1].amplitude[0] == 5.0*pq.V
@@ -43,10 +43,10 @@ def test_mhs_amplitude():
 
 def test_mhs_amplitude_dbm_notimplemented():
     with expected_protocol(
-        ik.minghe.MHS5200,
-        [],
-        [],
-        sep="\r\n"
+            ik.minghe.MHS5200,
+            [],
+            [],
+            sep="\r\n"
     ) as mhs:
         with pytest.raises(NotImplementedError):
             mhs.channel[0].amplitude = 6.6*ik.units.dBm
@@ -54,21 +54,21 @@ def test_mhs_amplitude_dbm_notimplemented():
 
 def test_mhs_duty_cycle():
     with expected_protocol(
-        ik.minghe.MHS5200,
-        [
-            ":r1d",
-            ":r2d",
-            ":s1d6",
-            ":s2d80"
+            ik.minghe.MHS5200,
+            [
+                ":r1d",
+                ":r2d",
+                ":s1d6",
+                ":s2d80"
 
-        ],
-        [
-            ":r1d010",
-            ":r2d100",
-            "ok",
-            "ok"
-        ],
-        sep="\r\n"
+            ],
+            [
+                ":r1d010",
+                ":r2d100",
+                "ok",
+                "ok"
+            ],
+            sep="\r\n"
     ) as mhs:
         assert mhs.channel[0].duty_cycle == 1.0
         assert mhs.channel[1].duty_cycle == 10.0
@@ -78,20 +78,20 @@ def test_mhs_duty_cycle():
 
 def test_mhs_enable():
     with expected_protocol(
-        ik.minghe.MHS5200,
-        [
-            ":r1b",
-            ":r2b",
-            ":s1b0",
-            ":s2b1"
-        ],
-        [
-            ":r1b1",
-            ":r2b0",
-            "ok",
-            "ok"
-        ],
-        sep="\r\n"
+            ik.minghe.MHS5200,
+            [
+                ":r1b",
+                ":r2b",
+                ":s1b0",
+                ":s2b1"
+            ],
+            [
+                ":r1b1",
+                ":r2b0",
+                "ok",
+                "ok"
+            ],
+            sep="\r\n"
     ) as mhs:
         assert mhs.channel[0].enable
         assert not mhs.channel[1].enable
@@ -101,21 +101,21 @@ def test_mhs_enable():
 
 def test_mhs_frequency():
     with expected_protocol(
-        ik.minghe.MHS5200,
-        [
-            ":r1f",
-            ":r2f",
-            ":s1f600000",
-            ":s2f800000"
+            ik.minghe.MHS5200,
+            [
+                ":r1f",
+                ":r2f",
+                ":s1f600000",
+                ":s2f800000"
 
-        ],
-        [
-            ":r1f3300000",
-            ":r2f50000000",
-            "ok",
-            "ok"
-        ],
-        sep="\r\n"
+            ],
+            [
+                ":r1f3300000",
+                ":r2f50000000",
+                "ok",
+                "ok"
+            ],
+            sep="\r\n"
     ) as mhs:
         assert mhs.channel[0].frequency == 33.0*pq.kHz
         assert mhs.channel[1].frequency == 500.0*pq.kHz
@@ -125,21 +125,21 @@ def test_mhs_frequency():
 
 def test_mhs_offset():
     with expected_protocol(
-        ik.minghe.MHS5200,
-        [
-            ":r1o",
-            ":r2o",
-            ":s1o60",
-            ":s2o180"
+            ik.minghe.MHS5200,
+            [
+                ":r1o",
+                ":r2o",
+                ":s1o60",
+                ":s2o180"
 
-        ],
-        [
-            ":r1o120",
-            ":r2o0",
-            "ok",
-            "ok"
-        ],
-        sep="\r\n"
+            ],
+            [
+                ":r1o120",
+                ":r2o0",
+                "ok",
+                "ok"
+            ],
+            sep="\r\n"
     ) as mhs:
         assert mhs.channel[0].offset == 0
         assert mhs.channel[1].offset == -1.2
@@ -149,21 +149,21 @@ def test_mhs_offset():
 
 def test_mhs_phase():
     with expected_protocol(
-        ik.minghe.MHS5200,
-        [
-            ":r1p",
-            ":r2p",
-            ":s1p60",
-            ":s2p180"
+            ik.minghe.MHS5200,
+            [
+                ":r1p",
+                ":r2p",
+                ":s1p60",
+                ":s2p180"
 
-        ],
-        [
-            ":r1p120",
-            ":r2p0",
-            "ok",
-            "ok"
-        ],
-        sep="\r\n"
+            ],
+            [
+                ":r1p120",
+                ":r2p0",
+                "ok",
+                "ok"
+            ],
+            sep="\r\n"
     ) as mhs:
         assert mhs.channel[0].phase == 120
         assert mhs.channel[1].phase == 0
@@ -173,21 +173,21 @@ def test_mhs_phase():
 
 def test_mhs_wave_type():
     with expected_protocol(
-        ik.minghe.MHS5200,
-        [
-            ":r1w",
-            ":r2w",
-            ":s1w2",
-            ":s2w3"
+            ik.minghe.MHS5200,
+            [
+                ":r1w",
+                ":r2w",
+                ":s1w2",
+                ":s2w3"
 
-        ],
-        [
-            ":r1w0",
-            ":r2w1",
-            "ok",
-            "ok"
-        ],
-        sep="\r\n"
+            ],
+            [
+                ":r1w0",
+                ":r2w1",
+                "ok",
+                "ok"
+            ],
+            sep="\r\n"
     ) as mhs:
         assert mhs.channel[0].function == mhs.Function.sine
         assert mhs.channel[1].function == mhs.Function.square
@@ -197,14 +197,14 @@ def test_mhs_wave_type():
 
 def test_mhs_serial_number():
     with expected_protocol(
-        ik.minghe.MHS5200,
-        [
-            ":r0c"
+            ik.minghe.MHS5200,
+            [
+                ":r0c"
 
-        ],
-        [
-            ":r0c5225A1",
-        ],
-        sep="\r\n"
+            ],
+            [
+                ":r0c5225A1",
+            ],
+            sep="\r\n"
     ) as mhs:
         assert mhs.serial_number == "5225A1"

--- a/instruments/tests/test_named_struct.py
+++ b/instruments/tests/test_named_struct.py
@@ -17,6 +17,7 @@ from instruments.named_struct import (
     Field, StringField, Padding, NamedStruct
 )
 
+
 # TESTS ######################################################################
 
 # We disable pylint warnings that are not as applicable for unit tests.
@@ -33,7 +34,6 @@ class TestNamedStruct(TestCase):
         foo = Foo(a=var1, b=var2)
         assert Foo.unpack(foo.pack()) == foo
 
-
     def test_str(self):
         class Foo(NamedStruct):
             a = StringField(8, strip_null=False)
@@ -47,7 +47,6 @@ class TestNamedStruct(TestCase):
         self.assertEqual(foo.a, '0123456\x00')
         self.assertEqual(foo.b, 'abc')
         self.assertEqual(foo.c, u'α')
-
 
     def test_negative_len(self):
         """

--- a/instruments/tests/test_newport/test_newportesp301.py
+++ b/instruments/tests/test_newport/test_newportesp301.py
@@ -16,16 +16,16 @@ from instruments.tests import expected_protocol
 
 def test_axis_returns_axis_class():
     with expected_protocol(
-        ik.newport.NewportESP301,
-        [
-            "1SN?",
-            "TB?"  # error check query
-        ],
-        [
-            "1",
-            "0,0,0"
-        ],
-        sep="\r"
+            ik.newport.NewportESP301,
+            [
+                "1SN?",
+                "TB?"  # error check query
+            ],
+            [
+                "1",
+                "0,0,0"
+            ],
+            sep="\r"
     ) as inst:
         axis = inst.axis[0]
         assert isinstance(axis, ik.newport.NewportESP301Axis) is True

--- a/instruments/tests/test_oxford/test_oxforditc503.py
+++ b/instruments/tests/test_oxford/test_oxforditc503.py
@@ -18,12 +18,12 @@ from instruments.tests import expected_protocol
 
 def test_sensor_returns_sensor_class():
     with expected_protocol(
-        ik.oxford.OxfordITC503,
-        [
-            "C3"
-        ],
-        [],
-        sep="\r"
+            ik.oxford.OxfordITC503,
+            [
+                "C3"
+            ],
+            [],
+            sep="\r"
     ) as inst:
         sensor = inst.sensor[0]
         assert isinstance(sensor, inst.Sensor) is True
@@ -31,15 +31,15 @@ def test_sensor_returns_sensor_class():
 
 def test_sensor_temperature():
     with expected_protocol(
-        ik.oxford.OxfordITC503,
-        [
-            "C3",
-            "R1"
-        ],
-        [
-            "R123"
-        ],
-        sep="\r"
+            ik.oxford.OxfordITC503,
+            [
+                "C3",
+                "R1"
+            ],
+            [
+                "R123"
+            ],
+            sep="\r"
     ) as inst:
         sensor = inst.sensor[0]
         assert sensor.temperature == 123 * pq.kelvin

--- a/instruments/tests/test_phasematrix/test_phasematrix_fsw0020.py
+++ b/instruments/tests/test_phasematrix/test_phasematrix_fsw0020.py
@@ -19,25 +19,25 @@ from instruments.units import mHz, dBm, cBm
 
 def test_reset():
     with expected_protocol(
-        ik.phasematrix.PhaseMatrixFSW0020,
-        [
-            "0E."
-        ],
-        []
+            ik.phasematrix.PhaseMatrixFSW0020,
+            [
+                "0E."
+            ],
+            []
     ) as inst:
         inst.reset()
 
 
 def test_frequency():
     with expected_protocol(
-        ik.phasematrix.PhaseMatrixFSW0020,
-        [
-            "04.",
-            "0C{:012X}.".format(int((10 * pq.GHz).rescale(mHz).magnitude))
-        ],
-        [
-            "00E8D4A51000"
-        ]
+            ik.phasematrix.PhaseMatrixFSW0020,
+            [
+                "04.",
+                "0C{:012X}.".format(int((10 * pq.GHz).rescale(mHz).magnitude))
+            ],
+            [
+                "00E8D4A51000"
+            ]
     ) as inst:
         assert inst.frequency == 1 * pq.GHz
         inst.frequency = 10 * pq.GHz
@@ -45,14 +45,14 @@ def test_frequency():
 
 def test_power():
     with expected_protocol(
-        ik.phasematrix.PhaseMatrixFSW0020,
-        [
-            "0D.",
-            "03{:04X}.".format(int((10 * dBm).rescale(cBm).magnitude))
-        ],
-        [
-            "-064"
-        ]
+            ik.phasematrix.PhaseMatrixFSW0020,
+            [
+                "0D.",
+                "03{:04X}.".format(int((10 * dBm).rescale(cBm).magnitude))
+            ],
+            [
+                "-064"
+            ]
     ) as inst:
         assert inst.power == -10 * dBm
         inst.power = 10 * dBm
@@ -60,12 +60,12 @@ def test_power():
 
 def test_blanking():
     with expected_protocol(
-        ik.phasematrix.PhaseMatrixFSW0020,
-        [
-            "05{:02X}.".format(1),
-            "05{:02X}.".format(0)
-        ],
-        []
+            ik.phasematrix.PhaseMatrixFSW0020,
+            [
+                "05{:02X}.".format(1),
+                "05{:02X}.".format(0)
+            ],
+            []
     ) as inst:
         inst.blanking = True
         inst.blanking = False
@@ -73,12 +73,12 @@ def test_blanking():
 
 def test_ref_output():
     with expected_protocol(
-        ik.phasematrix.PhaseMatrixFSW0020,
-        [
-            "08{:02X}.".format(1),
-            "08{:02X}.".format(0)
-        ],
-        []
+            ik.phasematrix.PhaseMatrixFSW0020,
+            [
+                "08{:02X}.".format(1),
+                "08{:02X}.".format(0)
+            ],
+            []
     ) as inst:
         inst.ref_output = True
         inst.ref_output = False
@@ -86,12 +86,12 @@ def test_ref_output():
 
 def test_output():
     with expected_protocol(
-        ik.phasematrix.PhaseMatrixFSW0020,
-        [
-            "0F{:02X}.".format(1),
-            "0F{:02X}.".format(0)
-        ],
-        []
+            ik.phasematrix.PhaseMatrixFSW0020,
+            [
+                "0F{:02X}.".format(1),
+                "0F{:02X}.".format(0)
+            ],
+            []
     ) as inst:
         inst.output = True
         inst.output = False
@@ -99,12 +99,12 @@ def test_output():
 
 def test_pulse_modulation():
     with expected_protocol(
-        ik.phasematrix.PhaseMatrixFSW0020,
-        [
-            "09{:02X}.".format(1),
-            "09{:02X}.".format(0)
-        ],
-        []
+            ik.phasematrix.PhaseMatrixFSW0020,
+            [
+                "09{:02X}.".format(1),
+                "09{:02X}.".format(0)
+            ],
+            []
     ) as inst:
         inst.pulse_modulation = True
         inst.pulse_modulation = False
@@ -112,12 +112,12 @@ def test_pulse_modulation():
 
 def test_am_modulation():
     with expected_protocol(
-        ik.phasematrix.PhaseMatrixFSW0020,
-        [
-            "0A{:02X}.".format(1),
-            "0A{:02X}.".format(0)
-        ],
-        []
+            ik.phasematrix.PhaseMatrixFSW0020,
+            [
+                "0A{:02X}.".format(1),
+                "0A{:02X}.".format(0)
+            ],
+            []
     ) as inst:
         inst.am_modulation = True
         inst.am_modulation = False

--- a/instruments/tests/test_picowatt/test_picowatt_avs47.py
+++ b/instruments/tests/test_picowatt/test_picowatt_avs47.py
@@ -23,66 +23,66 @@ def test_sensor_is_sensor_class():
 
 def test_init():
     with expected_protocol(
-        ik.picowatt.PicowattAVS47,
-        [
-            "HDR 0"
-        ],
-        []
-    ) as _:
+            ik.picowatt.PicowattAVS47,
+            [
+                "HDR 0"
+            ],
+            []
+    ):
         pass
 
 
 def test_sensor_resistance_same_channel():
     with expected_protocol(
-        ik.picowatt.PicowattAVS47,
-        [
-            "HDR 0",
-            "MUX?",
-            "ADC",
-            "RES?"
-        ],
-        [
-            "0",
-            "123"
-        ]
+            ik.picowatt.PicowattAVS47,
+            [
+                "HDR 0",
+                "MUX?",
+                "ADC",
+                "RES?"
+            ],
+            [
+                "0",
+                "123"
+            ]
     ) as inst:
         assert inst.sensor[0].resistance == 123 * pq.ohm
 
 
 def test_sensor_resistance_different_channel():
     with expected_protocol(
-        ik.picowatt.PicowattAVS47,
-        [
-            "HDR 0",
-            "MUX?",
-            "INP 0",
-            "MUX 0",
-            "INP 1",
-            "ADC",
-            "RES?"
-        ],
-        [
-            "1",
-            "123"
-        ]
+            ik.picowatt.PicowattAVS47,
+            [
+                "HDR 0",
+                "MUX?",
+                "INP 0",
+                "MUX 0",
+                "INP 1",
+                "ADC",
+                "RES?"
+            ],
+            [
+                "1",
+                "123"
+            ]
     ) as inst:
         assert inst.sensor[0].resistance == 123 * pq.ohm
 
 
 def test_remote():
     with expected_protocol(
-        ik.picowatt.PicowattAVS47,
-        [
-            "HDR 0",
-            "REM?",
-            "REM?",
-            "REM 1",
-            "REM 0"
-        ],
-        [
-            "0",
-            "1"
-        ]
+            ik.picowatt.PicowattAVS47,
+            [
+                "HDR 0",
+                "REM?",
+                "REM?",
+                "REM 1",
+                "REM 0"
+            ],
+            [
+                "0",
+                "1"
+            ]
     ) as inst:
         assert inst.remote is False
         assert inst.remote is True
@@ -92,15 +92,15 @@ def test_remote():
 
 def test_input_source():
     with expected_protocol(
-        ik.picowatt.PicowattAVS47,
-        [
-            "HDR 0",
-            "INP?",
-            "INP 1"
-        ],
-        [
-            "0",
-        ]
+            ik.picowatt.PicowattAVS47,
+            [
+                "HDR 0",
+                "INP?",
+                "INP 1"
+            ],
+            [
+                "0",
+            ]
     ) as inst:
         assert inst.input_source == inst.InputSource.ground
         inst.input_source = inst.InputSource.actual
@@ -108,15 +108,15 @@ def test_input_source():
 
 def test_mux_channel():
     with expected_protocol(
-        ik.picowatt.PicowattAVS47,
-        [
-            "HDR 0",
-            "MUX?",
-            "MUX 1"
-        ],
-        [
-            "3",
-        ]
+            ik.picowatt.PicowattAVS47,
+            [
+                "HDR 0",
+                "MUX?",
+                "MUX 1"
+            ],
+            [
+                "3",
+            ]
     ) as inst:
         assert inst.mux_channel == 3
         inst.mux_channel = 1
@@ -124,15 +124,15 @@ def test_mux_channel():
 
 def test_excitation():
     with expected_protocol(
-        ik.picowatt.PicowattAVS47,
-        [
-            "HDR 0",
-            "EXC?",
-            "EXC 1"
-        ],
-        [
-            "3",
-        ]
+            ik.picowatt.PicowattAVS47,
+            [
+                "HDR 0",
+                "EXC?",
+                "EXC 1"
+            ],
+            [
+                "3",
+            ]
     ) as inst:
         assert inst.excitation == 3
         inst.excitation = 1
@@ -140,15 +140,15 @@ def test_excitation():
 
 def test_display():
     with expected_protocol(
-        ik.picowatt.PicowattAVS47,
-        [
-            "HDR 0",
-            "DIS?",
-            "DIS 1"
-        ],
-        [
-            "3",
-        ]
+            ik.picowatt.PicowattAVS47,
+            [
+                "HDR 0",
+                "DIS?",
+                "DIS 1"
+            ],
+            [
+                "3",
+            ]
     ) as inst:
         assert inst.display == 3
         inst.display = 1

--- a/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
@@ -20,45 +20,44 @@ from instruments.tests import expected_protocol, unit_eq
 
 def test_cc1_count():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "COUN:C1?"
-        ],
-        [
-            "",
-            "Firmware v2.010",
-            "20"
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "COUN:C1?"
+            ],
+            [
+                "",
+                "Firmware v2.010",
+                "20"
+            ],
+            sep="\n"
     ) as cc:
         assert cc.channel[0].count == 20.0
 
 
 def test_cc1_window():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "WIND?",
-            ":WIND 7"
-        ],
-        [
-            "",
-            "Firmware v2.010",
-            "2",
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "WIND?",
+                ":WIND 7"
+            ],
+            [
+                "",
+                "Firmware v2.010",
+                "2",
+            ],
+            sep="\n"
     ) as cc:
         unit_eq(cc.window, pq.Quantity(2, "ns"))
         cc.window = 7
 
 
 def test_cc1_window_error():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.qubitekk.CC1,
             [
                 ":ACKN OF",
@@ -70,34 +69,33 @@ def test_cc1_window_error():
                 "Firmware v2.010"
             ],
             sep="\n"
-        ) as cc:
-            cc.window = 10
+    ) as cc:
+        cc.window = 10
 
 
 def test_cc1_delay():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "DELA?",
-            ":DELA 2"
-        ],
-        [
-            "",
-            "Firmware v2.010",
-            "8",
-            ""
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "DELA?",
+                ":DELA 2"
+            ],
+            [
+                "",
+                "Firmware v2.010",
+                "8",
+                ""
+            ],
+            sep="\n"
     ) as cc:
         unit_eq(cc.delay, pq.Quantity(8, "ns"))
         cc.delay = 2
 
 
 def test_cc1_delay_error1():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.qubitekk.CC1,
             [
                 ":ACKN OF",
@@ -109,13 +107,12 @@ def test_cc1_delay_error1():
                 "Firmware v2.010"
             ],
             sep="\n"
-        ) as cc:
-            cc.delay = -1
+    ) as cc:
+        cc.delay = -1
 
 
 def test_cc1_delay_error2():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.qubitekk.CC1,
             [
                 ":ACKN OF",
@@ -127,26 +124,26 @@ def test_cc1_delay_error2():
                 "Firmware v2.010"
             ],
             sep="\n"
-        ) as cc:
-            cc.delay = 1
+    ) as cc:
+        cc.delay = 1
 
 
 def test_cc1_dwell_old_firmware():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "DWEL?",
-            ":DWEL 2"
-        ],
-        [
-            "Unknown Command",
-            "Firmware v2.001",
-            "8000",
-            ""
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "DWEL?",
+                ":DWEL 2"
+            ],
+            [
+                "Unknown Command",
+                "Firmware v2.001",
+                "8000",
+                ""
+            ],
+            sep="\n"
     ) as cc:
         unit_eq(cc.dwell_time, pq.Quantity(8, "s"))
         cc.dwell_time = 2
@@ -154,27 +151,26 @@ def test_cc1_dwell_old_firmware():
 
 def test_cc1_dwell_new_firmware():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "DWEL?",
-            ":DWEL 2"
-        ],
-        [
-            "",
-            "Firmware v2.010",
-            "8"
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "DWEL?",
+                ":DWEL 2"
+            ],
+            [
+                "",
+                "Firmware v2.010",
+                "8"
+            ],
+            sep="\n"
     ) as cc:
         unit_eq(cc.dwell_time, pq.Quantity(8, "s"))
         cc.dwell_time = 2
 
 
 def test_cc1_dwell_time_error():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.qubitekk.CC1,
             [
                 ":ACKN OF",
@@ -186,92 +182,92 @@ def test_cc1_dwell_time_error():
                 "Firmware v2.010"
             ],
             sep="\n"
-        ) as cc:
-            cc.dwell_time = -1
+    ) as cc:
+        cc.dwell_time = -1
 
 
 def test_cc1_firmware():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?"
-        ],
-        [
-            "",
-            "Firmware v2.010"
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?"
+            ],
+            [
+                "",
+                "Firmware v2.010"
+            ],
+            sep="\n"
     ) as cc:
         assert cc.firmware == (2, 10, 0)
 
 
 def test_cc1_firmware_2():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?"
-        ],
-        [
-            "Unknown Command",
-            "Firmware v2"
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?"
+            ],
+            [
+                "Unknown Command",
+                "Firmware v2"
+            ],
+            sep="\n"
     ) as cc:
         assert cc.firmware == (2, 0, 0)
 
 
 def test_cc1_firmware_3():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?"
-        ],
-        [
-            "Unknown Command",
-            "Firmware v2.010.1"
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?"
+            ],
+            [
+                "Unknown Command",
+                "Firmware v2.010.1"
+            ],
+            sep="\n"
     ) as cc:
         assert cc.firmware == (2, 10, 1)
 
 
 def test_cc1_firmware_repeat_query():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "FIRM?"
-        ],
-        [
-            "Unknown Command",
-            "Unknown",
-            "Firmware v2.010"
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "FIRM?"
+            ],
+            [
+                "Unknown Command",
+                "Unknown",
+                "Firmware v2.010"
+            ],
+            sep="\n"
     ) as cc:
         assert cc.firmware == (2, 10, 0)
 
 
 def test_cc1_gate_new_firmware():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "GATE?",
-            ":GATE:ON",
-            ":GATE:OFF"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "GATE?",
+                ":GATE:ON",
+                ":GATE:OFF"
 
-        ],
-        [
-            "",
-            "Firmware v2.010",
-            "ON"
-        ],
+            ],
+            [
+                "",
+                "Firmware v2.010",
+                "ON"
+            ],
     ) as cc:
         assert cc.gate is True
         cc.gate = True
@@ -280,23 +276,23 @@ def test_cc1_gate_new_firmware():
 
 def test_cc1_gate_old_firmware():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "GATE?",
-            ":GATE 1",
-            ":GATE 0"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "GATE?",
+                ":GATE 1",
+                ":GATE 0"
 
-        ],
-        [
-            "Unknown Command",
-            "Firmware v2.001",
-            "1",
-            "",
-            ""
-        ],
-        sep="\n"
+            ],
+            [
+                "Unknown Command",
+                "Firmware v2.001",
+                "1",
+                "",
+                ""
+            ],
+            sep="\n"
     ) as cc:
         assert cc.gate is True
         cc.gate = True
@@ -304,8 +300,7 @@ def test_cc1_gate_old_firmware():
 
 
 def test_cc1_gate_error():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.qubitekk.CC1,
             [
                 ":ACKN OF",
@@ -317,28 +312,28 @@ def test_cc1_gate_error():
                 "Firmware v2.010"
             ],
             sep="\n"
-        ) as cc:
-            cc.gate = "blo"
+    ) as cc:
+        cc.gate = "blo"
 
 
 def test_cc1_subtract_new_firmware():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "SUBT?",
-            ":SUBT:ON",
-            ":SUBT:OFF"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "SUBT?",
+                ":SUBT:ON",
+                ":SUBT:OFF"
 
-        ],
-        [
-            "",
-            "Firmware v2.010",
-            "ON",
-            ":SUBT:OFF"
-        ],
-        sep="\n"
+            ],
+            [
+                "",
+                "Firmware v2.010",
+                "ON",
+                ":SUBT:OFF"
+            ],
+            sep="\n"
     ) as cc:
         assert cc.subtract is True
         cc.subtract = True
@@ -346,8 +341,7 @@ def test_cc1_subtract_new_firmware():
 
 
 def test_cc1_subtract_error():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.qubitekk.CC1,
             [
                 ":ACKN OF",
@@ -360,26 +354,26 @@ def test_cc1_subtract_error():
                 "Firmware v2.010"
             ],
             sep="\n"
-        ) as cc:
-            cc.subtract = "blo"
+    ) as cc:
+        cc.subtract = "blo"
 
 
 def test_cc1_trigger_mode():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "TRIG?",
-            ":TRIG:MODE CONT",
-            ":TRIG:MODE STOP"
-        ],
-        [
-            "",
-            "Firmware v2.010",
-            "MODE STOP"
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "TRIG?",
+                ":TRIG:MODE CONT",
+                ":TRIG:MODE STOP"
+            ],
+            [
+                "",
+                "Firmware v2.010",
+                "MODE STOP"
+            ],
+            sep="\n"
     ) as cc:
         assert cc.trigger_mode is cc.TriggerMode.start_stop
         cc.trigger_mode = cc.TriggerMode.continuous
@@ -388,22 +382,22 @@ def test_cc1_trigger_mode():
 
 def test_cc1_trigger_mode_old_firmware():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "TRIG?",
-            ":TRIG 0",
-            ":TRIG 1"
-        ],
-        [
-            "Unknown Command",
-            "Firmware v2.001",
-            "1",
-            "",
-            ""
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "TRIG?",
+                ":TRIG 0",
+                ":TRIG 1"
+            ],
+            [
+                "Unknown Command",
+                "Firmware v2.001",
+                "1",
+                "",
+                ""
+            ],
+            sep="\n"
     ) as cc:
         assert cc.trigger_mode == cc.TriggerMode.start_stop
         cc.trigger_mode = cc.TriggerMode.continuous
@@ -411,8 +405,7 @@ def test_cc1_trigger_mode_old_firmware():
 
 
 def test_cc1_trigger_mode_error():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.qubitekk.CC1,
             [
                 ":ACKN OF",
@@ -423,46 +416,46 @@ def test_cc1_trigger_mode_error():
                 "Firmware v2.010"
             ],
             sep="\n"
-        ) as cc:
-            cc.trigger_mode = "blo"
+    ) as cc:
+        cc.trigger_mode = "blo"
 
 
 def test_cc1_clear():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            "CLEA"
-        ],
-        [
-            "",
-            "Firmware v2.010"
-        ],
-        sep="\n"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                "CLEA"
+            ],
+            [
+                "",
+                "Firmware v2.010"
+            ],
+            sep="\n"
     ) as cc:
         cc.clear_counts()
 
 
 def test_acknowledge():
     with expected_protocol(
-        ik.qubitekk.CC1,
-        [
-            ":ACKN OF",
-            "FIRM?",
-            ":ACKN ON",
-            "CLEA",
-            ":ACKN OF",
-            "CLEA"
-        ],
-        [
-            "",
-            "Firmware v2.010",
-            "CLEA",
-            ":ACKN OF"
+            ik.qubitekk.CC1,
+            [
+                ":ACKN OF",
+                "FIRM?",
+                ":ACKN ON",
+                "CLEA",
+                ":ACKN OF",
+                "CLEA"
+            ],
+            [
+                "",
+                "Firmware v2.010",
+                "CLEA",
+                ":ACKN OF"
 
-        ],
-        sep="\n"
+            ],
+            sep="\n"
     ) as cc:
         assert not cc.acknowledge
         cc.acknowledge = True
@@ -474,8 +467,7 @@ def test_acknowledge():
 
 
 def test_acknowledge_notimplementederror():
-    with pytest.raises(NotImplementedError):
-        with expected_protocol(
+    with pytest.raises(NotImplementedError), expected_protocol(
             ik.qubitekk.CC1,
             [
                 ":ACKN OF",
@@ -487,13 +479,12 @@ def test_acknowledge_notimplementederror():
 
             ],
             sep="\n"
-        ) as cc:
-            cc.acknowledge = True
+    ) as cc:
+        cc.acknowledge = True
 
 
 def test_acknowledge_not_implemented_error():  # pylint: disable=protected-access
-    with pytest.raises(NotImplementedError):
-        with expected_protocol(
+    with pytest.raises(NotImplementedError), expected_protocol(
             ik.qubitekk.CC1,
             [
                 ":ACKN OF",
@@ -505,5 +496,5 @@ def test_acknowledge_not_implemented_error():  # pylint: disable=protected-acces
 
             ],
             sep="\n"
-        ) as cc:
-            cc.acknowledge = True
+    ) as cc:
+        cc.acknowledge = True

--- a/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
@@ -20,15 +20,15 @@ from instruments.tests import expected_protocol
 
 def test_mc1_setting():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [
-            "OUTP?",
-            ":OUTP 0"
-        ],
-        [
-            "1"
-        ],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [
+                "OUTP?",
+                ":OUTP 0"
+            ],
+            [
+                "1"
+            ],
+            sep="\r"
     ) as mc:
         assert mc.setting == 1
         mc.setting = 0
@@ -36,177 +36,176 @@ def test_mc1_setting():
 
 def test_mc1_internal_position():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [
-            "POSI?",
-            "STEP?"
+            ik.qubitekk.MC1,
+            [
+                "POSI?",
+                "STEP?"
 
-        ],
-        [
-            "-100",
-            "1"
-        ],
-        sep="\r"
+            ],
+            [
+                "-100",
+                "1"
+            ],
+            sep="\r"
     ) as mc:
         assert mc.internal_position == -100*pq.ms
 
 
 def test_mc1_metric_position():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [
-            "METR?"
-        ],
-        [
-            "-3.14159"
-        ],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [
+                "METR?"
+            ],
+            [
+                "-3.14159"
+            ],
+            sep="\r"
     ) as mc:
         assert mc.metric_position == -3.14159*pq.mm
 
 
 def test_mc1_direction():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [
-            "DIRE?"
-        ],
-        [
-            "-100"
-        ],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [
+                "DIRE?"
+            ],
+            [
+                "-100"
+            ],
+            sep="\r"
     ) as mc:
         assert mc.direction == -100
 
 
 def test_mc1_firmware():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [
-            "FIRM?"
-        ],
-        [
-            "1.0.1"
-        ],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [
+                "FIRM?"
+            ],
+            [
+                "1.0.1"
+            ],
+            sep="\r"
     ) as mc:
         assert mc.firmware == (1, 0, 1)
 
 
 def test_mc1_inertia():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [
-            "INER?"
-        ],
-        [
-            "20"
-        ],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [
+                "INER?"
+            ],
+            [
+                "20"
+            ],
+            sep="\r"
     ) as mc:
         assert mc.inertia == 20
 
 
 def test_mc1_step():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [
-            "STEP?"
-        ],
-        [
-            "20"
-        ],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [
+                "STEP?"
+            ],
+            [
+                "20"
+            ],
+            sep="\r"
     ) as mc:
         assert mc.step_size == 20*pq.ms
 
 
 def test_mc1_motor():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [
-            "MOTO?"
-        ],
-        [
-            "Radio"
-        ],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [
+                "MOTO?"
+            ],
+            [
+                "Radio"
+            ],
+            sep="\r"
     ) as mc:
         assert mc.controller == mc.MotorType.radio
 
 
 def test_mc1_move_timeout():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [
-            "TIME?",
-            "STEP?"
-        ],
-        [
-            "200",
-            "1"
-        ],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [
+                "TIME?",
+                "STEP?"
+            ],
+            [
+                "200",
+                "1"
+            ],
+            sep="\r"
     ) as mc:
         assert mc.move_timeout == 200*pq.ms
 
 
 def test_mc1_is_centering():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        ["CENT?"],
-        ["1"],
-        sep="\r"
+            ik.qubitekk.MC1,
+            ["CENT?"],
+            ["1"],
+            sep="\r"
     ) as mc:
         assert mc.is_centering() is True
 
 
 def test_mc1_is_centering_false():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        ["CENT?"],
-        ["0"],
-        sep="\r"
+            ik.qubitekk.MC1,
+            ["CENT?"],
+            ["0"],
+            sep="\r"
     ) as mc:
         assert mc.is_centering() is False
 
 
 def test_mc1_center():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [":CENT"],
-        [""],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [":CENT"],
+            [""],
+            sep="\r"
     ) as mc:
         mc.center()
 
 
 def test_mc1_reset():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        [":RESE"],
-        [""],
-        sep="\r"
+            ik.qubitekk.MC1,
+            [":RESE"],
+            [""],
+            sep="\r"
     ) as mc:
         mc.reset()
 
 
 def test_mc1_move():
     with expected_protocol(
-        ik.qubitekk.MC1,
-        ["STEP?", ":MOVE 0"],
-        ["1"],
-        sep="\r"
+            ik.qubitekk.MC1,
+            ["STEP?", ":MOVE 0"],
+            ["1"],
+            sep="\r"
     ) as mc:
         mc.move(0)
 
 
 def test_mc1_move_value_error():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.qubitekk.MC1,
             [":MOVE -1000"],
             [""],
             sep="\r"
-        ) as mc:
-            mc.move(-1000)
+    ) as mc:
+        mc.move(-1000)

--- a/instruments/tests/test_srs/test_srs345.py
+++ b/instruments/tests/test_srs/test_srs345.py
@@ -19,15 +19,15 @@ from instruments.tests import expected_protocol
 
 def test_amplitude():
     with expected_protocol(
-        ik.srs.SRS345,
-        [
-            "AMPL?",
-            "AMPL 0.1VP",
-            "AMPL 0.1VR"
-        ],
-        [
-            "1.234VP",
-        ]
+            ik.srs.SRS345,
+            [
+                "AMPL?",
+                "AMPL 0.1VP",
+                "AMPL 0.1VR"
+            ],
+            [
+                "1.234VP",
+            ]
     ) as inst:
         np.testing.assert_array_equal(
             inst.amplitude, (1.234 * pq.V, inst.VoltageMode.peak_to_peak)
@@ -38,14 +38,14 @@ def test_amplitude():
 
 def test_frequency():
     with expected_protocol(
-        ik.srs.SRS345,
-        [
-            "FREQ?",
-            "FREQ {:e}".format(0.1),
-        ],
-        [
-            "1.234",
-        ]
+            ik.srs.SRS345,
+            [
+                "FREQ?",
+                "FREQ {:e}".format(0.1),
+            ],
+            [
+                "1.234",
+            ]
     ) as inst:
         assert inst.frequency == 1.234 * pq.Hz
         inst.frequency = 0.1 * pq.Hz
@@ -53,14 +53,14 @@ def test_frequency():
 
 def test_function():
     with expected_protocol(
-        ik.srs.SRS345,
-        [
-            "FUNC?",
-            "FUNC 0"
-        ],
-        [
-            "1",
-        ]
+            ik.srs.SRS345,
+            [
+                "FUNC?",
+                "FUNC 0"
+            ],
+            [
+                "1",
+            ]
     ) as inst:
         assert inst.function == inst.Function.square
         inst.function = inst.Function.sinusoid
@@ -68,14 +68,14 @@ def test_function():
 
 def test_offset():
     with expected_protocol(
-        ik.srs.SRS345,
-        [
-            "OFFS?",
-            "OFFS {:e}".format(0.1),
-        ],
-        [
-            "1.234",
-        ]
+            ik.srs.SRS345,
+            [
+                "OFFS?",
+                "OFFS {:e}".format(0.1),
+            ],
+            [
+                "1.234",
+            ]
     ) as inst:
         assert inst.offset == 1.234 * pq.V
         inst.offset = 0.1 * pq.V
@@ -83,14 +83,14 @@ def test_offset():
 
 def test_phase():
     with expected_protocol(
-        ik.srs.SRS345,
-        [
-            "PHSE?",
-            "PHSE {:e}".format(0.1),
-        ],
-        [
-            "1.234",
-        ]
+            ik.srs.SRS345,
+            [
+                "PHSE?",
+                "PHSE {:e}".format(0.1),
+            ],
+            [
+                "1.234",
+            ]
     ) as inst:
         assert inst.phase == 1.234 * pq.degree
         inst.phase = 0.1 * pq.degree

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -20,14 +20,14 @@ from instruments.tests import expected_protocol
 
 def test_frequency_source():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "FMOD?",
-            "FMOD 0"
-        ],
-        [
-            "1",
-        ]
+            ik.srs.SRS830,
+            [
+                "FMOD?",
+                "FMOD 0"
+            ],
+            [
+                "1",
+            ]
     ) as inst:
         assert inst.frequency_source == inst.FreqSource.internal
         inst.frequency_source = inst.FreqSource.external
@@ -35,14 +35,14 @@ def test_frequency_source():
 
 def test_frequency():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "FREQ?",
-            "FREQ {:e}".format(1000)
-        ],
-        [
-            "12.34",
-        ]
+            ik.srs.SRS830,
+            [
+                "FREQ?",
+                "FREQ {:e}".format(1000)
+            ],
+            [
+                "12.34",
+            ]
     ) as inst:
         assert inst.frequency == 12.34 * pq.Hz
         inst.frequency = 1 * pq.kHz
@@ -50,14 +50,14 @@ def test_frequency():
 
 def test_phase():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "PHAS?",
-            "PHAS {:e}".format(10)
-        ],
-        [
-            "-45",
-        ]
+            ik.srs.SRS830,
+            [
+                "PHAS?",
+                "PHAS {:e}".format(10)
+            ],
+            [
+                "-45",
+            ]
     ) as inst:
         assert inst.phase == -45 * pq.degrees
         inst.phase = 10 * pq.degrees
@@ -65,14 +65,14 @@ def test_phase():
 
 def test_amplitude():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "SLVL?",
-            "SLVL {:e}".format(1)
-        ],
-        [
-            "0.1",
-        ]
+            ik.srs.SRS830,
+            [
+                "SLVL?",
+                "SLVL {:e}".format(1)
+            ],
+            [
+                "0.1",
+            ]
     ) as inst:
         assert inst.amplitude == 0.1 * pq.V
         inst.amplitude = 1 * pq.V
@@ -80,14 +80,14 @@ def test_amplitude():
 
 def test_input_shield_ground():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "IGND?",
-            "IGND 1"
-        ],
-        [
-            "0",
-        ]
+            ik.srs.SRS830,
+            [
+                "IGND?",
+                "IGND 1"
+            ],
+            [
+                "0",
+            ]
     ) as inst:
         assert inst.input_shield_ground is False
         inst.input_shield_ground = True
@@ -95,14 +95,14 @@ def test_input_shield_ground():
 
 def test_coupling():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "ICPL?",
-            "ICPL 0"
-        ],
-        [
-            "1",
-        ]
+            ik.srs.SRS830,
+            [
+                "ICPL?",
+                "ICPL 0"
+            ],
+            [
+                "1",
+            ]
     ) as inst:
         assert inst.coupling == inst.Coupling.dc
         inst.coupling = inst.Coupling.ac
@@ -110,17 +110,17 @@ def test_coupling():
 
 def test_sample_rate():  # sends index of VALID_SAMPLE_RATES
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "SRAT?",
-            "SRAT?",
-            "SRAT {:d}".format(5),
-            "SRAT 14"
-        ],
-        [
-            "8",
-            "14"
-        ]
+            ik.srs.SRS830,
+            [
+                "SRAT?",
+                "SRAT?",
+                "SRAT {:d}".format(5),
+                "SRAT 14"
+            ],
+            [
+                "8",
+                "14"
+            ]
     ) as inst:
         assert inst.sample_rate == 16 * pq.Hz
         assert inst.sample_rate == "trigger"
@@ -129,25 +129,24 @@ def test_sample_rate():  # sends index of VALID_SAMPLE_RATES
 
 
 def test_sample_rate_invalid():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            inst.sample_rate = "foobar"
+    ) as inst:
+        inst.sample_rate = "foobar"
 
 
 def test_buffer_mode():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "SEND?",
-            "SEND 1"
-        ],
-        [
-            "0",
-        ]
+            ik.srs.SRS830,
+            [
+                "SEND?",
+                "SEND 1"
+            ],
+            [
+                "0",
+            ]
     ) as inst:
         assert inst.buffer_mode == inst.BufferMode.one_shot
         inst.buffer_mode = inst.BufferMode.loop
@@ -155,27 +154,27 @@ def test_buffer_mode():
 
 def test_num_data_points():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "SPTS?"
-        ],
-        [
-            "5",
-        ]
+            ik.srs.SRS830,
+            [
+                "SPTS?"
+            ],
+            [
+                "5",
+            ]
     ) as inst:
         assert inst.num_data_points == 5
 
 
 def test_data_transfer():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "FAST?",
-            "FAST 2"
-        ],
-        [
-            "0",
-        ]
+            ik.srs.SRS830,
+            [
+                "FAST?",
+                "FAST 2"
+            ],
+            [
+                "0",
+            ]
     ) as inst:
         assert inst.data_transfer is False
         inst.data_transfer = True
@@ -183,206 +182,199 @@ def test_data_transfer():
 
 def test_auto_offset():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "AOFF 1",
-            "AOFF 1"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "AOFF 1",
+                "AOFF 1"
+            ],
+            []
     ) as inst:
         inst.auto_offset(inst.Mode.x)
         inst.auto_offset("x")
 
 
 def test_auto_offset_invalid():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [
                 "AOFF 1",
             ],
             []
-        ) as inst:
-            inst.auto_offset(inst.Mode.theta)
+    ) as inst:
+        inst.auto_offset(inst.Mode.theta)
 
 
 def test_auto_phase():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "APHS"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "APHS"
+            ],
+            []
     ) as inst:
         inst.auto_phase()
 
 
 def test_init():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "REST",
-            "SRAT 5",
-            "SEND 1"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "REST",
+                "SRAT 5",
+                "SEND 1"
+            ],
+            []
     ) as inst:
         inst.init(sample_rate=2, buffer_mode=inst.BufferMode.loop)
 
 
 def test_start_data_transfer():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "FAST 2",
-            "STRD"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "FAST 2",
+                "STRD"
+            ],
+            []
     ) as inst:
         inst.start_data_transfer()
 
 
 def test_take_measurement():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "REST",
-            "SRAT 4",
-            "SEND 0",
-            "FAST 2",
-            "STRD",
-            "PAUS",
-            "SPTS?",
-            "SPTS?",
-            "TRCA?1,0,2",
-            "SPTS?",
-            "TRCA?2,0,2"
-        ],
-        [
-            "2",
-            "2",
-            "1.234,5.678",
-            "2",
-            "0.456,5.321"
-        ]
+            ik.srs.SRS830,
+            [
+                "REST",
+                "SRAT 4",
+                "SEND 0",
+                "FAST 2",
+                "STRD",
+                "PAUS",
+                "SPTS?",
+                "SPTS?",
+                "TRCA?1,0,2",
+                "SPTS?",
+                "TRCA?2,0,2"
+            ],
+            [
+                "2",
+                "2",
+                "1.234,5.678",
+                "2",
+                "0.456,5.321"
+            ]
     ) as inst:
         resp = inst.take_measurement(sample_rate=1, num_samples=2)
         np.testing.assert_array_equal(resp, [[1.234, 5.678], [0.456, 5.321]])
 
 
 def test_take_measurement_invalid_num_samples():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            _ = inst.take_measurement(sample_rate=1, num_samples=16384)
+    ) as inst:
+        _ = inst.take_measurement(sample_rate=1, num_samples=16384)
 
 
 def test_set_offset_expand():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "OEXP 1,0,0"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "OEXP 1,0,0"
+            ],
+            []
     ) as inst:
         inst.set_offset_expand(mode=inst.Mode.x, offset=0, expand=1)
 
 
 def test_set_offset_expand_mode_as_str():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "OEXP 1,0,0"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "OEXP 1,0,0"
+            ],
+            []
     ) as inst:
         inst.set_offset_expand(mode="x", offset=0, expand=1)
 
 
 def test_set_offset_expand_invalid_mode():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            inst.set_offset_expand(mode=inst.Mode.theta, offset=0, expand=1)
+    ) as inst:
+        inst.set_offset_expand(mode=inst.Mode.theta, offset=0, expand=1)
 
 
 def test_set_offset_expand_invalid_offset():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            inst.set_offset_expand(mode=inst.Mode.x, offset=106, expand=1)
+    ) as inst:
+        inst.set_offset_expand(mode=inst.Mode.x, offset=106, expand=1)
 
 
 def test_set_offset_expand_invalid_expand():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            inst.set_offset_expand(mode=inst.Mode.x, offset=0, expand=5)
+    ) as inst:
+        inst.set_offset_expand(mode=inst.Mode.x, offset=0, expand=5)
 
 
 def test_set_offset_expand_invalid_type_offset():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            inst.set_offset_expand(mode=inst.Mode.x, offset="derp", expand=1)
+    ) as inst:
+        inst.set_offset_expand(mode=inst.Mode.x, offset="derp", expand=1)
 
 
 def test_set_offset_expand_invalid_type_expand():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            inst.set_offset_expand(mode=inst.Mode.x, offset=0, expand="derp")
+    ) as inst:
+        inst.set_offset_expand(mode=inst.Mode.x, offset=0, expand="derp")
 
 
 def test_start_scan():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "STRD"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "STRD"
+            ],
+            []
     ) as inst:
         inst.start_scan()
 
 
 def test_pause():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "PAUS"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "PAUS"
+            ],
+            []
     ) as inst:
         inst.pause()
 
 
 def test_data_snap():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "SNAP? 1,2"
-        ],
-        [
-            "1.234,9.876"
-        ]
+            ik.srs.SRS830,
+            [
+                "SNAP? 1,2"
+            ],
+            [
+                "1.234,9.876"
+            ]
     ) as inst:
         data = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.y)
         expected = [1.234, 9.876]
@@ -391,13 +383,13 @@ def test_data_snap():
 
 def test_data_snap_mode_as_str():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "SNAP? 1,2"
-        ],
-        [
-            "1.234,9.876"
-        ]
+            ik.srs.SRS830,
+            [
+                "SNAP? 1,2"
+            ],
+            [
+                "1.234,9.876"
+            ]
     ) as inst:
         data = inst.data_snap(mode1='x', mode2='y')
         expected = [1.234, 9.876]
@@ -405,46 +397,43 @@ def test_data_snap_mode_as_str():
 
 
 def test_data_snap_invalid_snap_mode1():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            _ = inst.data_snap(mode1=inst.Mode.xnoise, mode2=inst.Mode.y)
+    ) as inst:
+        _ = inst.data_snap(mode1=inst.Mode.xnoise, mode2=inst.Mode.y)
 
 
 def test_data_snap_invalid_snap_mode2():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            _ = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.ynoise)
+    ) as inst:
+        _ = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.ynoise)
 
 
 def test_data_snap_identical_modes():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            _ = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.x)
+    ) as inst:
+        _ = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.x)
 
 
 def test_read_data_buffer():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "SPTS?",
-            "TRCA?1,0,2"
-        ],
-        [
-            "2",
-            "1.234,9.876"
-        ]
+            ik.srs.SRS830,
+            [
+                "SPTS?",
+                "TRCA?1,0,2"
+            ],
+            [
+                "2",
+                "1.234,9.876"
+            ]
     ) as inst:
         data = inst.read_data_buffer(channel=inst.Mode.ch1)
         expected = [1.234, 9.876]
@@ -453,15 +442,15 @@ def test_read_data_buffer():
 
 def test_read_data_buffer_mode_as_str():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "SPTS?",
-            "TRCA?1,0,2"
-        ],
-        [
-            "2",
-            "1.234,9.876"
-        ]
+            ik.srs.SRS830,
+            [
+                "SPTS?",
+                "TRCA?1,0,2"
+            ],
+            [
+                "2",
+                "1.234,9.876"
+            ]
     ) as inst:
         data = inst.read_data_buffer(channel="ch1")
         expected = [1.234, 9.876]
@@ -469,33 +458,32 @@ def test_read_data_buffer_mode_as_str():
 
 
 def test_read_data_buffer_invalid_mode():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            _ = inst.read_data_buffer(channel=inst.Mode.x)
+    ) as inst:
+        _ = inst.read_data_buffer(channel=inst.Mode.x)
 
 
 def test_clear_data_buffer():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "REST"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "REST"
+            ],
+            []
     ) as inst:
         inst.clear_data_buffer()
 
 
 def test_set_channel_display():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "DDEF 1,0,0"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "DDEF 1,0,0"
+            ],
+            []
     ) as inst:
         inst.set_channel_display(
             channel=inst.Mode.ch1,
@@ -506,11 +494,11 @@ def test_set_channel_display():
 
 def test_set_channel_display_params_as_str():
     with expected_protocol(
-        ik.srs.SRS830,
-        [
-            "DDEF 1,0,0"
-        ],
-        []
+            ik.srs.SRS830,
+            [
+                "DDEF 1,0,0"
+            ],
+            []
     ) as inst:
         inst.set_channel_display(
             channel="ch1",
@@ -520,42 +508,39 @@ def test_set_channel_display_params_as_str():
 
 
 def test_set_channel_display_invalid_channel():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            inst.set_channel_display(
-                channel=inst.Mode.x,
-                display=inst.Mode.x,
-                ratio=inst.Mode.none
-            )
+    ) as inst:
+        inst.set_channel_display(
+            channel=inst.Mode.x,
+            display=inst.Mode.x,
+            ratio=inst.Mode.none
+        )
 
 
 def test_set_channel_display_invalid_display():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            inst.set_channel_display(
-                channel=inst.Mode.ch1,
-                display=inst.Mode.y,  # y is only valid for ch2, not ch1!
-                ratio=inst.Mode.none
-            )
+    ) as inst:
+        inst.set_channel_display(
+            channel=inst.Mode.ch1,
+            display=inst.Mode.y,  # y is only valid for ch2, not ch1!
+            ratio=inst.Mode.none
+        )
 
 
 def test_set_channel_display_invalid_ratio():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.srs.SRS830,
             [],
             []
-        ) as inst:
-            inst.set_channel_display(
-                channel=inst.Mode.ch1,
-                display=inst.Mode.x,
-                ratio=inst.Mode.xnoise
-            )
+    ) as inst:
+        inst.set_channel_display(
+            channel=inst.Mode.ch1,
+            display=inst.Mode.x,
+            ratio=inst.Mode.xnoise
+        )

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -23,17 +23,17 @@ def test_srsdg645_output_level():
     SRSDG645: Checks getting/setting unitful output level.
     """
     with expected_protocol(
-        ik.srs.SRSDG645,
-        [
-            "LAMP? 1",
-            "LAMP 1,4.0",
-        ],
-        [
-            "3.2"
-        ]
+            ik.srs.SRSDG645,
+            [
+                "LAMP? 1",
+                "LAMP 1,4.0",
+            ],
+            [
+                "3.2"
+            ]
     ) as ddg:
-        unit_eq(ddg.output['AB'].level_amplitude, pq.Quantity(3.2, "V"))
-        ddg.output['AB'].level_amplitude = 4.0
+        unit_eq(ddg.output["AB"].level_amplitude, pq.Quantity(3.2, "V"))
+        ddg.output["AB"].level_amplitude = 4.0
 
 
 def test_srsdg645_output_offset():
@@ -41,17 +41,17 @@ def test_srsdg645_output_offset():
     SRSDG645: Checks getting/setting unitful output offset.
     """
     with expected_protocol(
-        ik.srs.SRSDG645,
-        [
-            "LOFF? 1",
-            "LOFF 1,2.0",
-        ],
-        [
-            "1.2"
-        ]
+            ik.srs.SRSDG645,
+            [
+                "LOFF? 1",
+                "LOFF 1,2.0",
+            ],
+            [
+                "1.2"
+            ]
     ) as ddg:
-        unit_eq(ddg.output['AB'].level_offset, pq.Quantity(1.2, "V"))
-        ddg.output['AB'].level_offset = 2.0
+        unit_eq(ddg.output["AB"].level_offset, pq.Quantity(1.2, "V"))
+        ddg.output["AB"].level_offset = 2.0
 
 
 def test_srsdg645_output_polarity():
@@ -59,22 +59,22 @@ def test_srsdg645_output_polarity():
     SRSDG645: Checks getting/setting
     """
     with expected_protocol(
-        ik.srs.SRSDG645,
-        [
-            "LPOL? 1",
-            "LPOL 2,0"
-        ],
-        [
-            "1"
-        ]
+            ik.srs.SRSDG645,
+            [
+                "LPOL? 1",
+                "LPOL 2,0"
+            ],
+            [
+                "1"
+            ]
     ) as ddg:
-        assert ddg.output['AB'].polarity == ddg.LevelPolarity.positive
-        ddg.output['CD'].polarity = ddg.LevelPolarity.negative
+        assert ddg.output["AB"].polarity == ddg.LevelPolarity.positive
+        ddg.output["CD"].polarity = ddg.LevelPolarity.negative
 
 
 def test_srsdg645_trigger_source():
     with expected_protocol(ik.srs.SRSDG645, "DLAY?2\nDLAY 3,2,60.0\n", "0,42\n") as ddg:
-        ref, t = ddg.channel['A'].delay
+        ref, t = ddg.channel["A"].delay
         assert ref == ddg.Channels.T0
-        assert abs((t - pq.Quantity(42, 's')).magnitude) < 1e5
-        ddg.channel['B'].delay = (ddg.channel['A'], pq.Quantity(1, "minute"))
+        assert abs((t - pq.Quantity(42, "s")).magnitude) < 1e5
+        ddg.channel["B"].delay = (ddg.channel["A"], pq.Quantity(1, "minute"))

--- a/instruments/tests/test_tektronix/test_tektronix_tds224.py
+++ b/instruments/tests/test_tektronix/test_tektronix_tds224.py
@@ -23,13 +23,13 @@ test_tektds224_name = make_name_test(ik.tektronix.TekTDS224)
 
 def test_tektds224_data_width():
     with expected_protocol(
-        ik.tektronix.TekTDS224,
-        [
-            "DATA:WIDTH?",
-            "DATA:WIDTH 1"
-        ], [
-            "2"
-        ]
+            ik.tektronix.TekTDS224,
+            [
+                "DATA:WIDTH?",
+                "DATA:WIDTH 1"
+            ], [
+                "2"
+            ]
     ) as tek:
         assert tek.data_width == 2
         tek.data_width = 1
@@ -37,13 +37,13 @@ def test_tektds224_data_width():
 
 def test_tektds224_data_source():
     with expected_protocol(
-        ik.tektronix.TekTDS224,
-        [
-            "DAT:SOU?",
-            "DAT:SOU MATH"
-        ], [
-            "CH1"
-        ]
+            ik.tektronix.TekTDS224,
+            [
+                "DAT:SOU?",
+                "DAT:SOU MATH"
+            ], [
+                "CH1"
+            ]
     ) as tek:
         assert tek.data_source == ik.tektronix.tektds224._TekTDS224Channel(tek, 0)
         tek.data_source = tek.math
@@ -51,9 +51,9 @@ def test_tektds224_data_source():
 
 def test_tektds224_channel():
     with expected_protocol(
-        ik.tektronix.TekTDS224,
-        [],
-        []
+            ik.tektronix.TekTDS224,
+            [],
+            []
     ) as tek:
         assert tek.channel[
             0] == ik.tektronix.tektds224._TekTDS224Channel(tek, 0)
@@ -61,13 +61,13 @@ def test_tektds224_channel():
 
 def test_tektds224_channel_coupling():
     with expected_protocol(
-        ik.tektronix.TekTDS224,
-        [
-            "CH1:COUPL?",
-            "CH2:COUPL AC"
-        ], [
-            "DC"
-        ]
+            ik.tektronix.TekTDS224,
+            [
+                "CH1:COUPL?",
+                "CH2:COUPL AC"
+            ], [
+                "DC"
+            ]
     ) as tek:
         assert tek.channel[0].coupling == tek.Coupling.dc
         tek.channel[1].coupling = tek.Coupling.ac
@@ -75,31 +75,31 @@ def test_tektds224_channel_coupling():
 
 def test_tektds224_data_source_read_waveform():
     with expected_protocol(
-        ik.tektronix.TekTDS224,
-        [
-            "DAT:SOU?",
-            "DAT:SOU CH2",
-            "DAT:ENC RIB",
-            "DATA:WIDTH?",
-            "CURVE?",
-            "WFMP:CH2:YOF?",
-            "WFMP:CH2:YMU?",
-            "WFMP:CH2:YZE?",
-            "WFMP:XZE?",
-            "WFMP:XIN?",
-            "WFMP:CH2:NR_P?",
-            "DAT:SOU CH1"
-        ], [
-            "CH1",
-            "2",
-            # pylint: disable=no-member
-            "#210" + bytes.fromhex("00000001000200030004").decode("utf-8") + "0",
-            "1",
-            "0",
-            "0",
-            "1",
-            "5"
-        ]
+            ik.tektronix.TekTDS224,
+            [
+                "DAT:SOU?",
+                "DAT:SOU CH2",
+                "DAT:ENC RIB",
+                "DATA:WIDTH?",
+                "CURVE?",
+                "WFMP:CH2:YOF?",
+                "WFMP:CH2:YMU?",
+                "WFMP:CH2:YZE?",
+                "WFMP:XZE?",
+                "WFMP:XIN?",
+                "WFMP:CH2:NR_P?",
+                "DAT:SOU CH1"
+            ], [
+                "CH1",
+                "2",
+                # pylint: disable=no-member
+                "#210" + bytes.fromhex("00000001000200030004").decode("utf-8") + "0",
+                "1",
+                "0",
+                "0",
+                "1",
+                "5"
+            ]
     ) as tek:
         data = np.array([0, 1, 2, 3, 4])
         (x, y) = tek.channel[1].read_waveform()

--- a/instruments/tests/test_thorlabs/test_thorlabs_apt.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_apt.py
@@ -27,42 +27,42 @@ from instruments.tests import expected_protocol
 
 def test_apt_hw_info():
     with expected_protocol(
-        ik.thorlabs.ThorLabsAPT,
-        [
-            ThorLabsPacket(
-                message_id=ThorLabsCommands.HW_REQ_INFO,
-                param1=0x00, param2=0x00,
-                dest=0x50,
-                source=0x01,
-                data=None
-            ).pack()
-        ],
-        [
-            ThorLabsPacket(
-                message_id=ThorLabsCommands.HW_GET_INFO,
-                dest=0x01,
-                source=0x50,
-                data=hw_info_data.pack(
-                    # Serial number
-                    b'\x01\x02\x03\x04',
-                    # Model number
-                    "ABC-123".encode('ascii'),
-                    # HW type
-                    3,
-                    # FW version,
-                    0xa1, 0xa2, 0xa3,
-                    # Notes
-                    "abcdefg".encode('ascii'),
-                    # HW version
-                    42,
-                    # Mod state
-                    43,
-                    # Number of channels
-                    2
-                )
-            ).pack()
-        ],
-        sep=""
+            ik.thorlabs.ThorLabsAPT,
+            [
+                ThorLabsPacket(
+                    message_id=ThorLabsCommands.HW_REQ_INFO,
+                    param1=0x00, param2=0x00,
+                    dest=0x50,
+                    source=0x01,
+                    data=None
+                ).pack()
+            ],
+            [
+                ThorLabsPacket(
+                    message_id=ThorLabsCommands.HW_GET_INFO,
+                    dest=0x01,
+                    source=0x50,
+                    data=hw_info_data.pack(
+                        # Serial number
+                        b'\x01\x02\x03\x04',
+                        # Model number
+                        "ABC-123".encode('ascii'),
+                        # HW type
+                        3,
+                        # FW version,
+                        0xa1, 0xa2, 0xa3,
+                        # Notes
+                        "abcdefg".encode('ascii'),
+                        # HW version
+                        42,
+                        # Mod state
+                        43,
+                        # Number of channels
+                        2
+                    )
+                ).pack()
+            ],
+            sep=""
     ) as apt:
         # Check internal representations.
         # NB: we shouldn't do this in some sense, but these fields

--- a/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
@@ -19,43 +19,42 @@ from instruments.tests import expected_protocol, unit_eq
 
 def test_lcc25_name():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "*idn?"
-        ],
-        [
-            "*idn?",
-            "bloopbloop",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "*idn?"
+            ],
+            [
+                "*idn?",
+                "bloopbloop",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         name = lcc.name
-        assert name == "bloopbloop", "got {} expected bloopbloop".format(name)
+        assert name == "bloopbloop", f"got {name} expected bloopbloop"
 
 
 def test_lcc25_frequency():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "freq?",
-            "freq=10.0"
-        ],
-        [
-            "freq?",
-            "20",
-            ">freq=10.0",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "freq?",
+                "freq=10.0"
+            ],
+            [
+                "freq?",
+                "20",
+                ">freq=10.0",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         unit_eq(lcc.frequency, pq.Quantity(20, "Hz"))
         lcc.frequency = 10.0
 
 
 def test_lcc25_frequency_lowlimit():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.LCC25,
             [
                 "freq=0.0"
@@ -65,13 +64,12 @@ def test_lcc25_frequency_lowlimit():
                 ">"
             ],
             sep="\r"
-        ) as lcc:
-            lcc.frequency = 0.0
+    ) as lcc:
+        lcc.frequency = 0.0
 
 
 def test_lcc25_frequency_highlimit():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.LCC25,
             [
                 "freq=160.0"
@@ -81,140 +79,136 @@ def test_lcc25_frequency_highlimit():
                 ">"
             ],
             sep="\r"
-        ) as lcc:
-            lcc.frequency = 160.0
+    ) as lcc:
+        lcc.frequency = 160.0
 
 
 def test_lcc25_mode():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "mode?",
-            "mode=1"
-        ],
-        [
-            "mode?",
-            "2",
-            ">mode=1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "mode?",
+                "mode=1"
+            ],
+            [
+                "mode?",
+                "2",
+                ">mode=1",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         assert lcc.mode == ik.thorlabs.LCC25.Mode.voltage2
         lcc.mode = ik.thorlabs.LCC25.Mode.voltage1
 
 
 def test_lcc25_mode_invalid():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.LCC25,
             [],
             []
-        ) as lcc:
-            lcc.mode = "blo"
+    ) as lcc:
+        lcc.mode = "blo"
 
 
 def test_lcc25_enable():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "enable?",
-            "enable=1"
-        ],
-        [
-            "enable?",
-            "0",
-            ">enable=1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "enable?",
+                "enable=1"
+            ],
+            [
+                "enable?",
+                "0",
+                ">enable=1",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         assert lcc.enable is False
         lcc.enable = True
 
 
 def test_lcc25_enable_invalid_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.LCC25,
             [],
             []
-        ) as lcc:
-            lcc.enable = "blo"
+    ) as lcc:
+        lcc.enable = "blo"
 
 
 def test_lcc25_extern():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "extern?",
-            "extern=1"
-        ],
-        [
-            "extern?",
-            "0",
-            ">extern=1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "extern?",
+                "extern=1"
+            ],
+            [
+                "extern?",
+                "0",
+                ">extern=1",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         assert lcc.extern is False
         lcc.extern = True
 
 
 def test_tc200_extern_invalid_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.LCC25,
             [],
             []
-        ) as tc:
-            tc.extern = "blo"
+    ) as tc:
+        tc.extern = "blo"
 
 
 def test_lcc25_remote():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "remote?",
-            "remote=1"
-        ],
-        [
-            "remote?",
-            "0",
-            ">remote=1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "remote?",
+                "remote=1"
+            ],
+            [
+                "remote?",
+                "0",
+                ">remote=1",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         assert lcc.remote is False
         lcc.remote = True
 
 
 def test_tc200_remote_invalid_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.LCC25,
             [],
             []
-        ) as tc:
-            tc.remote = "blo"
+    ) as tc:
+        tc.remote = "blo"
 
 
 def test_lcc25_voltage1():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "volt1?",
-            "volt1=10.0"
-        ],
-        [
-            "volt1?",
-            "20",
-            ">volt1=10.0",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "volt1?",
+                "volt1=10.0"
+            ],
+            [
+                "volt1?",
+                "20",
+                ">volt1=10.0",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         unit_eq(lcc.voltage1, pq.Quantity(20, "V"))
         lcc.voltage1 = 10.0
@@ -228,18 +222,18 @@ def test_check_cmd():
 
 def test_lcc25_voltage2():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "volt2?",
-            "volt2=10.0",
-        ],
-        [
-            "volt2?",
-            "20",
-            ">volt2=10.0",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "volt2?",
+                "volt2=10.0",
+            ],
+            [
+                "volt2?",
+                "20",
+                ">volt2=10.0",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         unit_eq(lcc.voltage2, pq.Quantity(20, "V"))
         lcc.voltage2 = 10.0
@@ -247,18 +241,18 @@ def test_lcc25_voltage2():
 
 def test_lcc25_minvoltage():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "min?",
-            "min=10.0"
-        ],
-        [
-            "min?",
-            "20",
-            ">min=10.0",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "min?",
+                "min=10.0"
+            ],
+            [
+                "min?",
+                "20",
+                ">min=10.0",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         unit_eq(lcc.min_voltage, pq.Quantity(20, "V"))
         lcc.min_voltage = 10.0
@@ -266,18 +260,18 @@ def test_lcc25_minvoltage():
 
 def test_lcc25_maxvoltage():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "max?",
-            "max=10.0"
-        ],
-        [
-            "max?",
-            "20",
-            ">max=10.0",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "max?",
+                "max=10.0"
+            ],
+            [
+                "max?",
+                "20",
+                ">max=10.0",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         unit_eq(lcc.max_voltage, pq.Quantity(20, "V"))
         lcc.max_voltage = 10.0
@@ -285,26 +279,25 @@ def test_lcc25_maxvoltage():
 
 def test_lcc25_dwell():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "dwell?",
-            "dwell=10"
-        ],
-        [
-            "dwell?",
-            "20",
-            ">dwell=10",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "dwell?",
+                "dwell=10"
+            ],
+            [
+                "dwell?",
+                "20",
+                ">dwell=10",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         unit_eq(lcc.dwell, pq.Quantity(20, "ms"))
         lcc.dwell = 10
 
 
 def test_lcc25_dwell_positive():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.LCC25,
             [
                 "dwell=-10"
@@ -314,32 +307,31 @@ def test_lcc25_dwell_positive():
                 ">"
             ],
             sep="\r"
-        ) as lcc:
-            lcc.dwell = -10
+    ) as lcc:
+        lcc.dwell = -10
 
 
 def test_lcc25_increment():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "increment?",
-            "increment=10.0"
-        ],
-        [
-            "increment?",
-            "20",
-            ">increment=10.0",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "increment?",
+                "increment=10.0"
+            ],
+            [
+                "increment?",
+                "20",
+                ">increment=10.0",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         unit_eq(lcc.increment, pq.Quantity(20, "V"))
         lcc.increment = 10.0
 
 
 def test_lcc25_increment_positive():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.LCC25,
             [
                 "increment=-10"
@@ -349,127 +341,123 @@ def test_lcc25_increment_positive():
                 ">"
             ],
             sep="\r"
-        ) as lcc:
-            lcc.increment = -10
+    ) as lcc:
+        lcc.increment = -10
 
 
 def test_lcc25_default():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "default"
-        ],
-        [
-            "default",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "default"
+            ],
+            [
+                "default",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         lcc.default()
 
 
 def test_lcc25_save():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "save"
-        ],
-        [
-            "save",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "save"
+            ],
+            [
+                "save",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         lcc.save()
 
 
 def test_lcc25_set_settings():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "set=2"
-        ],
-        [
-            "set=2",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "set=2"
+            ],
+            [
+                "set=2",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         lcc.set_settings(2)
 
 
 def test_lcc25_set_settings_invalid():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.LCC25,
             [],
             [],
             sep="\r"
-        ) as lcc:
-            lcc.set_settings(5)
+    ) as lcc:
+        lcc.set_settings(5)
 
 
 def test_lcc25_get_settings():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "get=2"
-        ],
-        [
-            "get=2",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "get=2"
+            ],
+            [
+                "get=2",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         lcc.get_settings(2)
 
 
 def test_lcc25_get_settings_invalid():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.LCC25,
             [],
             [],
             sep="\r"
-        ) as lcc:
-            lcc.get_settings(5)
+    ) as lcc:
+        lcc.get_settings(5)
 
 
 def test_lcc25_test_mode():
     with expected_protocol(
-        ik.thorlabs.LCC25,
-        [
-            "test"
-        ],
-        [
-            "test",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.LCC25,
+            [
+                "test"
+            ],
+            [
+                "test",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as lcc:
         lcc.test_mode()
 
 
 def test_lcc25_remote_invalid_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.LCC25,
             [],
             []
-        ) as lcc:
-            lcc.remote = "blo"
+    ) as lcc:
+        lcc.remote = "blo"
 
 
 def test_lcc25_extern_invalid_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.LCC25,
             [],
             []
-        ) as lcc:
-            lcc.extern = "blo"
+    ) as lcc:
+        lcc.extern = "blo"

--- a/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
@@ -19,124 +19,121 @@ from instruments.tests import expected_protocol, unit_eq
 
 def test_sc10_name():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "id?"
-        ],
-        [
-            "id?",
-            "bloopbloop",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "id?"
+            ],
+            [
+                "id?",
+                "bloopbloop",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.name == "bloopbloop"
 
 
 def test_sc10_enable():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "ens?",
-            "ens=1"
-        ],
-        [
-            "ens?",
-            "0",
-            ">ens=1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "ens?",
+                "ens=1"
+            ],
+            [
+                "ens?",
+                "0",
+                ">ens=1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.enable is False
         sc.enable = True
 
 
 def test_sc10_enable_invalid():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.SC10,
             [],
             [],
             sep="\r"
-        ) as sc:
-            sc.enable = 10
+    ) as sc:
+        sc.enable = 10
 
 
 def test_sc10_repeat():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "rep?",
-            "rep=10"
-        ],
-        [
-            "rep?",
-            "20",
-            ">rep=10",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "rep?",
+                "rep=10"
+            ],
+            [
+                "rep?",
+                "20",
+                ">rep=10",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.repeat == 20
         sc.repeat = 10
 
 
 def test_sc10_repeat_invalid():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.SC10,
             [],
             [],
             sep="\r"
-        ) as sc:
-            sc.repeat = -1
+    ) as sc:
+        sc.repeat = -1
 
 
 def test_sc10_mode():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "mode?",
-            "mode=2"
-        ],
-        [
-            "mode?",
-            "1",
-            ">mode=2",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "mode?",
+                "mode=2"
+            ],
+            [
+                "mode?",
+                "1",
+                ">mode=2",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.mode == ik.thorlabs.SC10.Mode.manual
         sc.mode = ik.thorlabs.SC10.Mode.auto
 
 
 def test_sc10_mode_invalid():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.SC10,
             [],
             [],
             sep="\r"
-        ) as sc:
-            sc.mode = "blo"
+    ) as sc:
+        sc.mode = "blo"
 
 
 def test_sc10_trigger():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "trig?",
-            "trig=1"
-        ],
-        [
-            "trig?",
-            "0",
-            ">trig=1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "trig?",
+                "trig=1"
+            ],
+            [
+                "trig?",
+                "0",
+                ">trig=1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.trigger == 0
         sc.trigger = 1
@@ -144,18 +141,18 @@ def test_sc10_trigger():
 
 def test_sc10_out_trigger():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "xto?",
-            "xto=1"
-        ],
-        [
-            "xto?",
-            "0",
-            ">xto=1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "xto?",
+                "xto=1"
+            ],
+            [
+                "xto?",
+                "0",
+                ">xto=1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.out_trigger == 0
         sc.out_trigger = 1
@@ -163,18 +160,18 @@ def test_sc10_out_trigger():
 
 def test_sc10_open_time():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "open?",
-            "open=10"
-        ],
-        [
-            "open?",
-            "20",
-            ">open=10",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "open?",
+                "open=10"
+            ],
+            [
+                "open?",
+                "20",
+                ">open=10",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         unit_eq(sc.open_time, pq.Quantity(20, "ms"))
         sc.open_time = 10
@@ -182,18 +179,18 @@ def test_sc10_open_time():
 
 def test_sc10_shut_time():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "shut?",
-            "shut=10"
-        ],
-        [
-            "shut?",
-            "20",
-            ">shut=10",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "shut?",
+                "shut=10"
+            ],
+            [
+                "shut?",
+                "20",
+                ">shut=10",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         unit_eq(sc.shut_time, pq.Quantity(20, "ms"))
         sc.shut_time = 10.0
@@ -201,125 +198,124 @@ def test_sc10_shut_time():
 
 def test_sc10_baud_rate():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "baud?",
-            "baud=1"
-        ],
-        [
-            "baud?",
-            "0",
-            ">baud=1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "baud?",
+                "baud=1"
+            ],
+            [
+                "baud?",
+                "0",
+                ">baud=1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.baud_rate == 9600
         sc.baud_rate = 115200
 
 
 def test_sc10_baud_rate_error():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.SC10,
             [],
             [],
             sep="\r"
-        ) as sc:
-            sc.baud_rate = 115201
+    ) as sc:
+        sc.baud_rate = 115201
 
 
 def test_sc10_closed():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "closed?"
-        ],
-        [
-            "closed?",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "closed?"
+            ],
+            [
+                "closed?",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.closed
 
 
 def test_sc10_interlock():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "interlock?"
-        ],
-        [
-            "interlock?",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "interlock?"
+            ],
+            [
+                "interlock?",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.interlock
 
 
 def test_sc10_default():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "default"
-        ],
-        [
-            "default",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "default"
+            ],
+            [
+                "default",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.default()
 
 
 def test_sc10_save():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "savp"
-        ],
-        [
-            "savp",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "savp"
+            ],
+            [
+                "savp",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.save()
 
 
 def test_sc10_save_mode():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "save"
-        ],
-        [
-            "save",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "save"
+            ],
+            [
+                "save",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.save_mode()
 
 
 def test_sc10_restore():
     with expected_protocol(
-        ik.thorlabs.SC10,
-        [
-            "resp"
-        ],
-        [
-            "resp",
-            "1",
-            ">"
-        ],
-        sep="\r"
+            ik.thorlabs.SC10,
+            [
+                "resp"
+            ],
+            [
+                "resp",
+                "1",
+                ">"
+            ],
+            sep="\r"
     ) as sc:
         assert sc.restore()

--- a/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
@@ -20,35 +20,35 @@ from instruments.tests import expected_protocol
 
 def test_tc200_name():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "*idn?"
-        ],
-        [
-            "*idn?",
-            "bloopbloop",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "*idn?"
+            ],
+            [
+                "*idn?",
+                "bloopbloop",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.name() == "bloopbloop"
 
 
 def test_tc200_mode():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "stat?",
-            "stat?",
-            "mode=cycle"
-        ],
-        [
-            "stat?",
-            "0 > stat?",
-            "2 >  mode=cycle",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "stat?",
+                "stat?",
+                "mode=cycle"
+            ],
+            [
+                "stat?",
+                "0 > stat?",
+                "2 >  mode=cycle",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.mode == tc.Mode.normal
         assert tc.mode == tc.Mode.cycle
@@ -57,64 +57,62 @@ def test_tc200_mode():
 
 def test_tc200_mode_2():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "mode=normal"
-        ],
-        [
-            "mode=normal",
-            "Command error CMD_ARG_RANGE_ERR\n",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "mode=normal"
+            ],
+            [
+                "mode=normal",
+                "Command error CMD_ARG_RANGE_ERR\n",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         tc.mode = ik.thorlabs.TC200.Mode.normal
 
 
 def test_tc200_mode_error():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.TC200,
             [],
             [],
             sep="\r"
-        ) as tc:
-            tc.mode = "blo"
+    ) as tc:
+        tc.mode = "blo"
 
 
 def test_tc200_mode_error2():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.TC200,
             [],
             [],
             sep="\r"
-        ) as tc:
-            class TestEnum(IntEnum):
-                blo = 1
-                beep = 2
-            tc.mode = TestEnum.blo
+    ) as tc:
+        class TestEnum(IntEnum):
+            blo = 1
+            beep = 2
+        tc.mode = TestEnum.blo
 
 
 def test_tc200_enable():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "stat?",
-            "stat?",
-            "ens",
-            "stat?",
-            "ens"
-        ],
-        [
-            "stat?",
-            "54 > stat?",
-            "54 > ens",
-            "> stat?",
-            "55 > ens",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "stat?",
+                "stat?",
+                "ens",
+                "stat?",
+                "ens"
+            ],
+            [
+                "stat?",
+                "54 > stat?",
+                "54 > ens",
+                "> stat?",
+                "55 > ens",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.enable == 0
         tc.enable = True
@@ -122,57 +120,55 @@ def test_tc200_enable():
 
 
 def test_tc200_enable_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.TC200,
             [],
             [],
             sep="\r"
-        ) as tc:
-            tc.enable = "blo"
+    ) as tc:
+        tc.enable = "blo"
 
 
 def test_tc200_temperature():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "tact?",
-        ],
-        [
-            "tact?",
-            "30 C",
-            "> ",
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "tact?",
+            ],
+            [
+                "tact?",
+                "30 C",
+                "> ",
+            ],
+            sep="\r"
     ) as tc:
         assert tc.temperature == 30.0 * pq.degC
 
 
 def test_tc200_temperature_set():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "tset?",
-            "tmax?",
-            "tset=40.0"
-        ],
-        [
-            "tset?",
-            "30 C",
-            "> tmax?",
-            "250",
-            "> tset=40.0",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "tset?",
+                "tmax?",
+                "tset=40.0"
+            ],
+            [
+                "tset?",
+                "30 C",
+                "> tmax?",
+                "250",
+                "> tset=40.0",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.temperature_set == 30.0 * pq.degC
         tc.temperature_set = 40 * pq.degC
 
 
 def test_tc200_temperature_range():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "tmax?"
@@ -183,98 +179,96 @@ def test_tc200_temperature_range():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.temperature_set = 50 * pq.degC
+    ) as tc:
+        tc.temperature_set = 50 * pq.degC
 
 
 def test_tc200_pid():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "pid?",
-            "pgain=2"
-        ],
-        [
-            "pid?",
-            "2 0 220",
-            "> pgain=2",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "pid?",
+                "pgain=2"
+            ],
+            [
+                "pid?",
+                "2 0 220",
+                "> pgain=2",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.p == 2
         tc.p = 2
 
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "pid?",
-            "igain=0"
-        ],
-        [
-            "pid?",
-            "2 0 220",
-            "> igain=0",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "pid?",
+                "igain=0"
+            ],
+            [
+                "pid?",
+                "2 0 220",
+                "> igain=0",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.i == 0
         tc.i = 0
 
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "pid?",
-            "dgain=220"
-        ],
-        [
-            "pid?",
-            "2 0 220",
-            "> dgain=220",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "pid?",
+                "dgain=220"
+            ],
+            [
+                "pid?",
+                "2 0 220",
+                "> dgain=220",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.d == 220
         tc.d = 220
 
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "pid?",
-            "pgain=2",
-            "igain=0",
-            "dgain=220"
-        ],
-        [
-            "pid?",
-            "2 0 220",
-            "> pgain=2",
-            "> igain=0",
-            "> dgain=220",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "pid?",
+                "pgain=2",
+                "igain=0",
+                "dgain=220"
+            ],
+            [
+                "pid?",
+                "2 0 220",
+                "> pgain=2",
+                "> igain=0",
+                "> dgain=220",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.pid == [2, 0, 220]
         tc.pid = (2, 0, 220)
 
 
 def test_tc200_pid_invalid_type():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.TC200,
             [],
             [],
             sep="\r"
-        ) as tc:
-            tc.pid = "foo"
+    ) as tc:
+        tc.pid = "foo"
 
 
 def test_tc200_pmin():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "pgain=-1"
@@ -284,13 +278,12 @@ def test_tc200_pmin():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.p = -1
+    ) as tc:
+        tc.p = -1
 
 
 def test_tc200_pmax():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "pgain=260"
@@ -300,13 +293,12 @@ def test_tc200_pmax():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.p = 260
+    ) as tc:
+        tc.p = 260
 
 
 def test_tc200_imin():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "igain=-1"
@@ -316,13 +308,12 @@ def test_tc200_imin():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.i = -1
+    ) as tc:
+        tc.i = -1
 
 
 def test_tc200_imax():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "igain=260"
@@ -332,13 +323,12 @@ def test_tc200_imax():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.i = 260
+    ) as tc:
+        tc.i = 260
 
 
 def test_tc200_dmin():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "dgain=-1"
@@ -348,13 +338,12 @@ def test_tc200_dmin():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.d = -1
+    ) as tc:
+        tc.d = -1
 
 
 def test_tc200_dmax():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "dgain=260"
@@ -364,31 +353,31 @@ def test_tc200_dmax():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.d = 260
+    ) as tc:
+        tc.d = 260
 
 
 def test_tc200_degrees():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "stat?",
-            "stat?",
-            "stat?",
-            "unit=c",
-            "unit=f",
-            "unit=k"
-        ],
-        [
-            "stat?",
-            "44 > stat?",
-            "54 > stat?",
-            "0 >  unit=c",
-            "> unit=f",
-            "> unit=k",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "stat?",
+                "stat?",
+                "stat?",
+                "unit=c",
+                "unit=f",
+                "unit=k"
+            ],
+            [
+                "stat?",
+                "44 > stat?",
+                "54 > stat?",
+                "0 >  unit=c",
+                "> unit=f",
+                "> unit=k",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert str(tc.degrees).split(" ")[1] == "K"
         assert str(tc.degrees).split(" ")[1] == "degC"
@@ -400,80 +389,76 @@ def test_tc200_degrees():
 
 
 def test_tc200_degrees_invalid():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.thorlabs.TC200,
             [],
             [],
             sep="\r"
-        ) as tc:
-            tc.degrees = "blo"
+    ) as tc:
+        tc.degrees = "blo"
 
 
 def test_tc200_sensor():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "sns?",
-            "sns=ptc100"
-        ],
-        [
-            "sns?",
-            "Sensor = NTC10K, Beta = 5600",
-            "> sns=ptc100",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "sns?",
+                "sns=ptc100"
+            ],
+            [
+                "sns?",
+                "Sensor = NTC10K, Beta = 5600",
+                "> sns=ptc100",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.sensor == tc.Sensor.ntc10k
         tc.sensor = tc.Sensor.ptc100
 
 
 def test_tc200_sensor_error():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [],
             []
-        ) as tc:
-            tc.sensor = "blo"
+    ) as tc:
+        tc.sensor = "blo"
 
 
 def test_tc200_sensor_error2():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [],
             []
-        ) as tc:
-            class TestEnum(IntEnum):
-                blo = 1
-                beep = 2
-            tc.sensor = TestEnum.blo
+    ) as tc:
+        class TestEnum(IntEnum):
+            blo = 1
+            beep = 2
+        tc.sensor = TestEnum.blo
 
 
 def test_tc200_beta():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "beta?",
-            "beta=2000"
-        ],
-        [
-            "beta?",
-            "5600",
-            "> beta=2000",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "beta?",
+                "beta=2000"
+            ],
+            [
+                "beta?",
+                "5600",
+                "> beta=2000",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.beta == 5600
         tc.beta = 2000
 
 
 def test_tc200_beta_min():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "beta=200"
@@ -483,13 +468,12 @@ def test_tc200_beta_min():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.beta = 200
+    ) as tc:
+        tc.beta = 200
 
 
 def test_tc200_beta_max():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "beta=20000"
@@ -499,32 +483,31 @@ def test_tc200_beta_max():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.beta = 20000
+    ) as tc:
+        tc.beta = 20000
 
 
 def test_tc200_max_power():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "pmax?",
-            "pmax=12.0"
-        ],
-        [
-            "pmax?",
-            "15.0",
-            "> pmax=12.0",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "pmax?",
+                "pmax=12.0"
+            ],
+            [
+                "pmax?",
+                "15.0",
+                "> pmax=12.0",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.max_power == 15.0 * pq.W
         tc.max_power = 12 * pq.W
 
 
 def test_tc200_power_min():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "PMAX=-2"
@@ -534,13 +517,12 @@ def test_tc200_power_min():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.max_power = -1
+    ) as tc:
+        tc.max_power = -1
 
 
 def test_tc200_power_max():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "PMAX=20000"
@@ -550,32 +532,31 @@ def test_tc200_power_max():
                 "> "
             ],
             sep="\r"
-        ) as tc:
-            tc.max_power = 20000
+    ) as tc:
+        tc.max_power = 20000
 
 
 def test_tc200_max_temperature():
     with expected_protocol(
-        ik.thorlabs.TC200,
-        [
-            "tmax?",
-            "tmax=180.0"
-        ],
-        [
-            "tmax?",
-            "200.0",
-            "> tmax=180.0",
-            "> "
-        ],
-        sep="\r"
+            ik.thorlabs.TC200,
+            [
+                "tmax?",
+                "tmax=180.0"
+            ],
+            [
+                "tmax?",
+                "200.0",
+                "> tmax=180.0",
+                "> "
+            ],
+            sep="\r"
     ) as tc:
         assert tc.max_temperature == 200.0 * pq.degC
         tc.max_temperature = 180 * pq.degC
 
 
 def test_tc200_temp_min():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "TMAX=-2"
@@ -585,13 +566,12 @@ def test_tc200_temp_min():
                 ">"
             ],
             sep="\r"
-        ) as tc:
-            tc.max_temperature = -1
+    ) as tc:
+        tc.max_temperature = -1
 
 
 def test_tc200_temp_max():
-    with pytest.raises(ValueError):
-        with expected_protocol(
+    with pytest.raises(ValueError), expected_protocol(
             ik.thorlabs.TC200,
             [
                 "TMAX=20000"
@@ -601,5 +581,5 @@ def test_tc200_temp_max():
                 ">"
             ],
             sep="\r"
-        ) as tc:
-            tc.max_temperature = 20000
+    ) as tc:
+        tc.max_temperature = 20000

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -20,19 +20,19 @@ from instruments.tests import expected_protocol
 
 def test_laser_serial_number():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:serial-number)",
-            "(param-ref 'laser2:serial-number)"
-        ],
-        [
-            "(param-ref 'laser1:serial-number)",
-            "bloop1",
-            "> (param-ref 'laser2:serial-number)",
-            "bloop2",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:serial-number)",
+                "(param-ref 'laser2:serial-number)"
+            ],
+            [
+                "(param-ref 'laser1:serial-number)",
+                "bloop1",
+                "> (param-ref 'laser2:serial-number)",
+                "bloop2",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].serial_number == "bloop1"
         assert tm.laser[1].serial_number == "bloop2"
@@ -40,19 +40,19 @@ def test_laser_serial_number():
 
 def test_model():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:model)",
-            "(param-ref 'laser2:model)"
-        ],
-        [
-            "(param-ref 'laser1:model)",
-            "bloop1",
-            "> (param-ref 'laser2:model)",
-            "bloop2",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:model)",
+                "(param-ref 'laser2:model)"
+            ],
+            [
+                "(param-ref 'laser1:model)",
+                "bloop1",
+                "> (param-ref 'laser2:model)",
+                "bloop2",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].model == "bloop1"
         assert tm.laser[1].model == "bloop2"
@@ -60,19 +60,19 @@ def test_model():
 
 def test_wavelength():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:wavelength)",
-            "(param-ref 'laser2:wavelength)"
-        ],
-        [
-            "(param-ref 'laser1:wavelength)",
-            "640",
-            "> (param-ref 'laser2:wavelength)",
-            "405.3",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:wavelength)",
+                "(param-ref 'laser2:wavelength)"
+            ],
+            [
+                "(param-ref 'laser1:wavelength)",
+                "640",
+                "> (param-ref 'laser2:wavelength)",
+                "405.3",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].wavelength == 640 * pq.nm
         assert tm.laser[1].wavelength == 405.3 * pq.nm
@@ -80,30 +80,29 @@ def test_wavelength():
 
 def test_laser_enable():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:emission)",
-            "(param-ref 'laser1:serial-number)",
-            "(param-set! 'laser1:enable-emission #t)"
-        ],
-        [
-            "(param-ref 'laser1:emission)",
-            "#f",
-            "> (param-ref 'laser1:serial-number)",
-            "bloop1",
-            "> (param-set! 'laser1:enable-emission #t)",
-            "0",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:emission)",
+                "(param-ref 'laser1:serial-number)",
+                "(param-set! 'laser1:enable-emission #t)"
+            ],
+            [
+                "(param-ref 'laser1:emission)",
+                "#f",
+                "> (param-ref 'laser1:serial-number)",
+                "bloop1",
+                "> (param-set! 'laser1:enable-emission #t)",
+                "0",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].enable is False
         tm.laser[0].enable = True
 
 
 def test_laser_enable_no_laser():
-    with pytest.raises(RuntimeError):
-        with expected_protocol(
+    with pytest.raises(RuntimeError), expected_protocol(
             ik.toptica.TopMode,
             [
                 "(param-ref 'laser1:serial-number)",
@@ -117,13 +116,12 @@ def test_laser_enable_no_laser():
                 "> "
             ],
             sep="\r\n"
-        ) as tm:
-            tm.laser[0].enable = True
+    ) as tm:
+        tm.laser[0].enable = True
 
 
 def test_laser_enable_error():
-    with pytest.raises(TypeError):
-        with expected_protocol(
+    with pytest.raises(TypeError), expected_protocol(
             ik.toptica.TopMode,
             [
                 "(param-ref 'laser1:serial-number)",
@@ -137,80 +135,80 @@ def test_laser_enable_error():
                 "> "
             ],
             sep="\n"
-        ) as tm:
-            tm.laser[0].enable = 'True'
+    ) as tm:
+        tm.laser[0].enable = 'True'
 
 
 def test_laser_tec_status():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:tec:ready)"
-        ],
-        [
-            "(param-ref 'laser1:tec:ready)",
-            "#f",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:tec:ready)"
+            ],
+            [
+                "(param-ref 'laser1:tec:ready)",
+                "#f",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].tec_status is False
 
 
 def test_laser_intensity():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:intensity)"
-        ],
-        [
-            "(param-ref 'laser1:intensity)",
-            "0.666",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:intensity)"
+            ],
+            [
+                "(param-ref 'laser1:intensity)",
+                "0.666",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].intensity == 0.666
 
 
 def test_laser_mode_hop():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)"
-        ],
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)",
-            "#f",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)"
+            ],
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)",
+                "#f",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].mode_hop is False
 
 
 def test_laser_lock_start():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:charm:correction-status)",
-            "(param-ref 'laser1:charm:reg:started)"
-        ],
-        [
-            "(param-ref 'laser1:charm:correction-status)",
-            "2",
-            "> (param-ref 'laser1:charm:reg:started)",
-            "\"2012-12-01 01:02:01\"",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:charm:correction-status)",
+                "(param-ref 'laser1:charm:reg:started)"
+            ],
+            [
+                "(param-ref 'laser1:charm:correction-status)",
+                "2",
+                "> (param-ref 'laser1:charm:reg:started)",
+                "\"2012-12-01 01:02:01\"",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         _date = datetime(2012, 12, 1, 1, 2, 1)
         assert tm.laser[0].lock_start == _date
 
+
 def test_laser_lock_start_runtime_error():
-    with pytest.raises(RuntimeError):
-        with expected_protocol(
+    with pytest.raises(RuntimeError), expected_protocol(
             ik.toptica.TopMode,
             [
                 "(param-ref 'laser1:charm:correction-status)",
@@ -224,14 +222,13 @@ def test_laser_lock_start_runtime_error():
                 "> "
             ],
             sep="\r\n"
-        ) as tm:
-            _date = datetime(2012, 12, 1, 1, 2, 1)
-            assert tm.laser[0].lock_start == _date
+    ) as tm:
+        _date = datetime(2012, 12, 1, 1, 2, 1)
+        assert tm.laser[0].lock_start == _date
 
 
 def test_laser_first_mode_hop_time_runtime_error():
-    with pytest.raises(RuntimeError):
-        with expected_protocol(
+    with pytest.raises(RuntimeError), expected_protocol(
             ik.toptica.TopMode,
             [
                 "(param-ref 'laser1:charm:reg:mh-occurred)",
@@ -245,33 +242,32 @@ def test_laser_first_mode_hop_time_runtime_error():
                 "> "
             ],
             sep="\r\n"
-        ) as tm:
-            assert tm.laser[0].first_mode_hop_time is None
+    ) as tm:
+        assert tm.laser[0].first_mode_hop_time is None
 
 
 def test_laser_first_mode_hop_time():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)",
-            "(param-ref 'laser1:charm:reg:first-mh)"
-        ],
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)",
-            "#t",
-            "> (param-ref 'laser1:charm:reg:first-mh)",
-            "\"2012-12-01 01:02:01\"",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)",
+                "(param-ref 'laser1:charm:reg:first-mh)"
+            ],
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)",
+                "#t",
+                "> (param-ref 'laser1:charm:reg:first-mh)",
+                "\"2012-12-01 01:02:01\"",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         _date = datetime(2012, 12, 1, 1, 2, 1)
         assert tm.laser[0].first_mode_hop_time == _date
 
 
 def test_laser_latest_mode_hop_time_none():
-    with pytest.raises(RuntimeError):
-        with expected_protocol(
+    with pytest.raises(RuntimeError), expected_protocol(
             ik.toptica.TopMode,
             [
                 "(param-ref 'laser1:charm:reg:mh-occurred)",
@@ -285,25 +281,25 @@ def test_laser_latest_mode_hop_time_none():
                 "> "
             ],
             sep="\r\n"
-        ) as tm:
-            assert tm.laser[0].latest_mode_hop_time is None
+    ) as tm:
+        assert tm.laser[0].latest_mode_hop_time is None
 
 
 def test_laser_latest_mode_hop_time():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)",
-            "(param-ref 'laser1:charm:reg:latest-mh)"
-        ],
-        [
-            "(param-ref 'laser1:charm:reg:mh-occurred)",
-            "#t",
-            "> (param-ref 'laser1:charm:reg:latest-mh)",
-            "\"2012-12-01 01:02:01\"",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)",
+                "(param-ref 'laser1:charm:reg:latest-mh)"
+            ],
+            [
+                "(param-ref 'laser1:charm:reg:mh-occurred)",
+                "#t",
+                "> (param-ref 'laser1:charm:reg:latest-mh)",
+                "\"2012-12-01 01:02:01\"",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         _date = datetime(2012, 12, 1, 1, 2, 1)
         assert tm.laser[0].latest_mode_hop_time == _date
@@ -311,51 +307,50 @@ def test_laser_latest_mode_hop_time():
 
 def test_laser_correction_status():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:charm:correction-status)"
-        ],
-        [
-            "(param-ref 'laser1:charm:correction-status)",
-            "0",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:charm:correction-status)"
+            ],
+            [
+                "(param-ref 'laser1:charm:correction-status)",
+                "0",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
-        assert tm.laser[
-            0].correction_status == ik.toptica.TopMode.CharmStatus.un_initialized
+        assert tm.laser[0].correction_status == ik.toptica.TopMode.CharmStatus.un_initialized
 
 
 def test_laser_correction():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:charm:correction-status)",  # 1st
-            "(exec 'laser1:charm:start-correction-initial)",
-            "(param-ref 'laser1:charm:correction-status)",  # 2nd
-            "(exec 'laser1:charm:start-correction)",
-            "(param-ref 'laser1:charm:correction-status)",  # 3rd
-            "(param-ref 'laser1:charm:correction-status)",  # 4th
-            "(exec 'laser1:charm:start-correction)"
-        ],
-        [
-            "(param-ref 'laser1:charm:correction-status)",  # 1st
-            "0",
-            "> (exec 'laser1:charm:start-correction-initial)",
-            "()",
-            "> (param-ref 'laser1:charm:correction-status)",  # 3nd
-            "1",
-            "> (exec 'laser1:charm:start-correction)",
-            "()",
-            "> (param-ref 'laser1:charm:correction-status)",  # 3rd
-            "3",
-            "> (param-ref 'laser1:charm:correction-status)",  # 4th
-            "2",
-            "> (exec 'laser1:charm:start-correction)",
-            "()",
-            "> ",
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:charm:correction-status)",  # 1st
+                "(exec 'laser1:charm:start-correction-initial)",
+                "(param-ref 'laser1:charm:correction-status)",  # 2nd
+                "(exec 'laser1:charm:start-correction)",
+                "(param-ref 'laser1:charm:correction-status)",  # 3rd
+                "(param-ref 'laser1:charm:correction-status)",  # 4th
+                "(exec 'laser1:charm:start-correction)"
+            ],
+            [
+                "(param-ref 'laser1:charm:correction-status)",  # 1st
+                "0",
+                "> (exec 'laser1:charm:start-correction-initial)",
+                "()",
+                "> (param-ref 'laser1:charm:correction-status)",  # 3nd
+                "1",
+                "> (exec 'laser1:charm:start-correction)",
+                "()",
+                "> (param-ref 'laser1:charm:correction-status)",  # 3rd
+                "3",
+                "> (param-ref 'laser1:charm:correction-status)",  # 4th
+                "2",
+                "> (exec 'laser1:charm:start-correction)",
+                "()",
+                "> ",
+            ],
+            sep="\r\n"
     ) as tm:
         tm.laser[0].correction()
         tm.laser[0].correction()
@@ -365,163 +360,163 @@ def test_laser_correction():
 
 def test_reboot_system():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(exec 'reboot-system)"
-        ],
-        [
-            "(exec 'reboot-system)",
-            "reboot process started.",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(exec 'reboot-system)"
+            ],
+            [
+                "(exec 'reboot-system)",
+                "reboot process started.",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         tm.reboot()
 
 
 def test_laser_ontime():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:ontime)"
-        ],
-        [
-            "(param-ref 'laser1:ontime)",
-            "10000",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:ontime)"
+            ],
+            [
+                "(param-ref 'laser1:ontime)",
+                "10000",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].on_time == 10000 * pq.s
 
 
 def test_laser_charm_status():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:health)"
-        ],
-        [
-            "(param-ref 'laser1:health)",
-            "230",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:health)"
+            ],
+            [
+                "(param-ref 'laser1:health)",
+                "230",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].charm_status == 1
 
 
 def test_laser_temperature_control_status():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:health)"
-        ],
-        [
-            "(param-ref 'laser1:health)",
-            "230",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:health)"
+            ],
+            [
+                "(param-ref 'laser1:health)",
+                "230",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].temperature_control_status == 1
 
 
 def test_laser_current_control_status():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:health)"
-        ],
-        [
-            "(param-ref 'laser1:health)",
-            "230",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:health)"
+            ],
+            [
+                "(param-ref 'laser1:health)",
+                "230",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].current_control_status == 1
 
 
 def test_laser_production_date():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'laser1:production-date)"
-        ],
-        [
-            "(param-ref 'laser1:production-date)",
-            "2016-01-16",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'laser1:production-date)"
+            ],
+            [
+                "(param-ref 'laser1:production-date)",
+                "2016-01-16",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.laser[0].production_date == "2016-01-16"
 
 
 def test_set_str():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-set! 'blo \"blee\")"
-        ],
-        [
-            "(param-set! 'blo \"blee\")",
-            "0",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-set! 'blo \"blee\")"
+            ],
+            [
+                "(param-set! 'blo \"blee\")",
+                "0",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
-        tm.set('blo', 'blee')
+        tm.set("blo", "blee")
 
 
 def test_set_list():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-set! 'blo '(blee blo))"
-        ],
-        [
-            "(param-set! 'blo '(blee blo))",
-            "0",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-set! 'blo '(blee blo))"
+            ],
+            [
+                "(param-set! 'blo '(blee blo))",
+                "0",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
-        tm.set('blo', ['blee', 'blo'])
+        tm.set("blo", ["blee", "blo"])
 
 
 def test_display():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-disp 'blo)"
-        ],
-        [
-            "(param-disp 'blo)",
-            "bloop",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-disp 'blo)"
+            ],
+            [
+                "(param-disp 'blo)",
+                "bloop",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
-        assert tm.display('blo') == "bloop"
+        assert tm.display("blo") == "bloop"
 
 
 def test_enable():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'emission)",
-            "(param-set! 'enable-emission #f)"
-        ],
-        [
-            "(param-ref 'emission)",
-            "#f",
-            "> (param-set! 'enable-emission #f)",
-            "0",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'emission)",
+                "(param-set! 'enable-emission #f)"
+            ],
+            [
+                "(param-ref 'emission)",
+                "#f",
+                "> (param-set! 'enable-emission #f)",
+                "0",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.enable is False
         tm.enable = False
@@ -529,32 +524,32 @@ def test_enable():
 
 def test_firmware():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'fw-ver)"
-        ],
-        [
-            "(param-ref 'fw-ver)",
-            "1.02.01",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'fw-ver)"
+            ],
+            [
+                "(param-ref 'fw-ver)",
+                "1.02.01",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.firmware == (1, 2, 1)
 
 
 def test_serial_number():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'serial-number)"
-        ],
-        [
-            "(param-ref 'serial-number)",
-            "010101",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'serial-number)"
+            ],
+            [
+                "(param-ref 'serial-number)",
+                "010101",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.serial_number == '010101'
 
@@ -562,110 +557,110 @@ def test_serial_number():
 def test_enable_error():
     with pytest.raises(TypeError):
         with expected_protocol(
-            ik.toptica.TopMode,
-            [
-                "(param-set! 'enable-emission #f)"
-            ],
-            [
-                "(param-set! 'enable-emission #f)",
-                ">"
-            ],
-            sep="\r\n"
+                ik.toptica.TopMode,
+                [
+                    "(param-set! 'enable-emission #f)"
+                ],
+                [
+                    "(param-set! 'enable-emission #f)",
+                    ">"
+                ],
+                sep="\r\n"
         ) as tm:
             tm.enable = "False"
 
 
 def test_front_key():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'front-key-locked)"
-        ],
-        [
-            "(param-ref 'front-key-locked)",
-            "#f",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'front-key-locked)"
+            ],
+            [
+                "(param-ref 'front-key-locked)",
+                "#f",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.locked is False
 
 
 def test_interlock():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'interlock-open)"
-        ],
-        [
-            "(param-ref 'interlock-open)",
-            "#f",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'interlock-open)"
+            ],
+            [
+                "(param-ref 'interlock-open)",
+                "#f",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.interlock is False
 
 
 def test_fpga_status():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'system-health)"
-        ],
-        [
-            "(param-ref 'system-health)",
-            "0",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'system-health)"
+            ],
+            [
+                "(param-ref 'system-health)",
+                "0",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.fpga_status is True
 
 
 def test_fpga_status_false():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'system-health)"
-        ],
-        [
-            "(param-ref 'system-health)",
-            "#f",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'system-health)"
+            ],
+            [
+                "(param-ref 'system-health)",
+                "#f",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.fpga_status is False
 
 
 def test_temperature_status():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'system-health)"
-        ],
-        [
-            "(param-ref 'system-health)",
-            "2",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'system-health)"
+            ],
+            [
+                "(param-ref 'system-health)",
+                "2",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.temperature_status is False
 
 
 def test_current_status():
     with expected_protocol(
-        ik.toptica.TopMode,
-        [
-            "(param-ref 'system-health)"
-        ],
-        [
-            "(param-ref 'system-health)",
-            "4",
-            "> "
-        ],
-        sep="\r\n"
+            ik.toptica.TopMode,
+            [
+                "(param-ref 'system-health)"
+            ],
+            [
+                "(param-ref 'system-health)",
+                "4",
+                "> "
+            ],
+            sep="\r\n"
     ) as tm:
         assert tm.current_status is False

--- a/instruments/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/instruments/tests/test_yokogawa/test_yokogawa_6370.py
@@ -10,16 +10,16 @@ from __future__ import absolute_import
 
 import struct
 
+from hypothesis import (
+    given,
+    strategies as st,
+)
 import numpy as np
 import quantities as pq
 
 import instruments as ik
 from instruments.tests import expected_protocol
 
-from hypothesis import (
-    given,
-    strategies as st,
-)
 
 # TESTS #######################################################################
 
@@ -31,11 +31,11 @@ def test_channel_is_channel_class():
 
 def test_init():
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64"
-        ],
-        []
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64"
+            ],
+            []
     ) as _:
         pass
 
@@ -47,14 +47,14 @@ def test_channel_data(values, channel):
     values_len = str(len(values_packed)).encode()
     values_len_of_len = str(len(values_len)).encode()
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":TRAC:Y? {}".format(channel.value),
-        ],
-        [
-            b"#" + values_len_of_len + values_len + values_packed
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":TRAC:Y? {}".format(channel.value),
+            ],
+            [
+                b"#" + values_len_of_len + values_len + values_packed
+            ]
     ) as inst:
         np.testing.assert_array_equal(inst.channel[channel].data(), np.array(values, dtype="<d"))
 
@@ -66,14 +66,14 @@ def test_channel_wavelength(values, channel):
     values_len = str(len(values_packed)).encode()
     values_len_of_len = str(len(values_len)).encode()
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":TRAC:X? {}".format(channel.value),
-        ],
-        [
-            b"#" + values_len_of_len + values_len + values_packed
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":TRAC:X? {}".format(channel.value),
+            ],
+            [
+                b"#" + values_len_of_len + values_len + values_packed
+            ]
     ) as inst:
         np.testing.assert_array_equal(
             inst.channel[channel].wavelength(),
@@ -84,15 +84,15 @@ def test_channel_wavelength(values, channel):
 @given(value=st.floats(min_value=600e-9, max_value=1700e-9))
 def test_start_wavelength(value):
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":SENS:WAV:STAR?",
-            ":SENS:WAV:STAR {:e}".format(value),
-        ],
-        [
-            "6.000000e-06"
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":SENS:WAV:STAR?",
+                ":SENS:WAV:STAR {:e}".format(value),
+            ],
+            [
+                "6.000000e-06"
+            ]
     ) as inst:
         assert inst.start_wl == 6e-6 * pq.meter
         inst.start_wl = value * pq.meter
@@ -101,15 +101,15 @@ def test_start_wavelength(value):
 @given(value=st.floats(min_value=600e-9, max_value=1700e-9))
 def test_end_wavelength(value):
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":SENS:WAV:STOP?",
-            ":SENS:WAV:STOP {:e}".format(value),
-        ],
-        [
-            "6.000000e-06"
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":SENS:WAV:STOP?",
+                ":SENS:WAV:STOP {:e}".format(value),
+            ],
+            [
+                "6.000000e-06"
+            ]
     ) as inst:
         assert inst.stop_wl == 6e-6 * pq.meter
         inst.stop_wl = value * pq.meter
@@ -117,15 +117,15 @@ def test_end_wavelength(value):
 
 def test_bandwidth():
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":SENS:BAND:RES?",
-            ":SENS:BAND:RES 1.000000e-06"
-        ],
-        [
-            "6.000000e-06"
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":SENS:BAND:RES?",
+                ":SENS:BAND:RES 1.000000e-06"
+            ],
+            [
+                "6.000000e-06"
+            ]
     ) as inst:
         assert inst.bandwidth == 6e-6 * pq.meter
         inst.bandwidth = 1e-6 * pq.meter
@@ -133,15 +133,15 @@ def test_bandwidth():
 
 def test_span():
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":SENS:WAV:SPAN?",
-            ":SENS:WAV:SPAN 1.000000e-06"
-        ],
-        [
-            "6.000000e-06"
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":SENS:WAV:SPAN?",
+                ":SENS:WAV:SPAN 1.000000e-06"
+            ],
+            [
+                "6.000000e-06"
+            ]
     ) as inst:
         assert inst.span == 6e-6 * pq.meter
         inst.span = 1e-6 * pq.meter
@@ -149,15 +149,15 @@ def test_span():
 
 def test_center_wl():
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":SENS:WAV:CENT?",
-            ":SENS:WAV:CENT 1.000000e-06"
-        ],
-        [
-            "6.000000e-06"
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":SENS:WAV:CENT?",
+                ":SENS:WAV:CENT 1.000000e-06"
+            ],
+            [
+                "6.000000e-06"
+            ]
     ) as inst:
         assert inst.center_wl == 6e-6 * pq.meter
         inst.center_wl = 1e-6 * pq.meter
@@ -165,15 +165,15 @@ def test_center_wl():
 
 def test_points():
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":SENS:SWE:POIN?",
-            ":SENS:SWE:POIN 1.000000e+00"
-        ],
-        [
-            "6"
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":SENS:SWE:POIN?",
+                ":SENS:SWE:POIN 1.000000e+00"
+            ],
+            [
+                "6"
+            ]
     ) as inst:
         assert inst.points == 6
         inst.points = 1
@@ -181,21 +181,21 @@ def test_points():
 
 def test_sweep_mode():
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":INIT:SMOD 1",
-            ":INIT:SMOD 2",
-            ":INIT:SMOD 3",
-            ":INIT:SMOD?",
-            ":INIT:SMOD?",
-            ":INIT:SMOD?",
-        ],
-        [
-            "1",
-            "2",
-            "3",
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":INIT:SMOD 1",
+                ":INIT:SMOD 2",
+                ":INIT:SMOD 3",
+                ":INIT:SMOD?",
+                ":INIT:SMOD?",
+                ":INIT:SMOD?",
+            ],
+            [
+                "1",
+                "2",
+                "3",
+            ]
     ) as inst:
         for mode in inst.SweepModes:
             inst.sweep_mode = mode
@@ -205,18 +205,18 @@ def test_sweep_mode():
 
 def test_active_trace():
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            ":TRAC:ACTIVE TRA",
-            ":TRAC:ACTIVE TRD",
-            ":TRAC:ACTIVE?",
-            ":TRAC:ACTIVE?",
-        ],
-        [
-            "TRB",
-            "TRG",
-        ]
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                ":TRAC:ACTIVE TRA",
+                ":TRAC:ACTIVE TRD",
+                ":TRAC:ACTIVE?",
+                ":TRAC:ACTIVE?",
+            ],
+            [
+                "TRB",
+                "TRG",
+            ]
     ) as inst:
         inst.active_trace = inst.Traces.A
         inst.active_trace = inst.Traces.D
@@ -226,11 +226,11 @@ def test_active_trace():
 
 def test_start_sweep():
     with expected_protocol(
-        ik.yokogawa.Yokogawa6370,
-        [
-            ":FORMat:DATA REAL,64",
-            "*CLS;:init",
-        ],
-        []
+            ik.yokogawa.Yokogawa6370,
+            [
+                ":FORMat:DATA REAL,64",
+                "*CLS;:init",
+            ],
+            []
     ) as inst:
         inst.start_sweep()

--- a/instruments/thorlabs/_abstract.py
+++ b/instruments/thorlabs/_abstract.py
@@ -11,11 +11,11 @@ from __future__ import division
 
 import time
 
+from quantities import second
+
 from instruments.thorlabs import _packets
 from instruments.abstract_instruments.instrument import Instrument
 from instruments.util_fns import assume_units
-
-from quantities import second
 
 # CLASSES #####################################################################
 
@@ -29,7 +29,7 @@ class ThorLabsInstrument(Instrument):
 
     def __init__(self, filelike):
         super(ThorLabsInstrument, self).__init__(filelike)
-        self.terminator = ''
+        self.terminator = ""
 
     def sendpacket(self, packet):
         """

--- a/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/thorlabs/thorlabsapt.py
@@ -425,9 +425,6 @@ class APTStrainGaugeReader(APTPiezoDevice):
 
         .. warning:: This is not currently implemented
         """
-        # STRAIN GAUGE COMMANDS #
-
-        pass
 
     _channel_type = StrainGaugeChannel
 
@@ -515,7 +512,14 @@ class APTMotorController(ThorLabsAPT):
 
         @property
         def motion_timeout(self):
+            """
+            Gets/sets the motor channel motion timeout.
+
+            :units: Seconds
+            :type: `~quantities.quantity.Quantity`
+            """
             return self._motion_timeout
+
         @motion_timeout.setter
         def motion_timeout(self, newval):
             self._motion_timeout = assume_units(newval, pq.second)

--- a/instruments/util_fns.py
+++ b/instruments/util_fns.py
@@ -106,8 +106,7 @@ def convert_temperature(temperature, base):
     elif str(newval.units).split(" ")[1] == 'K' and str(base).split(" ")[1] == 'K':
         return_val = newval
     else:
-        raise ValueError(
-            "Unable to convert " + str(newval.units) + " to " + str(base))
+        raise ValueError(f"Unable to convert {str(newval.units)} to {str(base)}")
     return return_val
 
 
@@ -156,12 +155,10 @@ def split_unit_str(s, default_units=pq.dimensionless, lookup=None):
 
         return float(val), lookup(units)
 
-    else:
-        try:
-            return float(s), default_units
-        except ValueError:
-            raise ValueError("Could not split '{}' into value "
-                             "and units.".format(repr(s)))
+    try:
+        return float(s), default_units
+    except ValueError:
+        raise ValueError(f"Could not split '{repr(s)}' into value and units.")
 
 
 def rproperty(fget=None, fset=None, doc=None, readonly=False, writeonly=False):
@@ -478,17 +475,17 @@ def unitful_property(command, units, set_cmd=None, format_code='{:e}', doc=None,
     def _setter(self, newval):
         min_value, max_value = valid_range
         if min_value is not None:
-            if hasattr(min_value, '__call__'):
-                min_value = min_value(self)
+            if callable(min_value):
+                min_value = min_value(self)  # pylint: disable=not-callable
             if newval < min_value:
-                raise ValueError("Unitful quantity is too low. Got {}, minimum "
-                                 "value is {}".format(newval, min_value))
+                raise ValueError(f"Unitful quantity is too low. Got {newval}, "
+                                 f"minimum value is {min_value}")
         if max_value is not None:
-            if hasattr(max_value, '__call__'):
-                max_value = max_value(self)
+            if callable(max_value):
+                max_value = max_value(self)  # pylint: disable=not-callable
             if newval > max_value:
-                raise ValueError("Unitful quantity is too high. Got {}, maximum"
-                                 " value is {}".format(newval, max_value))
+                raise ValueError(f"Unitful quantity is too high. Got {newval}, "
+                                 f"maximum value is {max_value}")
         # Rescale to the correct unit before printing. This will also
         # catch bad units.
         strval = format_code.format(
@@ -614,7 +611,7 @@ def string_property(command, set_cmd=None, bookmark_symbol='"', doc=None,
 # CLASSES #####################################################################
 
 
-class ProxyList(object):
+class ProxyList:
     """
     This is a special class used to generate lists of objects where the valid
     keys are defined by the `valid_set` init parameter. This allows an
@@ -666,8 +663,7 @@ class ProxyList(object):
             if not isinstance(idx, self._valid_set):
                 raise IndexError("Index out of range. Must be "
                                  "in {}.".format(self._valid_set))
-            else:
-                idx = idx.value
+            idx = idx.value
         else:
             if idx not in self._valid_set:
                 raise IndexError("Index out of range. Must be "


### PR DESCRIPTION
Updates the repo to `pylint==2.4.4`, fixes a bunch of new rules that comes with it, and disables checking for refactor rules until after we finish ripping out all the old Py2 stuff.