### PR TITLE
Change all quantities imports to instruments.units

### DIFF
--- a/doc/examples/ex_hp3456.py
+++ b/doc/examples/ex_hp3456.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, print_function
 import logging
 import time
 import instruments as ik
-import quantities as pq
+import instruments.units as u
 
 dmm = ik.hp.HP3456a.open_gpibusb('/dev/ttyUSB0', 22)
 logging.basicConfig(level=logging.DEBUG)
@@ -50,7 +50,7 @@ print(dmm.measure(dmm.Mode.ratio_dcv_dcv))
 print(dmm.measure(dmm.Mode.resistance_2wire))
 dmm.nplc = 1
 for i in range(-1, 4):
-    value = (10 ** i) * pq.volt
+    value = (10 ** i) * u.volt
     dmm.input_range = value
     print(dmm.measure(dmm.Mode.dcv))
 

--- a/doc/examples/ex_topticatopmode.py
+++ b/doc/examples/ex_topticatopmode.py
@@ -5,7 +5,7 @@ Toptica Topmode example
 """
 
 import instruments as ik
-import quantities as pq
+import instruments.units as u
 from platform import system
 if system() == 'Windows':
       tm = ik.toptica.TopMode.open_serial('COM17', 115200)

--- a/doc/examples/minghe/ex_minghe_mhs5200.py
+++ b/doc/examples/minghe/ex_minghe_mhs5200.py
@@ -1,25 +1,25 @@
 #!/usr/bin/python
 from instruments.minghe import MHS5200
-import quantities as pq
+import instruments.units as u
 
 mhs = MHS5200.open_serial(vid=6790, pid=29987, baud=57600)
 print(mhs.serial_number)
-mhs.channel[0].frequency = 3000000*pq.Hz
+mhs.channel[0].frequency = 3000000*u.Hz
 print(mhs.channel[0].frequency)
 mhs.channel[0].function = MHS5200.Function.sawtooth_down
 print(mhs.channel[0].function)
-mhs.channel[0].amplitude = 9.0*pq.V
+mhs.channel[0].amplitude = 9.0*u.V
 print(mhs.channel[0].amplitude)
 mhs.channel[0].offset = -0.5
 print(mhs.channel[0].offset)
 mhs.channel[0].phase = 90
 print(mhs.channel[0].phase)
 
-mhs.channel[1].frequency = 2000000*pq.Hz
+mhs.channel[1].frequency = 2000000*u.Hz
 print(mhs.channel[1].frequency)
 mhs.channel[1].function = MHS5200.Function.square
 print(mhs.channel[1].function)
-mhs.channel[1].amplitude = 2.0*pq.V
+mhs.channel[1].amplitude = 2.0*u.V
 print(mhs.channel[1].amplitude)
 mhs.channel[1].offset = 0.0
 print(mhs.channel[1].offset)

--- a/doc/examples/qubitekk/ex_qubitekk_mc1.py
+++ b/doc/examples/qubitekk/ex_qubitekk_mc1.py
@@ -3,14 +3,14 @@
 from time import sleep
 
 from instruments.qubitekk import MC1
-import quantities as pq
+import instruments.units as u
 
 
 if __name__ == "__main__":
 
     mc1 = MC1.open_serial(vid=1027, pid=24577, baud=9600, timeout=1)
-    mc1.step_size = 25*pq.ms
-    mc1.inertia = 10*pq.ms
+    mc1.step_size = 25*u.ms
+    mc1.inertia = 10*u.ms
     print("step size:", mc1.step_size)
     print("inertial force: ", mc1.inertia)
 
@@ -26,9 +26,9 @@ if __name__ == "__main__":
     print("Stage Centered")
     # for the motor in the mechanical delay line, the travel is limited from
     # the full range of travel. Here's how to set the limits.
-    mc1.lower_limit = -260*pq.ms
-    mc1.upper_limit = 300*pq.ms
-    mc1.increment = 5*pq.ms
+    mc1.lower_limit = -260*u.ms
+    mc1.upper_limit = 300*u.ms
+    mc1.increment = 5*u.ms
     x_pos = mc1.lower_limit
     while x_pos <= mc1.upper_limit:
         print(str(mc1.metric_position)+" "+str(mc1.direction))

--- a/doc/examples/srs_DG645.ipynb
+++ b/doc/examples/srs_DG645.ipynb
@@ -43,7 +43,7 @@
      "collapsed": false,
      "input": [
       "from instruments.srs import SRSDG645\n",
-      "import quantities as pq"
+      "import instruments.units as u"
      ],
      "language": "python",
      "metadata": {},
@@ -100,7 +100,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "ddg.channel[ddg.Channels.A].delay = (ddg.Channels.B, pq.Quantity(10, 'us'))"
+      "ddg.channel[ddg.Channels.A].delay = (ddg.Channels.B, u.Quantity(10, 'us'))"
      ],
      "language": "python",
      "metadata": {},

--- a/doc/examples/srs_DG645.py
+++ b/doc/examples/srs_DG645.py
@@ -21,7 +21,7 @@
 # <codecell>
 
 from instruments.srs import SRSDG645
-import quantities as pq
+import instruments.units as u
 
 # <markdowncell>
 
@@ -38,7 +38,7 @@ ddg = SRSDG645.open_gpibusb('/dev/ttyUSB0', 15)
 
 # <codecell>
 
-ddg.channel[ddg.Channels.A].delay = (ddg.Channels.B, pq.Quantity(10, 'us'))
+ddg.channel[ddg.Channels.A].delay = (ddg.Channels.B, u.Quantity(10, 'us'))
 
 # <codecell>
 

--- a/doc/source/devguide/testing.rst
+++ b/doc/source/devguide/testing.rst
@@ -63,7 +63,7 @@ a simple test case for :class:`instruments.srs.SRSDG645``::
 	            ],
 	            sep="\n"
 	    ) as ddg:
-	        unit_eq(ddg.output['AB'].level_amplitude, pq.Quantity(3.2, "V"))
+	        unit_eq(ddg.output['AB'].level_amplitude, u.Quantity(3.2, "V"))
 	        ddg.output['AB'].level_amplitude = 4.0
 
 Here, we see that the test has a name beginning with ``test_``, has a simple

--- a/doc/source/devguide/util_fns.rst
+++ b/doc/source/devguide/util_fns.rst
@@ -74,7 +74,7 @@ These properties, when implemented in your class, might look like this::
     voltage, voltage_min, voltage_max = bounded_unitful_property(
         voltage = unitful_property(
         "VOLT",
-        pq.volt,
+        u.volt,
         valid_range=(0*quantities.volt, 10*quantities.volt)
         doc="""
         Gets/sets the output voltage.
@@ -129,7 +129,7 @@ the `~instruments.thorlabs.TC200` class::
 
     temperature = unitful_property(
         "tact",
-        units=pq.degC,
+        units=u.degC,
         readonly=True,
         input_decoration=lambda x: x.replace(
             " C", "").replace(" F", "").replace(" K", ""),

--- a/instruments/abstract_instruments/comm/gpib_communicator.py
+++ b/instruments/abstract_instruments/comm/gpib_communicator.py
@@ -16,7 +16,7 @@ import io
 import time
 
 from builtins import chr, str, bytes
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
@@ -48,7 +48,7 @@ class GPIBCommunicator(io.IOBase, AbstractCommunicator):
         self._terminator = None
         self.terminator = "\n"
         self._eoi = True
-        self._timeout = 1000 * pq.millisecond
+        self._timeout = 1000 * u.millisecond
         if self._model == GPIBCommunicator.Model.gi and self._version <= 4:
             self._eos = 10
         else:
@@ -109,15 +109,15 @@ class GPIBCommunicator(io.IOBase, AbstractCommunicator):
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, pq.second)
+        newval = assume_units(newval, u.second)
         if self._model == GPIBCommunicator.Model.gi and self._version <= 4:
-            newval = newval.rescale(pq.second)
+            newval = newval.rescale(u.second)
             self._file.sendcmd('+t:{}'.format(int(newval.magnitude)))
         else:
-            newval = newval.rescale(pq.millisecond)
+            newval = newval.rescale(u.millisecond)
             self._file.sendcmd("++read_tmo_ms {}".format(int(newval.magnitude)))
-        self._file.timeout = newval.rescale(pq.second)
-        self._timeout = newval.rescale(pq.second)
+        self._file.timeout = newval.rescale(u.second)
+        self._timeout = newval.rescale(u.second)
 
     @property
     def terminator(self):

--- a/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/abstract_instruments/comm/serial_communicator.py
@@ -16,7 +16,7 @@ import io
 from builtins import bytes, str
 import serial
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
@@ -88,11 +88,11 @@ class SerialCommunicator(io.IOBase, AbstractCommunicator):
         :type: `~quantities.Quantity`
         :units: As specified or assumed to be of units ``seconds``
         """
-        return self._conn.timeout * pq.second
+        return self._conn.timeout * u.second
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, pq.second).rescale(pq.second).magnitude
+        newval = assume_units(newval, u.second).rescale(u.second).magnitude
         self._conn.timeout = newval
 
     # FILE-LIKE METHODS #

--- a/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/instruments/abstract_instruments/comm/socket_communicator.py
@@ -15,7 +15,7 @@ import io
 import socket
 
 from builtins import str, bytes
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
@@ -77,11 +77,11 @@ class SocketCommunicator(io.IOBase, AbstractCommunicator):
         :type: `~quantities.Quantity`
         :units: As specified or assumed to be of units ``seconds``
         """
-        return self._conn.gettimeout() * pq.second
+        return self._conn.gettimeout() * u.second
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, pq.second).rescale(pq.second).magnitude
+        newval = assume_units(newval, u.second).rescale(u.second).magnitude
         self._conn.settimeout(newval)
 
     # FILE-LIKE METHODS #

--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -15,7 +15,7 @@ import io
 from builtins import str, bytes
 
 import usbtmc
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
@@ -74,11 +74,11 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
         :type: `~quantities.Quantity`
         :units: As specified or assumed to be of units ``seconds``
         """
-        return self._filelike.timeout * pq.second
+        return self._filelike.timeout * u.second
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, pq.second).rescale(pq.s).magnitude
+        newval = assume_units(newval, u.second).rescale(u.s).magnitude
         self._filelike.timeout = newval
 
     # FILE-LIKE METHODS #

--- a/instruments/abstract_instruments/comm/visa_communicator.py
+++ b/instruments/abstract_instruments/comm/visa_communicator.py
@@ -16,7 +16,7 @@ from __future__ import unicode_literals
 import io
 from builtins import str
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
@@ -95,11 +95,11 @@ class VisaCommunicator(io.IOBase, AbstractCommunicator):
 
     @property
     def timeout(self):
-        return self._conn.timeout * pq.second
+        return self._conn.timeout * u.second
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, pq.second).rescale(pq.second).magnitude
+        newval = assume_units(newval, u.second).rescale(u.second).magnitude
         self._conn.timeout = newval
 
     # FILE-LIKE METHODS #

--- a/instruments/abstract_instruments/function_generator.py
+++ b/instruments/abstract_instruments/function_generator.py
@@ -14,7 +14,6 @@ from enum import Enum
 
 from builtins import range
 from future.utils import with_metaclass
-import quantities as pq
 
 from instruments.abstract_instruments import Instrument
 import instruments.units as u
@@ -170,9 +169,9 @@ class FunctionGenerator(with_metaclass(abc.ABCMeta, Instrument)):
             mag, units = self._get_amplitude_()
 
             if units == self._parent.VoltageMode.dBm:
-                return pq.Quantity(mag, u.dBm)
+                return u.Quantity(mag, u.dBm)
 
-            return pq.Quantity(mag, pq.V), units
+            return u.Quantity(mag, u.V), units
 
         @amplitude.setter
         def amplitude(self, newval):
@@ -191,7 +190,7 @@ class FunctionGenerator(with_metaclass(abc.ABCMeta, Instrument)):
                     mag, units = newval
 
                 # Finally, convert the magnitude out to a float.
-                mag = float(assume_units(mag, pq.V).rescale(pq.V).magnitude)
+                mag = float(assume_units(mag, u.V).rescale(u.V).magnitude)
 
             self._set_amplitude_(mag, units)
 

--- a/instruments/agilent/agilent33220a.py
+++ b/instruments/agilent/agilent33220a.py
@@ -12,7 +12,7 @@ from builtins import range
 
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIFunctionGenerator
 from instruments.util_fns import (
@@ -33,10 +33,10 @@ class Agilent33220a(SCPIFunctionGenerator):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> inst = ik.agilent.Agilent33220a.open_gpibusb('/dev/ttyUSB0', 1)
     >>> inst.function = inst.Function.sinusoid
-    >>> inst.frequency = 1 * pq.kHz
+    >>> inst.frequency = 1 * u.kHz
     >>> inst.output = True
 
     .. _Agilent/Keysight 33220a: http://www.keysight.com/en/pd-127539-pn-33220A
@@ -166,7 +166,7 @@ class Agilent33220a(SCPIFunctionGenerator):
         """
         value = self.query("OUTP:LOAD?")
         try:
-            return int(value) * pq.ohm
+            return int(value) * u.ohm
         except ValueError:
             return self.LoadResistance(value.strip())
 
@@ -175,7 +175,7 @@ class Agilent33220a(SCPIFunctionGenerator):
         if isinstance(newval, self.LoadResistance):
             newval = newval.value
         else:
-            newval = assume_units(newval, pq.ohm).rescale(pq.ohm).magnitude
+            newval = assume_units(newval, u.ohm).rescale(u.ohm).magnitude
             if (newval < 0) or (newval > 10000):
                 raise ValueError(
                     "Load resistance must be between 0 and 10,000")

--- a/instruments/agilent/agilent34410a.py
+++ b/instruments/agilent/agilent34410a.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import map
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIMultimeter
 
@@ -28,7 +28,7 @@ class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> dmm = ik.agilent.Agilent34410a.open_gpibusb('/dev/ttyUSB0', 1)
     >>> print(dmm.measure(dmm.Mode.resistance))
 
@@ -173,7 +173,7 @@ class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
             data[0] = float(data[0])
             if data[1] in unit_map:
                 data[1] = unit_map[data[1]]
-            return pq.Quantity(*data)
+            return u.Quantity(*data)
 
     def read_meter(self):
         """
@@ -193,16 +193,16 @@ class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
 # UNITS #######################################################################
 
 UNITS = {
-    Agilent34410a.Mode.capacitance: pq.farad,
-    Agilent34410a.Mode.voltage_dc:  pq.volt,
-    Agilent34410a.Mode.voltage_ac:  pq.volt,
-    Agilent34410a.Mode.diode:       pq.volt,
-    Agilent34410a.Mode.current_ac:  pq.amp,
-    Agilent34410a.Mode.current_dc:  pq.amp,
-    Agilent34410a.Mode.resistance:  pq.ohm,
-    Agilent34410a.Mode.fourpt_resistance: pq.ohm,
-    Agilent34410a.Mode.frequency:   pq.hertz,
-    Agilent34410a.Mode.period:      pq.second,
-    Agilent34410a.Mode.temperature: pq.kelvin,
+    Agilent34410a.Mode.capacitance: u.farad,
+    Agilent34410a.Mode.voltage_dc:  u.volt,
+    Agilent34410a.Mode.voltage_ac:  u.volt,
+    Agilent34410a.Mode.diode:       u.volt,
+    Agilent34410a.Mode.current_ac:  u.amp,
+    Agilent34410a.Mode.current_dc:  u.amp,
+    Agilent34410a.Mode.resistance:  u.ohm,
+    Agilent34410a.Mode.fourpt_resistance: u.ohm,
+    Agilent34410a.Mode.frequency:   u.hertz,
+    Agilent34410a.Mode.period:      u.second,
+    Agilent34410a.Mode.temperature: u.kelvin,
     Agilent34410a.Mode.continuity:  1,
 }

--- a/instruments/config.py
+++ b/instruments/config.py
@@ -21,12 +21,11 @@ except ImportError:
     # a false positive from its import-error checker, so we locally disable
     # it here. Once the cause for the false positive has been identified,
     # the import-error check should be re-enabled.
-    import ruamel_yaml as yaml # pylint: disable=import-error
-
-import quantities as pq
+    import ruamel_yaml as yaml  # pylint: disable=import-error
 
 from future.builtins import str
 
+import instruments.units as u
 from instruments.util_fns import setattr_expression, split_unit_str
 
 # FUNCTIONS ###################################################################
@@ -62,12 +61,12 @@ def walk_dict(d, path):
 
 def quantity_constructor(loader, node):
     """
-    Constructs a `pq.Quantity` instance from a PyYAML
+    Constructs a `u.Quantity` instance from a PyYAML
     node tagged as ``!Q``.
     """
     # Follows the example of http://stackoverflow.com/a/43081967/267841.
     value = loader.construct_scalar(node)
-    return pq.Quantity(*split_unit_str(value))
+    return u.Quantity(*split_unit_str(value))
 
 # We avoid having to register !Q every time by doing as soon as the
 # relevant constructor is defined.
@@ -102,7 +101,7 @@ def load_instruments(conf_file_name, conf_path="/"):
                 channel[0].motor_model: PRM1-Z8
 
     Unitful attributes can be specified by using the ``!Q`` tag to quickly create
-    instances of `pq.Quantity`. In the example above, for instance, we can set a motion
+    instances of `u.Quantity`. In the example above, for instance, we can set a motion
     timeout as a unitful quantity::
 
         attrs:

--- a/instruments/fluke/fluke3000.py
+++ b/instruments/fluke/fluke3000.py
@@ -40,7 +40,7 @@ from builtins import range
 
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Multimeter
 
@@ -105,7 +105,7 @@ class Fluke3000(Multimeter):
         Initialize the instrument, and set the properties needed for communication.
         """
         super(Fluke3000, self).__init__(filelike)
-        self.timeout = 3 * pq.second
+        self.timeout = 3 * u.second
         self.terminator = "\r"
         self.positions = {}
         self.connect()
@@ -211,7 +211,7 @@ class Fluke3000(Multimeter):
         if not self.positions:
             self.reset()                   # Reset the PC3000 dongle
             timeout = self.timeout         # Store default timeout
-            self.timeout = 30 * pq.second  # PC 3000 can take a while to bind with wireless devices
+            self.timeout = 30 * u.second  # PC 3000 can take a while to bind with wireless devices
             self.query_lines("rfdis", 3)   # Discover available modules and bind them
             self.timeout = timeout         # Restore default timeout
             self.scan()                    # Look for connected devices
@@ -295,7 +295,7 @@ class Fluke3000(Multimeter):
         until a terminator is not found.
         """
         timeout = self.timeout
-        self.timeout = 0.1 * pq.second
+        self.timeout = 0.1 * u.second
         init_time = time.time()
         while time.time() - init_time < 1.:
             try:
@@ -472,14 +472,14 @@ class Fluke3000(Multimeter):
 
 UNITS = {
     None: 1,
-    Fluke3000.Mode.voltage_ac:  pq.volt,
-    Fluke3000.Mode.voltage_dc:  pq.volt,
-    Fluke3000.Mode.current_ac:  pq.amp,
-    Fluke3000.Mode.current_dc:  pq.amp,
-    Fluke3000.Mode.frequency:   pq.hertz,
-    Fluke3000.Mode.temperature: pq.celsius,
-    Fluke3000.Mode.resistance:  pq.ohm,
-    Fluke3000.Mode.capacitance: pq.farad
+    Fluke3000.Mode.voltage_ac:  u.volt,
+    Fluke3000.Mode.voltage_dc:  u.volt,
+    Fluke3000.Mode.current_ac:  u.amp,
+    Fluke3000.Mode.current_dc:  u.amp,
+    Fluke3000.Mode.frequency:   u.hertz,
+    Fluke3000.Mode.temperature: u.celsius,
+    Fluke3000.Mode.resistance:  u.ohm,
+    Fluke3000.Mode.capacitance: u.farad
 }
 
 # METRIC PREFIXES #############################################################

--- a/instruments/generic_scpi/scpi_function_generator.py
+++ b/instruments/generic_scpi/scpi_function_generator.py
@@ -9,7 +9,7 @@ Provides support for SCPI compliant function generators
 from __future__ import absolute_import
 from __future__ import division
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import FunctionGenerator
 from instruments.generic_scpi import SCPIInstrument
@@ -27,9 +27,9 @@ class SCPIFunctionGenerator(FunctionGenerator, SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> inst = ik.generic_scpi.SCPIFunctionGenerator.open_tcpip("192.168.1.1")
-    >>> inst.frequency = 1 * pq.kHz
+    >>> inst.frequency = 1 * u.kHz
     """
 
     # CONSTANTS #
@@ -76,7 +76,7 @@ class SCPIFunctionGenerator(FunctionGenerator, SCPIInstrument):
 
     frequency = unitful_property(
         command="FREQ",
-        units=pq.Hz,
+        units=u.Hz,
         doc="""
         Gets/sets the output frequency.
 
@@ -97,7 +97,7 @@ class SCPIFunctionGenerator(FunctionGenerator, SCPIInstrument):
 
     offset = unitful_property(
         command="VOLT:OFFS",
-        units=pq.volt,
+        units=u.volt,
         doc="""
         Gets/sets the offset voltage of the function generator.
 

--- a/instruments/generic_scpi/scpi_instrument.py
+++ b/instruments/generic_scpi/scpi_instrument.py
@@ -12,7 +12,7 @@ from __future__ import division
 from builtins import map
 
 from enum import IntEnum
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import assume_units
@@ -151,7 +151,7 @@ class SCPIInstrument(Instrument):
         :units: Hertz
         :type: `~quantities.quantity.Quantity`
         """
-        return pq.Quantity(
+        return u.Quantity(
             float(self.query("SYST:LFR?")),
             "Hz"
         )

--- a/instruments/generic_scpi/scpi_multimeter.py
+++ b/instruments/generic_scpi/scpi_multimeter.py
@@ -11,7 +11,7 @@ from __future__ import division
 
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Multimeter
 from instruments.generic_scpi import SCPIInstrument
@@ -178,7 +178,7 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
         Example usages:
 
         >>> dmm.input_range = dmm.InputRange.automatic
-        >>> dmm.input_range = 1 * pq.millivolt
+        >>> dmm.input_range = 1 * u.millivolt
 
         :units: As appropriate for the current mode setting.
         :type: `~quantities.Quantity`, or `~SCPIMultimeter.InputRange`
@@ -318,7 +318,7 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
 
     trigger_delay = unitful_property(
         command="TRIG:DEL",
-        units=pq.second,
+        units=u.second,
         doc="""
         Gets/sets the time delay which the multimeter will use following
         receiving a trigger event before starting the measurement.
@@ -345,7 +345,7 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
 
     sample_timer = unitful_property(
         command="SAMP:TIM",
-        units=pq.second,
+        units=u.second,
         doc="""
         Gets/sets the sample interval when the sample counter is greater than
         one and when the sample source is set to timer (see
@@ -418,16 +418,16 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
 # UNITS #######################################################################
 
 UNITS = {
-    SCPIMultimeter.Mode.capacitance: pq.farad,
-    SCPIMultimeter.Mode.voltage_dc:  pq.volt,
-    SCPIMultimeter.Mode.voltage_ac:  pq.volt,
-    SCPIMultimeter.Mode.diode:       pq.volt,
-    SCPIMultimeter.Mode.current_ac:  pq.amp,
-    SCPIMultimeter.Mode.current_dc:  pq.amp,
-    SCPIMultimeter.Mode.resistance:  pq.ohm,
-    SCPIMultimeter.Mode.fourpt_resistance: pq.ohm,
-    SCPIMultimeter.Mode.frequency:   pq.hertz,
-    SCPIMultimeter.Mode.period:      pq.second,
-    SCPIMultimeter.Mode.temperature: pq.kelvin,
+    SCPIMultimeter.Mode.capacitance: u.farad,
+    SCPIMultimeter.Mode.voltage_dc:  u.volt,
+    SCPIMultimeter.Mode.voltage_ac:  u.volt,
+    SCPIMultimeter.Mode.diode:       u.volt,
+    SCPIMultimeter.Mode.current_ac:  u.amp,
+    SCPIMultimeter.Mode.current_dc:  u.amp,
+    SCPIMultimeter.Mode.resistance:  u.ohm,
+    SCPIMultimeter.Mode.fourpt_resistance: u.ohm,
+    SCPIMultimeter.Mode.frequency:   u.hertz,
+    SCPIMultimeter.Mode.period:      u.second,
+    SCPIMultimeter.Mode.temperature: u.kelvin,
     SCPIMultimeter.Mode.continuity:  1,
 }

--- a/instruments/glassman/glassmanfr.py
+++ b/instruments/glassman/glassmanfr.py
@@ -39,7 +39,7 @@ from struct import unpack
 
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import (
     PowerSupply,
@@ -74,16 +74,16 @@ class GlassmanFR(PowerSupply, PowerSupplyChannel):
     >>> psu.voltage
     array(100.0) * V
     >>> psu.output = True # Turns on the power supply
-    >>> psu.voltage_sense < 200 * pq.volt
+    >>> psu.voltage_sense < 200 * u.volt
     True
 
     This code uses default values of `voltage_max`, `current_max` and
     `polarity` that are only valid of the FR50R6 in its positive setting.
     If your power supply differs, reset those values by calling:
 
-    >>> import quantities as pq
-    >>> psu.voltage_max = 40.0 * pq.kilovolt
-    >>> psu.current_max = 7.5 * pq.milliamp
+    >>> import instruments.units as u
+    >>> psu.voltage_max = 40.0 * u.kilovolt
+    >>> psu.current_max = 7.5 * u.milliamp
     >>> psu.polarity = -1
     """
 
@@ -93,12 +93,12 @@ class GlassmanFR(PowerSupply, PowerSupplyChannel):
         """
         super(GlassmanFR, self).__init__(filelike)
         self.terminator = "\r"
-        self.voltage_max = 50.0 * pq.kilovolt
-        self.current_max = 6.0 * pq.milliamp
+        self.voltage_max = 50.0 * u.kilovolt
+        self.current_max = 6.0 * u.milliamp
         self.polarity = +1
         self._device_timeout = False
-        self._voltage = 0. * pq.volt
-        self._current = 0. * pq.amp
+        self._voltage = 0. * u.volt
+        self._current = 0. * u.amp
 
     # ENUMS ##
 
@@ -166,7 +166,7 @@ class GlassmanFR(PowerSupply, PowerSupplyChannel):
 
     @voltage.setter
     def voltage(self, newval):
-        self.set_status(voltage=assume_units(newval, pq.volt))
+        self.set_status(voltage=assume_units(newval, u.volt))
 
     @property
     def current(self):
@@ -180,7 +180,7 @@ class GlassmanFR(PowerSupply, PowerSupplyChannel):
 
     @current.setter
     def current(self, newval):
-        self.set_status(current=assume_units(newval, pq.amp))
+        self.set_status(current=assume_units(newval, u.amp))
 
     @property
     def voltage_sense(self):
@@ -334,8 +334,8 @@ class GlassmanFR(PowerSupply, PowerSupplyChannel):
         kept as what they were set to previously.
         """
         if reset:
-            self._voltage = 0. * pq.volt
-            self._current = 0. * pq.amp
+            self._voltage = 0. * u.volt
+            self._current = 0. * u.amp
             cmd = format(4, "013d")
         else:
             # The maximum value is encoded as the maximum of three hex characters (4095)
@@ -343,19 +343,19 @@ class GlassmanFR(PowerSupply, PowerSupplyChannel):
             value_max = int(0xfff)
 
             # If the voltage is not specified, keep it as is
-            voltage = assume_units(voltage, pq.volt) if voltage is not None else self.voltage
-            ratio = float(voltage.rescale(pq.volt)/self.voltage_max.rescale(pq.volt))
+            voltage = assume_units(voltage, u.volt) if voltage is not None else self.voltage
+            ratio = float(voltage.rescale(u.volt)/self.voltage_max.rescale(u.volt))
             voltage_int = int(round(value_max*ratio))
             self._voltage = self.voltage_max*float(voltage_int)/value_max
-            assert 0. * pq.volt <= self._voltage <= self.voltage_max
+            assert 0. * u.volt <= self._voltage <= self.voltage_max
             cmd += format(voltage_int, "03X")
 
             # If the current is not specified, keep it as is
-            current = assume_units(current, pq.amp) if current is not None else self.current
-            ratio = float(current.rescale(pq.amp)/self.current_max.rescale(pq.amp))
+            current = assume_units(current, u.amp) if current is not None else self.current
+            ratio = float(current.rescale(u.amp)/self.current_max.rescale(u.amp))
             current_int = int(round(value_max*ratio))
             self._current = self.current_max*float(current_int)/value_max
-            assert 0. * pq.amp <= self._current <= self.current_max
+            assert 0. * u.amp <= self._current <= self.current_max
             cmd += format(current_int, "03X")
 
             # If the output status is not specified, keep it as is

--- a/instruments/holzworth/holzworth_hs9000.py
+++ b/instruments/holzworth/holzworth_hs9000.py
@@ -9,7 +9,7 @@ Provides support for the Holzworth HS9000
 from __future__ import absolute_import
 from __future__ import division
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments.signal_generator import (
     SignalGenerator,
@@ -127,11 +127,11 @@ class HS9000(SignalGenerator):
             """
             val, units = split_unit_str(self.query("TEMP?"))
             units = "deg{}".format(units)
-            return pq.Quantity(val, units)
+            return u.Quantity(val, units)
 
         frequency, frequency_min, frequency_max = bounded_unitful_property(
             "FREQ",
-            units=pq.GHz,
+            units=u.GHz,
             doc="""
             Gets/sets the frequency of the specified channel. When setting,
             values are bounded between what is returned by `frequency_min`
@@ -169,7 +169,7 @@ class HS9000(SignalGenerator):
         )
         phase, phase_min, phase_max = bounded_unitful_property(
             "PHASE",
-            units=pq.degree,
+            units=u.degree,
             doc="""
             Gets/sets the output phase of the specified channel. When setting,
             values are bounded between what is returned by `phase_min`

--- a/instruments/hp/hp3456a.py
+++ b/instruments/hp/hp3456a.py
@@ -39,7 +39,7 @@ from builtins import range
 
 from enum import Enum, IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Multimeter
 from instruments.util_fns import assume_units, bool_property, enum_property
@@ -67,7 +67,7 @@ class HP3456a(Multimeter):
         communication.
         """
         super(HP3456a, self).__init__(filelike)
-        self.timeout = 15 * pq.second
+        self.timeout = 15 * u.second
         self.terminator = "\r"
         self.sendcmd("HO0T4SO1")
         self._null = False
@@ -298,11 +298,11 @@ class HP3456a(Multimeter):
         :rtype: `~quantaties.Quantity.s`
 
         """
-        return self._register_read(HP3456a.Register.delay) * pq.s
+        return self._register_read(HP3456a.Register.delay) * u.s
 
     @delay.setter
     def delay(self, value):
-        delay = assume_units(value, pq.s).rescale(pq.s).magnitude
+        delay = assume_units(value, u.s).rescale(u.s).magnitude
         self._register_write(HP3456a.Register.delay, delay)
 
     @property
@@ -434,13 +434,13 @@ class HP3456a(Multimeter):
                 raise ValueError("Only 'auto' is acceptable when specifying "
                                  "the input range as a string.")
 
-        elif isinstance(value, pq.quantity.Quantity):
-            if value.units == pq.volt:
+        elif isinstance(value, u.quantity.Quantity):
+            if value.units == u.volt:
                 valid = HP3456a.ValidRange.voltage.value
-                value = value.rescale(pq.volt)
-            elif value.units == pq.ohm:
+                value = value.rescale(u.volt)
+            elif value.units == u.ohm:
                 valid = HP3456a.ValidRange.resistance.value
-                value = value.rescale(pq.ohm)
+                value = value.rescale(u.ohm)
             else:
                 raise ValueError("Value {} not quantity.volt or quantity.ohm"
                                  "".format(value))
@@ -619,14 +619,14 @@ class HP3456a(Multimeter):
 
 UNITS = {
     None: 1,
-    HP3456a.Mode.dcv: pq.volt,
-    HP3456a.Mode.acv: pq.volt,
-    HP3456a.Mode.acvdcv: pq.volt,
-    HP3456a.Mode.resistance_2wire: pq.ohm,
-    HP3456a.Mode.resistance_4wire: pq.ohm,
+    HP3456a.Mode.dcv: u.volt,
+    HP3456a.Mode.acv: u.volt,
+    HP3456a.Mode.acvdcv: u.volt,
+    HP3456a.Mode.resistance_2wire: u.ohm,
+    HP3456a.Mode.resistance_4wire: u.ohm,
     HP3456a.Mode.ratio_dcv_dcv: 1,
     HP3456a.Mode.ratio_acv_dcv: 1,
     HP3456a.Mode.ratio_acvdcv_dcv: 1,
-    HP3456a.Mode.oc_resistence_2wire: pq.ohm,
-    HP3456a.Mode.oc_resistence_4wire: pq.ohm,
+    HP3456a.Mode.oc_resistence_2wire: u.ohm,
+    HP3456a.Mode.oc_resistence_4wire: u.ohm,
 }

--- a/instruments/hp/hp6624a.py
+++ b/instruments/hp/hp6624a.py
@@ -12,7 +12,7 @@ from __future__ import division
 from builtins import range
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import (
     PowerSupply,
@@ -111,7 +111,7 @@ class HP6624a(PowerSupply):
 
         voltage = unitful_property(
             "VSET",
-            pq.volt,
+            u.volt,
             set_fmt="{} {:.1f}",
             output_decoration=float,
             doc="""
@@ -127,7 +127,7 @@ class HP6624a(PowerSupply):
 
         current = unitful_property(
             "ISET",
-            pq.amp,
+            u.amp,
             set_fmt="{} {:.1f}",
             output_decoration=float,
             doc="""
@@ -143,7 +143,7 @@ class HP6624a(PowerSupply):
 
         voltage_sense = unitful_property(
             "VOUT",
-            pq.volt,
+            u.volt,
             readonly=True,
             doc="""
             Gets the actual voltage as measured by the sense wires for the
@@ -156,7 +156,7 @@ class HP6624a(PowerSupply):
 
         current_sense = unitful_property(
             "IOUT",
-            pq.amp,
+            u.amp,
             readonly=True,
             doc="""
             Gets the actual output current as measured by the instrument for
@@ -169,7 +169,7 @@ class HP6624a(PowerSupply):
 
         overvoltage = unitful_property(
             "OVSET",
-            pq.volt,
+            u.volt,
             set_fmt="{} {:.1f}",
             output_decoration=float,
             doc="""

--- a/instruments/hp/hp6632b.py
+++ b/instruments/hp/hp6632b.py
@@ -37,7 +37,7 @@ from __future__ import division
 from builtins import range
 
 from enum import Enum, IntEnum
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi.scpi_instrument import SCPIInstrument
 from instruments.hp.hp6652a import HP6652a
@@ -259,7 +259,7 @@ class HP6632b(SCPIInstrument, HP6652a):
 
     voltage_trigger = unitful_property(
         "VOLT:TRIG",
-        pq.volt,
+        u.volt,
         doc="""
         Gets/sets the pending triggered output voltage.
 
@@ -272,7 +272,7 @@ class HP6632b(SCPIInstrument, HP6652a):
 
     current_trigger = unitful_property(
         "CURR:TRIG",
-        pq.amp,
+        u.amp,
         doc="""
         Gets/sets the pending triggered output current.
 
@@ -299,7 +299,7 @@ class HP6632b(SCPIInstrument, HP6652a):
 
     current_sense_range = unitful_property(
         'SENS:CURR:RANGE',
-        pq.ampere,
+        u.ampere,
         doc="""
         Get/set the sense current range by the current max value.
 
@@ -379,7 +379,7 @@ class HP6632b(SCPIInstrument, HP6652a):
 
     sense_sweep_interval = unitful_property(
         "SENS:SWE:TINT",
-        pq.second,
+        u.second,
         doc="""
         Get/set the digitizer sample spacing. Can be set from 15.6 us to 31200
         seconds, the interval will be rounded to the nearest 15.6 us increment.
@@ -401,7 +401,7 @@ class HP6632b(SCPIInstrument, HP6652a):
 
     output_protection_delay = unitful_property(
         "OUTP:PROT:DEL",
-        pq.second,
+        u.second,
         doc="""
         Get/set the time between programming of an output change that produces
         a constant current condition and the recording of that condigition in

--- a/instruments/hp/hp6652a.py
+++ b/instruments/hp/hp6652a.py
@@ -11,7 +11,7 @@ Originally contributed by Wil Langford (wil.langford+instrumentkit@gmail.com)
 from __future__ import absolute_import
 from __future__ import division
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import (PowerSupply, PowerSupplyChannel)
 from instruments.util_fns import unitful_property, bool_property
@@ -64,7 +64,7 @@ class HP6652a(PowerSupply, PowerSupplyChannel):
 
     voltage = unitful_property(
         "VOLT",
-        pq.volt,
+        u.volt,
         doc="""
         Gets/sets the output voltage.
 
@@ -77,7 +77,7 @@ class HP6652a(PowerSupply, PowerSupplyChannel):
 
     current = unitful_property(
         "CURR",
-        pq.amp,
+        u.amp,
         doc="""
         Gets/sets the output current.
 
@@ -90,7 +90,7 @@ class HP6652a(PowerSupply, PowerSupplyChannel):
 
     voltage_sense = unitful_property(
         "MEAS:VOLT",
-        pq.volt,
+        u.volt,
         readonly=True,
         doc="""
         Gets the actual output voltage as measured by the sense wires.
@@ -102,7 +102,7 @@ class HP6652a(PowerSupply, PowerSupplyChannel):
 
     current_sense = unitful_property(
         "MEAS:CURR",
-        pq.amp,
+        u.amp,
         readonly=True,
         doc="""
         Gets the actual output current as measured by the sense wires.
@@ -114,7 +114,7 @@ class HP6652a(PowerSupply, PowerSupplyChannel):
 
     overvoltage = unitful_property(
         "VOLT:PROT",
-        pq.volt,
+        u.volt,
         doc="""
         Gets/sets the overvoltage protection setting in volts.
 

--- a/instruments/hp/hpe3631a.py
+++ b/instruments/hp/hpe3631a.py
@@ -37,7 +37,7 @@ from __future__ import absolute_import
 from __future__ import division
 import time
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import (
     PowerSupply,
@@ -164,7 +164,7 @@ class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
         :type: `float` or `~quantities.Quantity`
         """
         raw = self.query("SOUR:VOLT?")
-        return pq.Quantity(*split_unit_str(raw, pq.volt)).rescale(pq.volt)
+        return u.Quantity(*split_unit_str(raw, u.volt)).rescale(u.volt)
 
     @voltage.setter
     def voltage(self, newval):
@@ -185,7 +185,7 @@ class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
 
         # Rescale to the correct unit before printing. This will also
         # catch bad units.
-        strval = "{:e}".format(assume_units(newval, pq.volt).rescale(pq.volt).item())
+        strval = "{:e}".format(assume_units(newval, u.volt).rescale(u.volt).item())
         self.sendcmd('SOUR:VOLT {}'.format(strval))
 
     @property
@@ -221,14 +221,14 @@ class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
         :units: :math:`\\text{V}`.
         :type: array of `~quantities.Quantity`
         """
-        value = pq.Quantity(*split_unit_str(self.query("SOUR:VOLT? MAX"), pq.volt))
+        value = u.Quantity(*split_unit_str(self.query("SOUR:VOLT? MAX"), u.volt))
         if value < 0.:
             return value, 0.
         return 0., value
 
     current, current_min, current_max = bounded_unitful_property(
         "SOUR:CURR",
-        pq.amp,
+        u.amp,
         min_fmt_str="{}? MIN",
         max_fmt_str="{}? MAX",
         doc="""
@@ -241,7 +241,7 @@ class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
 
     voltage_sense = unitful_property(
         "MEAS:VOLT",
-        pq.volt,
+        u.volt,
         readonly=True,
         doc="""
         Gets the actual output voltage as measured by the sense wires.
@@ -253,7 +253,7 @@ class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
 
     current_sense = unitful_property(
         "MEAS:CURR",
-        pq.amp,
+        u.amp,
         readonly=True,
         doc="""
         Gets the actual output current as measured by the sense wires.

--- a/instruments/keithley/keithley195.py
+++ b/instruments/keithley/keithley195.py
@@ -13,7 +13,7 @@ import time
 import struct
 from enum import Enum, IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Multimeter
 
@@ -29,7 +29,7 @@ class Keithley195(Multimeter):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> dmm = ik.keithley.Keithley195.open_gpibusb('/dev/ttyUSB0', 12)
     >>> print dmm.measure(dmm.Mode.resistance)
 
@@ -210,7 +210,7 @@ class Keithley195(Multimeter):
             else:
                 raise ValueError('Only "auto" is acceptable when specifying '
                                  'the input range as a string.')
-        if isinstance(newval, pq.quantity.Quantity):
+        if isinstance(newval, u.quantity.Quantity):
             newval = float(newval)
 
         mode = self.mode
@@ -246,7 +246,7 @@ class Keithley195(Multimeter):
         Example usage:
 
         >>> import instruments as ik
-        >>> import quantities as pq
+        >>> import instruments.units as u
         >>> dmm = ik.keithley.Keithley195.open_gpibusb('/dev/ttyUSB0', 12)
         >>> print(dmm.measure(dmm.Mode.resistance))
 
@@ -341,17 +341,17 @@ class Keithley195(Multimeter):
 # UNITS #######################################################################
 
 UNITS = {
-    'DCV':  pq.volt,
-    'ACV':  pq.volt,
-    'ACA':  pq.amp,
-    'DCA':  pq.amp,
-    'OHM':  pq.ohm,
+    'DCV':  u.volt,
+    'ACV':  u.volt,
+    'ACA':  u.amp,
+    'DCA':  u.amp,
+    'OHM':  u.ohm,
 }
 
 UNITS2 = {
-    Keithley195.Mode.voltage_dc:  pq.volt,
-    Keithley195.Mode.voltage_ac:  pq.volt,
-    Keithley195.Mode.current_dc:  pq.amp,
-    Keithley195.Mode.current_ac:  pq.amp,
-    Keithley195.Mode.resistance:  pq.ohm,
+    Keithley195.Mode.voltage_dc:  u.volt,
+    Keithley195.Mode.voltage_ac:  u.volt,
+    Keithley195.Mode.current_dc:  u.amp,
+    Keithley195.Mode.current_ac:  u.amp,
+    Keithley195.Mode.resistance:  u.ohm,
 }

--- a/instruments/keithley/keithley2182.py
+++ b/instruments/keithley/keithley2182.py
@@ -11,7 +11,7 @@ from __future__ import division
 from builtins import range, map
 
 from enum import Enum
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIMultimeter
 from instruments.abstract_instruments import Multimeter
@@ -190,14 +190,14 @@ class Keithley2182(SCPIMultimeter):
         """
         mode = self.channel[0].mode
         if mode == Keithley2182.Mode.voltage_dc:
-            return pq.volt
+            return u.volt
         unit = self.query("UNIT:TEMP?")
         if unit == "C":
-            unit = pq.celsius
+            unit = u.celsius
         elif unit == "K":
-            unit = pq.kelvin
+            unit = u.kelvin
         elif unit == "F":
-            unit = pq.fahrenheit
+            unit = u.fahrenheit
         else:
             raise ValueError("Unknown temperature units.")
         return unit

--- a/instruments/keithley/keithley485.py
+++ b/instruments/keithley/keithley485.py
@@ -40,7 +40,7 @@ from struct import unpack
 
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 
@@ -192,7 +192,7 @@ class Keithley485(Instrument):
         value = self.get_status()["range"]
         if isinstance(value, str):
             return value
-        return value * pq.amp
+        return value * u.amp
 
     @input_range.setter
     def input_range(self, newval):
@@ -205,7 +205,7 @@ class Keithley485(Instrument):
             else:
                 raise ValueError("Only `auto` is acceptable when specifying "
                                  "the range as a string.")
-        if isinstance(newval, pq.quantity.Quantity):
+        if isinstance(newval, u.quantity.Quantity):
             newval = float(newval)
 
         if isinstance(newval, (float, int)):
@@ -422,7 +422,7 @@ class Keithley485(Instrument):
                 raise ValueError("Instrument not in normal mode: {}".format(status.name))
             if function != b"DC":
                 raise ValueError("Instrument not returning DC function: {}".format(function))
-            current = float(current) * pq.amp if base == b"A" else 10 ** (float(current)) * pq.amp
+            current = float(current) * u.amp if base == b"A" else 10 ** (float(current)) * u.amp
         except:
             raise Exception("Cannot parse measurement: {}".format(measurement))
 

--- a/instruments/keithley/keithley580.py
+++ b/instruments/keithley/keithley580.py
@@ -40,7 +40,7 @@ import struct
 
 from enum import IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 
@@ -265,7 +265,7 @@ class Keithley580(Instrument):
         :type: `~quantities.quantity.Quantity` or `str`
         """
         value = float(self.parse_status_word(self.get_status_word())['range'])
-        return value * pq.ohm
+        return value * u.ohm
 
     @input_range.setter
     def input_range(self, newval):
@@ -278,7 +278,7 @@ class Keithley580(Instrument):
             else:
                 raise ValueError('Only "auto" is acceptable when specifying '
                                  'the input range as a string.')
-        if isinstance(newval, pq.quantity.Quantity):
+        if isinstance(newval, u.quantity.Quantity):
             newval = float(newval)
 
         if isinstance(newval, (float, int)):
@@ -451,7 +451,7 @@ class Keithley580(Instrument):
             polarity = valid['polarity'][polarity]
             drycircuit = valid['drycircuit'][drycircuit]
             drive = valid['drive'][drive]
-            resistance = float(resistance) * pq.ohm
+            resistance = float(resistance) * u.ohm
         except:
             raise Exception('Cannot parse measurement: {}'.format(measurement))
 

--- a/instruments/keithley/keithley6220.py
+++ b/instruments/keithley/keithley6220.py
@@ -9,7 +9,7 @@ Provides support for the Keithley 6220 constant current supply
 from __future__ import absolute_import
 from __future__ import division
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import PowerSupply
 from instruments.generic_scpi import SCPIInstrument
@@ -28,10 +28,10 @@ class Keithley6220(SCPIInstrument, PowerSupply):
 
     Example usage:
 
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> import instruments as ik
     >>> ccs = ik.keithley.Keithley6220.open_gpibusb("/dev/ttyUSB0", 10)
-    >>> ccs.current = 10 * pq.milliamp # Sets current to 10mA
+    >>> ccs.current = 10 * u.milliamp # Sets current to 10mA
     >>> ccs.disable() # Turns off the output and sets the current to 0A
     """
 
@@ -68,8 +68,8 @@ class Keithley6220(SCPIInstrument, PowerSupply):
 
     current, current_min, current_max = bounded_unitful_property(
         "SOUR:CURR",
-        pq.amp,
-        valid_range=(-105 * pq.milliamp, +105 * pq.milliamp),
+        u.amp,
+        valid_range=(-105 * u.milliamp, +105 * u.milliamp),
         doc="""
         Gets/sets the output current of the source. Value must be between
         -105mA and +105mA.

--- a/instruments/keithley/keithley6514.py
+++ b/instruments/keithley/keithley6514.py
@@ -12,7 +12,7 @@ from builtins import map
 
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Electrometer
 from instruments.generic_scpi import SCPIInstrument
@@ -30,7 +30,7 @@ class Keithley6514(SCPIInstrument, Electrometer):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> dmm = ik.keithley.Keithley6514.open_gpibusb('/dev/ttyUSB0', 12)
     """
 
@@ -78,10 +78,10 @@ class Keithley6514(SCPIInstrument, Electrometer):
     # CONSTANTS #
 
     _MODE_UNITS = {
-        Mode.voltage: pq.volt,
-        Mode.current: pq.amp,
-        Mode.resistance: pq.ohm,
-        Mode.charge: pq.coulomb
+        Mode.voltage: u.volt,
+        Mode.current: u.amp,
+        Mode.resistance: u.ohm,
+        Mode.charge: u.coulomb
     }
 
     # PRIVATE METHODS #

--- a/instruments/lakeshore/lakeshore340.py
+++ b/instruments/lakeshore/lakeshore340.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import ProxyList
@@ -26,7 +26,7 @@ class Lakeshore340(SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> inst = ik.lakeshore.Lakeshore340.open_gpibusb('/dev/ttyUSB0', 1)
     >>> print(inst.sensor[0].temperature)
     >>> print(inst.sensor[1].temperature)
@@ -58,7 +58,7 @@ class Lakeshore340(SCPIInstrument):
             :type: `~quantities.quantity.Quantity`
             """
             value = self._parent.query('KRDG?{}'.format(self._idx))
-            return pq.Quantity(float(value), pq.Kelvin)
+            return u.Quantity(float(value), u.Kelvin)
 
     # PROPERTIES ##
 

--- a/instruments/lakeshore/lakeshore370.py
+++ b/instruments/lakeshore/lakeshore370.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import ProxyList
@@ -62,7 +62,7 @@ class Lakeshore370(SCPIInstrument):
             :rtype: `~quantities.quantity.Quantity`
             """
             value = self._parent.query('RDGR? {}'.format(self._idx))
-            return pq.Quantity(float(value), pq.ohm)
+            return u.Quantity(float(value), u.ohm)
 
     # PROPERTIES ##
 

--- a/instruments/lakeshore/lakeshore475.py
+++ b/instruments/lakeshore/lakeshore475.py
@@ -12,7 +12,7 @@ from __future__ import division
 from builtins import range
 from enum import IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import assume_units, bool_property
@@ -20,15 +20,15 @@ from instruments.util_fns import assume_units, bool_property
 # CONSTANTS ###################################################################
 
 LAKESHORE_FIELD_UNITS = {
-    1: pq.gauss,
-    2: pq.tesla,
-    3: pq.oersted,
-    4: pq.CompoundUnit('A/m')
+    1: u.gauss,
+    2: u.tesla,
+    3: u.oersted,
+    4: u.CompoundUnit('A/m')
 }
 
 LAKESHORE_TEMP_UNITS = {
-    1: pq.celsius,
-    2: pq.kelvin
+    1: u.celsius,
+    2: u.kelvin
 }
 
 LAKESHORE_FIELD_UNITS_INV = dict((v, k) for k, v in
@@ -47,11 +47,11 @@ class Lakeshore475(SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> gm = ik.lakeshore.Lakeshore475.open_gpibusb('/dev/ttyUSB0', 1)
     >>> print(gm.field)
-    >>> gm.field_units = pq.tesla
-    >>> gm.field_setpoint = 0.05 * pq.tesla
+    >>> gm.field_units = u.tesla
+    >>> gm.field_setpoint = 0.05 * u.tesla
     """
 
     # ENUMS ##
@@ -112,7 +112,7 @@ class Lakeshore475(SCPIInstrument):
 
     @field_units.setter
     def field_units(self, newval):
-        if isinstance(newval, pq.unitquantity.UnitQuantity):
+        if isinstance(newval, u.unitquantity.UnitQuantity):
             if newval in LAKESHORE_FIELD_UNITS_INV:
                 self.sendcmd('UNIT ' + LAKESHORE_FIELD_UNITS_INV[newval])
             else:
@@ -134,7 +134,7 @@ class Lakeshore475(SCPIInstrument):
 
     @temp_units.setter
     def temp_units(self, newval):
-        if isinstance(newval, pq.unitquantity.UnitQuantity):
+        if isinstance(newval, u.unitquantity.UnitQuantity):
             if newval in LAKESHORE_TEMP_UNITS_INV:
                 self.sendcmd('TUNIT ' + LAKESHORE_TEMP_UNITS_INV[newval])
             else:
@@ -158,7 +158,7 @@ class Lakeshore475(SCPIInstrument):
     @field_setpoint.setter
     def field_setpoint(self, newval):
         units = self.field_units
-        newval = float(assume_units(newval, pq.gauss).rescale(units).magnitude)
+        newval = float(assume_units(newval, u.gauss).rescale(units).magnitude)
         self.sendcmd('CSETP {}'.format(newval))
 
     @property
@@ -171,8 +171,8 @@ class Lakeshore475(SCPIInstrument):
         """
         params = self.query('CPARAM?').strip().split(',')
         params = [float(x) for x in params]
-        params[2] = params[2] * self.field_units / pq.minute
-        params[3] = params[3] * pq.volt / pq.minute
+        params[2] = params[2] * self.field_units / u.minute
+        params[3] = params[3] * u.volt / u.minute
         return tuple(params)
 
     @field_control_params.setter
@@ -184,10 +184,10 @@ class Lakeshore475(SCPIInstrument):
         newval[0] = float(newval[0])
         newval[1] = float(newval[1])
 
-        unit = self.field_units / pq.minute
+        unit = self.field_units / u.minute
         newval[2] = float(
             assume_units(newval[2], unit).rescale(unit).magnitude)
-        unit = pq.volt / pq.minute
+        unit = u.volt / u.minute
         newval[3] = float(
             assume_units(newval[3], unit).rescale(unit).magnitude)
 
@@ -243,7 +243,7 @@ class Lakeshore475(SCPIInstrument):
 
     @ramp_rate.setter
     def ramp_rate(self, newval):
-        unit = self.field_units / pq.minute
+        unit = self.field_units / u.minute
         newval = float(assume_units(newval, unit).rescale(unit).magnitude)
         values = list(self.field_control_params)
         values[2] = newval
@@ -262,7 +262,7 @@ class Lakeshore475(SCPIInstrument):
 
     @control_slope_limit.setter
     def control_slope_limit(self, newval):
-        unit = pq.volt / pq.minute
+        unit = u.volt / u.minute
         newval = float(assume_units(newval, unit).rescale(unit).magnitude)
         values = list(self.field_control_params)
         values[3] = newval

--- a/instruments/minghe/mhs5200a.py
+++ b/instruments/minghe/mhs5200a.py
@@ -14,7 +14,7 @@ from __future__ import division
 from builtins import range
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 from instruments.abstract_instruments import FunctionGenerator
 from instruments.util_fns import ProxyList, assume_units
 
@@ -70,7 +70,7 @@ class MHS5200(FunctionGenerator):
         def _set_amplitude_(self, magnitude, units):
             if units == self._mhs.VoltageMode.peak_to_peak or \
                             units == self._mhs.VoltageMode.rms:
-                magnitude = assume_units(magnitude, "V").rescale(pq.V).magnitude
+                magnitude = assume_units(magnitude, "V").rescale(u.V).magnitude
             elif units == self._mhs.VoltageMode.dBm:
                 raise NotImplementedError("Decibel units are not supported.")
             magnitude *= 100
@@ -122,12 +122,12 @@ class MHS5200(FunctionGenerator):
             """
             query = ":r{0}f".format(self._chan)
             response = self._mhs.query(query)
-            freq = float(response.replace(query, ""))*pq.Hz
+            freq = float(response.replace(query, ""))*u.Hz
             return freq/100.0
 
         @frequency.setter
         def frequency(self, new_val):
-            new_val = assume_units(new_val, pq.Hz).rescale(pq.Hz).\
+            new_val = assume_units(new_val, u.Hz).rescale(u.Hz).\
                           magnitude*100.0
             query = ":s{0}f{1}".format(self._chan, int(new_val))
             self._mhs.sendcmd(query)
@@ -164,11 +164,11 @@ class MHS5200(FunctionGenerator):
             # need to convert
             query = ":r{0}p".format(self._chan)
             response = self._mhs.query(query)
-            return int(response.replace(query, ""))*pq.deg
+            return int(response.replace(query, ""))*u.deg
 
         @phase.setter
         def phase(self, new_val):
-            new_val = assume_units(new_val, pq.deg).rescale("deg").magnitude
+            new_val = assume_units(new_val, u.deg).rescale("deg").magnitude
             query = ":s{0}p{1}".format(self._chan, int(new_val))
             self._mhs.sendcmd(query)
 

--- a/instruments/newport/newportesp301.py
+++ b/instruments/newport/newportesp301.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 from builtins import range, map
 from enum import IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 from instruments.newport.errors import NewportError
@@ -304,7 +304,7 @@ class NewportESP301Axis(object):
     returned by `NewportESP301.axis`.
     """
     # quantities micro inch
-    micro_inch = pq.UnitQuantity('micro-inch', pq.inch / 1e6, symbol='uin')
+    micro_inch = u.UnitQuantity('micro-inch', u.inch / 1e6, symbol='uin')
 
     # Some more work might need to be done here to make
     # the encoder_step and motor_step functional
@@ -312,18 +312,18 @@ class NewportESP301Axis(object):
     # going to do this until I have a physical device
 
     _unit_dict = {
-        0:  pq.count,
-        1:  pq.count,
-        2:  pq.mm,
-        3:  pq.um,
-        4:  pq.inch,
-        5:  pq.mil,
+        0:  u.count,
+        1:  u.count,
+        2:  u.mm,
+        3:  u.um,
+        4:  u.inch,
+        5:  u.mil,
         6:  micro_inch,  # compound unit for micro-inch
-        7:  pq.deg,
-        8:  pq.grad,
-        9:  pq.rad,
-        10:  pq.mrad,
-        11:  pq.urad,
+        7:  u.deg,
+        8:  u.grad,
+        9:  u.rad,
+        10:  u.mrad,
+        11:  u.urad,
     }
 
     def __init__(self, controller, axis_id):
@@ -405,15 +405,15 @@ class NewportESP301Axis(object):
 
         return assume_units(
             float(self._newport_cmd("AC?", target=self.axis_id)),
-            self._units / (pq.s**2)
+            self._units / (u.s**2)
         )
 
     @acceleration.setter
     def acceleration(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / (pq.s**2)).rescale(
-            self._units / (pq.s**2)).magnitude)
+        newval = float(assume_units(newval, self._units / (u.s**2)).rescale(
+            self._units / (u.s**2)).magnitude)
         self._newport_cmd("AC", target=self.axis_id, params=[newval])
 
     @property
@@ -427,15 +427,15 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("AG?", target=self.axis_id)),
-            self._units / (pq.s**2)
+            self._units / (u.s**2)
         )
 
     @deceleration.setter
     def deceleration(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / (pq.s**2)).rescale(
-            self._units / (pq.s**2)).magnitude)
+        newval = float(assume_units(newval, self._units / (u.s**2)).rescale(
+            self._units / (u.s**2)).magnitude)
         self._newport_cmd("AG", target=self.axis_id, params=[newval])
 
     @property
@@ -449,13 +449,13 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("AE?", target=self.axis_id)),
-            self._units / (pq.s**2)
+            self._units / (u.s**2)
         )
 
     @estop_deceleration.setter
     def estop_deceleration(self, decel):
-        decel = float(assume_units(decel, self._units / (pq.s**2)).rescale(
-            self._units / (pq.s**2)).magnitude)
+        decel = float(assume_units(decel, self._units / (u.s**2)).rescale(
+            self._units / (u.s**2)).magnitude)
         self._newport_cmd("AE", target=self.axis_id, params=[decel])
 
     @property
@@ -470,13 +470,13 @@ class NewportESP301Axis(object):
 
         return assume_units(
             float(self._newport_cmd("JK?", target=self.axis_id)),
-            self._units / (pq.s**3)
+            self._units / (u.s**3)
         )
 
     @jerk.setter
     def jerk(self, jerk):
-        jerk = float(assume_units(jerk, self._units / (pq.s**3)).rescale(
-            self._units / (pq.s**3)).magnitude)
+        jerk = float(assume_units(jerk, self._units / (u.s**3)).rescale(
+            self._units / (u.s**3)).magnitude)
         self._newport_cmd("JK", target=self.axis_id, params=[jerk])
 
     @property
@@ -490,13 +490,13 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("VA?", target=self.axis_id)),
-            self._units / pq.s
+            self._units / u.s
         )
 
     @velocity.setter
     def velocity(self, velocity):
-        velocity = float(assume_units(velocity, self._units / (pq.s)).rescale(
-            self._units / pq.s).magnitude)
+        velocity = float(assume_units(velocity, self._units / (u.s)).rescale(
+            self._units / u.s).magnitude)
         self._newport_cmd("VA", target=self.axis_id, params=[velocity])
 
     @property
@@ -510,15 +510,15 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("VU?", target=self.axis_id)),
-            self._units / pq.s
+            self._units / u.s
         )
 
     @max_velocity.setter
     def max_velocity(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / pq.s).rescale(
-            self._units / pq.s).magnitude)
+        newval = float(assume_units(newval, self._units / u.s).rescale(
+            self._units / u.s).magnitude)
         self._newport_cmd("VU", target=self.axis_id, params=[newval])
 
     @property
@@ -532,15 +532,15 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("VB?", target=self.axis_id)),
-            self._units / pq.s
+            self._units / u.s
         )
 
     @max_base_velocity.setter
     def max_base_velocity(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / pq.s).rescale(
-            self._units / pq.s).magnitude)
+        newval = float(assume_units(newval, self._units / u.s).rescale(
+            self._units / u.s).magnitude)
         self._newport_cmd("VB", target=self.axis_id, params=[newval])
 
     @property
@@ -554,7 +554,7 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("JH?", target=self.axis_id)),
-            self._units / pq.s
+            self._units / u.s
         )
 
     @jog_high_velocity.setter
@@ -563,8 +563,8 @@ class NewportESP301Axis(object):
             return
         newval = float(assume_units(
             newval,
-            self._units / pq.s
-        ).rescale(self._units / pq.s).magnitude)
+            self._units / u.s
+        ).rescale(self._units / u.s).magnitude)
         self._newport_cmd("JH", target=self.axis_id, params=[newval])
 
     @property
@@ -578,7 +578,7 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("JW?", target=self.axis_id)),
-            self._units / pq.s
+            self._units / u.s
         )
 
     @jog_low_velocity.setter
@@ -587,8 +587,8 @@ class NewportESP301Axis(object):
             return
         newval = float(assume_units(
             newval,
-            self._units / pq.s
-        ).rescale(self._units / pq.s).magnitude)
+            self._units / u.s
+        ).rescale(self._units / u.s).magnitude)
         self._newport_cmd("JW", target=self.axis_id, params=[newval])
 
     @property
@@ -602,7 +602,7 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("OH?", target=self.axis_id)),
-            self._units / pq.s
+            self._units / u.s
         )
 
     @homing_velocity.setter
@@ -611,8 +611,8 @@ class NewportESP301Axis(object):
             return
         newval = float(assume_units(
             newval,
-            self._units / pq.s
-        ).rescale(self._units / pq.s).magnitude)
+            self._units / u.s
+        ).rescale(self._units / u.s).magnitude)
         self._newport_cmd("OH", target=self.axis_id, params=[newval])
 
     @property
@@ -626,15 +626,15 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("AU?", target=self.axis_id)),
-            self._units / (pq.s**2)
+            self._units / (u.s**2)
         )
 
     @max_acceleration.setter
     def max_acceleration(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / (pq.s**2)).rescale(
-            self._units / (pq.s**2)).magnitude)
+        newval = float(assume_units(newval, self._units / (u.s**2)).rescale(
+            self._units / (u.s**2)).magnitude)
         self._newport_cmd("AU", target=self.axis_id, params=[newval])
 
     @property
@@ -651,8 +651,8 @@ class NewportESP301Axis(object):
 
     @max_deceleration.setter
     def max_deceleration(self, decel):
-        decel = float(assume_units(decel, self._units / (pq.s**2)).rescale(
-            self._units / (pq.s**2)).magnitude)
+        decel = float(assume_units(decel, self._units / (u.s**2)).rescale(
+            self._units / (u.s**2)).magnitude)
         self.max_acceleration = decel
 
     @property
@@ -694,7 +694,7 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("DP?", target=self.axis_id)),
-            self._units / pq.s
+            self._units / u.s
         )
 
     @property
@@ -738,7 +738,7 @@ class NewportESP301Axis(object):
             return
         if isinstance(newval, int):
             self._units = self._get_pq_unit(NewportESP301Units(int(newval)))
-        elif isinstance(newval, pq.Quantity):
+        elif isinstance(newval, u.Quantity):
             self._units = newval
             newval = self._get_unit_num(newval)
         self._set_units(newval)
@@ -863,15 +863,15 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("QI?", target=self.axis_id)),
-            pq.A
+            u.A
         )
 
     @current.setter
     def current(self, newval):
         if newval is None:
             return
-        current = float(assume_units(newval, pq.A).rescale(
-            pq.A).magnitude)
+        current = float(assume_units(newval, u.A).rescale(
+            u.A).magnitude)
         self._newport_cmd("QI", target=self.axis_id, params=[current])
 
     @property
@@ -885,15 +885,15 @@ class NewportESP301Axis(object):
         """
         return assume_units(
             float(self._newport_cmd("QV?", target=self.axis_id)),
-            pq.V
+            u.V
         )
 
     @voltage.setter
     def voltage(self, newval):
         if newval is None:
             return
-        voltage = float(assume_units(newval, pq.V).rescale(
-            pq.V).magnitude)
+        voltage = float(assume_units(newval, u.V).rescale(
+            u.V).magnitude)
         self._newport_cmd("QV", target=self.axis_id, params=[voltage])
 
     @property
@@ -1192,10 +1192,10 @@ class NewportESP301Axis(object):
         #        In programming mode, the "WS" command should be
         #        sent instead, and the two parameters to this method should
         #        be ignored.
-        poll_interval = float(assume_units(poll_interval, pq.s).rescale(
-            pq.s).magnitude)
-        max_wait = float(assume_units(max_wait, pq.s).rescale(
-            pq.s).magnitude)
+        poll_interval = float(assume_units(poll_interval, u.s).rescale(
+            u.s).magnitude)
+        max_wait = float(assume_units(max_wait, u.s).rescale(
+            u.s).magnitude)
         tic = time()
         while True:
             if self.is_motion_done:
@@ -1282,12 +1282,12 @@ class NewportESP301Axis(object):
                                                        'configuration')
         if 'reduce_motor_torque_time' in kwargs and 'reduce_motor_torque_percentage' in kwargs:
             motor_time = kwargs['reduce_motor_torque_time']
-            motor_time = int(assume_units(motor_time, pq.ms).rescale(pq.ms).magnitude)
+            motor_time = int(assume_units(motor_time, u.ms).rescale(u.ms).magnitude)
             if motor_time < 0 or motor_time > 60000:
                 raise ValueError("Time must be between 0 and 60000 ms")
             percentage = kwargs['reduce_motor_torque_percentage']
-            percentage = int(assume_units(percentage, pq.percent).rescale(
-                pq.percent).magnitude)
+            percentage = int(assume_units(percentage, u.percent).rescale(
+                u.percent).magnitude)
             if percentage < 0 or percentage > 100:
                 raise ValueError("Time must be between 0 and 60000 ms")
             self._newport_cmd(

--- a/instruments/ondax/lm.py
+++ b/instruments/ondax/lm.py
@@ -13,7 +13,7 @@ from __future__ import division
 
 from enum import IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import convert_temperature, assume_units
@@ -85,7 +85,7 @@ class LM(Instrument):
             :type: `~quantities.Quantity`
             """
             response = float(self._parent.query("rstli?"))
-            return response*pq.mA
+            return response*u.mA
 
         @property
         def enabled(self):
@@ -174,7 +174,7 @@ class LM(Instrument):
             :type: `~quantities.Quantities`
             """
             response = self._parent.query("rslp?")
-            return float(response)*pq.mW
+            return float(response)*u.mW
 
         @property
         def enabled(self):
@@ -254,10 +254,10 @@ class LM(Instrument):
             Example usage:
 
             >>> import instruments as ik
-            >>> import quantities as pq
+            >>> import instruments.units as u
             >>> laser = ik.ondax.LM.open_serial('/dev/ttyUSB0', baud=1234)
             >>> print(laser.modulation.on_time)
-            >>> laser.modulation.on_time = 1 * pq.ms
+            >>> laser.modulation.on_time = 1 * u.ms
 
             :return: The TTL modulation on time
             :units: As specified (if a `~quantities.Quantity`) or assumed
@@ -265,11 +265,11 @@ class LM(Instrument):
             :type: `~quantities.Quantity`
             """
             response = self._parent.query("stsont?")
-            return float(response)*pq.ms
+            return float(response)*u.ms
 
         @on_time.setter
         def on_time(self, newval):
-            newval = assume_units(newval, pq.ms).rescale(pq.ms).magnitude
+            newval = assume_units(newval, u.ms).rescale(u.ms).magnitude
             self._parent.sendcmd("stsont:"+str(newval))
 
         @property
@@ -282,10 +282,10 @@ class LM(Instrument):
             Example usage:
 
             >>> import instruments as ik
-            >>> import quantities as pq
+            >>> import instruments.units as u
             >>> laser = ik.ondax.LM.open_serial('/dev/ttyUSB0', baud=1234)
             >>> print(laser.modulation.on_time)
-            >>> laser.modulation.on_time = 1 * pq.ms
+            >>> laser.modulation.on_time = 1 * u.ms
 
             :return: The TTL modulation off time.
             :units: As specified (if a `~quantities.Quantity`) or assumed
@@ -293,11 +293,11 @@ class LM(Instrument):
             :type: `~quantities.Quantity`
             """
             response = self._parent.query("stsofft?")
-            return float(response)*pq.ms
+            return float(response)*u.ms
 
         @off_time.setter
         def off_time(self, newval):
-            newval = assume_units(newval, pq.ms).rescale(pq.ms).magnitude
+            newval = assume_units(newval, u.ms).rescale(u.ms).magnitude
             self._parent.sendcmd("stsofft:"+str(newval))
 
         @property
@@ -358,7 +358,7 @@ class LM(Instrument):
             :type: `~quantities.Quantity`
             """
             response = self._parent.query("rti?")
-            return float(response)*pq.mA
+            return float(response)*u.mA
 
         @property
         def target(self):
@@ -377,7 +377,7 @@ class LM(Instrument):
             :type: `~quantities.Quantity`
             """
             response = self._parent.query("rstt?")
-            return float(response)*pq.degC
+            return float(response)*u.degC
 
         @property
         def enabled(self):
@@ -434,11 +434,11 @@ class LM(Instrument):
         :type: `~quantities.Quantity`
         """
         response = self.query("rli?")
-        return float(response)*pq.mA
+        return float(response)*u.mA
 
     @current.setter
     def current(self, newval):
-        newval = assume_units(newval, pq.mA).rescale(pq.mA).magnitude
+        newval = assume_units(newval, u.mA).rescale(u.mA).magnitude
         self.sendcmd("slc:"+str(newval))
 
     @property
@@ -452,11 +452,11 @@ class LM(Instrument):
         :type: `~quantities.Quantity`
         """
         response = self.query("rlcm?")
-        return float(response)*pq.mA
+        return float(response)*u.mA
 
     @maximum_current.setter
     def maximum_current(self, newval):
-        newval = assume_units(newval, pq.mA).rescale('mA').magnitude
+        newval = assume_units(newval, u.mA).rescale('mA').magnitude
         self.sendcmd("smlc:" + str(newval))
 
     @property
@@ -469,11 +469,11 @@ class LM(Instrument):
         :rtype: `~quantities.Quantity`
         """
         response = self.query("rlp?")
-        return float(response)*pq.mW
+        return float(response)*u.mW
 
     @power.setter
     def power(self, newval):
-        newval = assume_units(newval, pq.mW).rescale(pq.mW).magnitude
+        newval = assume_units(newval, u.mW).rescale(u.mW).magnitude
         self.sendcmd("slp:"+str(newval))
 
     @property
@@ -506,11 +506,11 @@ class LM(Instrument):
         :type: `~quantities.Quantity`
         """
         response = self.query("rtt?")
-        return float(response)*pq.degC
+        return float(response)*u.degC
 
     @temperature.setter
     def temperature(self, newval):
-        newval = convert_temperature(newval, pq.degC).magnitude
+        newval = convert_temperature(newval, u.degC).magnitude
         self.sendcmd("stt:"+str(newval))
 
     @property

--- a/instruments/oxford/oxforditc503.py
+++ b/instruments/oxford/oxforditc503.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 from __future__ import division
 from builtins import range
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import ProxyList
@@ -62,7 +62,7 @@ class OxfordITC503(Instrument):
             :type: `~quantities.quantity.Quantity`
             """
             value = float(self._parent.query('R{}'.format(self._idx))[1:])
-            return pq.Quantity(value, pq.Kelvin)
+            return u.Quantity(value, u.Kelvin)
 
     # PROPERTIES #
 

--- a/instruments/phasematrix/phasematrix_fsw0020.py
+++ b/instruments/phasematrix/phasematrix_fsw0020.py
@@ -27,9 +27,9 @@ class PhaseMatrixFSW0020(SingleChannelSG):
     Example::
 
         >>> import instruments as ik
-        >>> import quantities as pq
+        >>> import instruments.units as u
         >>> inst = ik.phasematrix.PhaseMatrixFSW0020.open_serial("/dev/ttyUSB0", baud=115200)
-        >>> inst.frequency = 1 * pq.GHz
+        >>> inst.frequency = 1 * u.GHz
         >>> inst.power = 0 * ik.units.dBm  # Can omit units and will assume dBm
         >>> inst.output = True
     """

--- a/instruments/picowatt/picowattavs47.py
+++ b/instruments/picowatt/picowattavs47.py
@@ -12,7 +12,7 @@ from __future__ import division
 from builtins import range
 from enum import IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import (enum_property, bool_property, int_property,
@@ -69,7 +69,7 @@ class PicowattAVS47(SCPIInstrument):
                 self._parent.input_source = self._parent.InputSource.actual
             # Next, prep a measurement with the ADC command
             self._parent.sendcmd("ADC")
-            return float(self._parent.query("RES?")) * pq.ohm
+            return float(self._parent.query("RES?")) * u.ohm
 
     # ENUMS #
 

--- a/instruments/qubitekk/cc1.py
+++ b/instruments/qubitekk/cc1.py
@@ -13,7 +13,7 @@ from __future__ import division
 from builtins import range, map
 
 from enum import Enum
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi.scpi_instrument import SCPIInstrument
 from instruments.util_fns import (
@@ -229,11 +229,11 @@ class CC1(SCPIInstrument):
             of units nanoseconds.
         :type: `~quantities.Quantity`
         """
-        return pq.Quantity(*split_unit_str(self.query("WIND?"), "ns"))
+        return u.Quantity(*split_unit_str(self.query("WIND?"), "ns"))
 
     @window.setter
     def window(self, new_val):
-        new_val_mag = int(assume_units(new_val, pq.ns).rescale(pq.ns).magnitude)
+        new_val_mag = int(assume_units(new_val, u.ns).rescale(u.ns).magnitude)
         if new_val_mag < 0 or new_val_mag > 7:
             raise ValueError("Window is out of range.")
         # window must be an integer!
@@ -249,12 +249,12 @@ class CC1(SCPIInstrument):
         :rtype: quantities.ns
         :return: the delay value
         """
-        return pq.Quantity(*split_unit_str(self.query("DELA?"), "ns"))
+        return u.Quantity(*split_unit_str(self.query("DELA?"), "ns"))
 
     @delay.setter
     def delay(self, new_val):
-        new_val = assume_units(new_val, pq.ns).rescale(pq.ns)
-        if new_val < 0*pq.ns or new_val > 14*pq.ns:
+        new_val = assume_units(new_val, u.ns).rescale(u.ns)
+        if new_val < 0*u.ns or new_val > 14*u.ns:
             raise ValueError("New delay value is out of bounds.")
         if new_val.magnitude % 2 != 0:
             raise ValueError("New magnitude must be an even number")
@@ -272,7 +272,7 @@ class CC1(SCPIInstrument):
         """
         # the older versions of the firmware erroneously report the units of the
         # dwell time as being seconds rather than ms
-        dwell_time = pq.Quantity(*split_unit_str(self.query("DWEL?"), "s"))
+        dwell_time = u.Quantity(*split_unit_str(self.query("DWEL?"), "s"))
         if self.firmware[0] <= 2 and self.firmware[1] <= 1:
             return dwell_time/1000.0
 
@@ -280,7 +280,7 @@ class CC1(SCPIInstrument):
 
     @dwell_time.setter
     def dwell_time(self, new_val):
-        new_val_mag = assume_units(new_val, pq.s).rescale(pq.s).magnitude
+        new_val_mag = assume_units(new_val, u.s).rescale(u.s).magnitude
         if new_val_mag < 0:
             raise ValueError("Dwell time cannot be negative.")
         self.sendcmd(":DWEL {}".format(new_val_mag))

--- a/instruments/qubitekk/mc1.py
+++ b/instruments/qubitekk/mc1.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, division
 from builtins import range, map
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import (
@@ -31,9 +31,9 @@ class MC1(Instrument):
     def __init__(self, filelike):
         super(MC1, self).__init__(filelike)
         self.terminator = "\r"
-        self._increment = 1*pq.ms
-        self._lower_limit = -300*pq.ms
-        self._upper_limit = 300*pq.ms
+        self._increment = 1*u.ms
+        self._lower_limit = -300*u.ms
+        self._upper_limit = 300*u.ms
         self._firmware = None
         self._controller = None
 
@@ -60,7 +60,7 @@ class MC1(Instrument):
 
     @increment.setter
     def increment(self, newval):
-        self._increment = assume_units(newval, pq.ms).rescale(pq.ms)
+        self._increment = assume_units(newval, u.ms).rescale(u.ms)
 
     @property
     def lower_limit(self):
@@ -74,7 +74,7 @@ class MC1(Instrument):
 
     @lower_limit.setter
     def lower_limit(self, newval):
-        self._lower_limit = assume_units(newval, pq.ms).rescale(pq.ms)
+        self._lower_limit = assume_units(newval, u.ms).rescale(u.ms)
 
     @property
     def upper_limit(self):
@@ -88,7 +88,7 @@ class MC1(Instrument):
 
     @upper_limit.setter
     def upper_limit(self, newval):
-        self._upper_limit = assume_units(newval, pq.ms).rescale(pq.ms)
+        self._upper_limit = assume_units(newval, u.ms).rescale(u.ms)
 
     direction = unitful_property(
         command="DIRE",
@@ -99,7 +99,7 @@ class MC1(Instrument):
         :type: `~quantities.Quantity`
         :units: milliseconds
         """,
-        units=pq.ms,
+        units=u.ms,
         readonly=True
     )
 
@@ -113,8 +113,8 @@ class MC1(Instrument):
         :units: milliseconds
         """,
         format_code='{:.0f}',
-        units=pq.ms,
-        valid_range=(0*pq.ms, 100*pq.ms),
+        units=u.ms,
+        valid_range=(0*u.ms, 100*u.ms),
         set_fmt=":{} {}"
     )
 
@@ -140,7 +140,7 @@ class MC1(Instrument):
         :type: `~quantities.Quantity`
         :units: millimeters
         """,
-        units=pq.mm,
+        units=u.mm,
         readonly=True
     )
 
@@ -167,8 +167,8 @@ class MC1(Instrument):
         :units: milliseconds
         """,
         format_code='{:.0f}',
-        units=pq.ms,
-        valid_range=(1*pq.ms, 100*pq.ms),
+        units=u.ms,
+        valid_range=(1*u.ms, 100*u.ms),
         set_fmt=":{} {}"
     )
 
@@ -247,7 +247,7 @@ class MC1(Instrument):
         :type new_position: `~quantities.Quantity`
         """
         if self.lower_limit <= new_position <= self.upper_limit:
-            new_position = assume_units(new_position, pq.ms).rescale(pq.ms)
+            new_position = assume_units(new_position, u.ms).rescale(u.ms)
             clock_cycles = new_position/self.step_size
             cmd = ":MOVE "+str(int(clock_cycles))
             self.sendcmd(cmd)

--- a/instruments/srs/srs345.py
+++ b/instruments/srs/srs345.py
@@ -11,7 +11,7 @@ from __future__ import division
 
 from enum import IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import FunctionGenerator
 from instruments.generic_scpi import SCPIInstrument
@@ -28,9 +28,9 @@ class SRS345(SCPIInstrument, FunctionGenerator):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> srs = ik.srs.SRS345.open_gpib('/dev/ttyUSB0', 1)
-    >>> srs.frequency = 1 * pq.MHz
+    >>> srs.frequency = 1 * u.MHz
     >>> print(srs.offset)
     >>> srs.function = srs.Function.triangle
     """
@@ -79,7 +79,7 @@ class SRS345(SCPIInstrument, FunctionGenerator):
 
     frequency = unitful_property(
         command="FREQ",
-        units=pq.Hz,
+        units=u.Hz,
         doc="""
         Gets/sets the output frequency.
 
@@ -101,7 +101,7 @@ class SRS345(SCPIInstrument, FunctionGenerator):
 
     offset = unitful_property(
         command="OFFS",
-        units=pq.volt,
+        units=u.volt,
         doc="""
         Gets/sets the offset voltage for the output waveform.
 
@@ -112,7 +112,7 @@ class SRS345(SCPIInstrument, FunctionGenerator):
 
     phase = unitful_property(
         command="PHSE",
-        units=pq.degree,
+        units=u.degree,
         doc="""
         Gets/sets the phase for the output waveform.
 

--- a/instruments/srs/srs830.py
+++ b/instruments/srs/srs830.py
@@ -17,7 +17,7 @@ from builtins import range, map
 from enum import Enum, IntEnum
 
 import numpy as np
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.abstract_instruments.comm import (
@@ -45,9 +45,9 @@ class SRS830(SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> srs = ik.srs.SRS830.open_gpibusb('/dev/ttyUSB0', 1)
-    >>> srs.frequency = 1000 * pq.hertz # Lock-In frequency
+    >>> srs.frequency = 1000 * u.hertz # Lock-In frequency
     >>> data = srs.take_measurement(1, 10) # 1Hz sample rate, 10 samples total
     """
 
@@ -139,7 +139,7 @@ class SRS830(SCPIInstrument):
 
     frequency = unitful_property(
         "FREQ",
-        pq.hertz,
+        u.hertz,
         valid_range=(0, None),
         doc="""
         Gets/sets the lock-in amplifier reference frequency.
@@ -152,8 +152,8 @@ class SRS830(SCPIInstrument):
 
     phase, phase_min, phase_max = bounded_unitful_property(
         "PHAS",
-        pq.degrees,
-        valid_range=(-360 * pq.degrees, 730 * pq.degrees),
+        u.degrees,
+        valid_range=(-360 * u.degrees, 730 * u.degrees),
         doc="""
         Gets/set the phase of the internal reference signal.
 
@@ -167,8 +167,8 @@ class SRS830(SCPIInstrument):
 
     amplitude, amplitude_min, amplitude_max = bounded_unitful_property(
         "SLVL",
-        pq.volt,
-        valid_range=(0.004 * pq.volt, 5 * pq.volt),
+        u.volt,
+        valid_range=(0.004 * u.volt, 5 * u.volt),
         doc="""
         Gets/set the amplitude of the internal reference signal.
 
@@ -215,7 +215,7 @@ class SRS830(SCPIInstrument):
         value = int(self.query('SRAT?'))
         if value == 14:
             return "trigger"
-        return pq.Quantity(VALID_SAMPLE_RATES[value], pq.Hz)
+        return u.Quantity(VALID_SAMPLE_RATES[value], u.Hz)
 
     @sample_rate.setter
     def sample_rate(self, newval):

--- a/instruments/srs/srsctc100.py
+++ b/instruments/srs/srsctc100.py
@@ -10,14 +10,12 @@ from __future__ import absolute_import
 from __future__ import division
 from contextlib import contextmanager
 from builtins import range
-
 from enum import Enum
 
-import quantities as pq
 import numpy as np
 
-
 from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################
@@ -43,11 +41,11 @@ class SRSCTC100(SCPIInstrument):
 
     # Note that the SRS CTC-100 uses '\xb0' to represent '°'.
     _UNIT_NAMES = {
-        '\xb0C': pq.celsius,
-        'W':     pq.watt,
-        'V':     pq.volt,
-        '\xea':  pq.ohm,
-        '':      pq.dimensionless
+        '\xb0C': u.celsius,
+        'W':     u.watt,
+        'V':     u.volt,
+        '\xea':  u.ohm,
+        '':      u.dimensionless
     }
 
     # INNER CLASSES ##
@@ -126,7 +124,7 @@ class SRSCTC100(SCPIInstrument):
             # WARNING: Queries all units all the time.
             # TODO: Make an OutputChannel that subclasses this class,
             #       and add a setter for value.
-            return pq.Quantity(
+            return u.Quantity(
                 float(self._get('value')),
                 self.units
             )
@@ -197,7 +195,7 @@ class SRSCTC100(SCPIInstrument):
 
             :type: `~quantities.Quantity`
             """
-            return pq.Quantity(
+            return u.Quantity(
                 float(self._get('average')),
                 self.units
             )
@@ -210,7 +208,7 @@ class SRSCTC100(SCPIInstrument):
 
             :type: `~quantities.Quantity`
             """
-            return pq.Quantity(
+            return u.Quantity(
                 float(self._get('SD')),
                 self.units
             )
@@ -240,7 +238,7 @@ class SRSCTC100(SCPIInstrument):
                     'getLog.xy {}, {}'.format(self._chan_name, which)
                 ).split(',')
             ]
-            return pq.Quantity(point[0], 'ms'), pq.Quantity(point[1], units)
+            return u.Quantity(point[0], 'ms'), u.Quantity(point[1], units)
 
         def get_log(self):
             """
@@ -261,8 +259,8 @@ class SRSCTC100(SCPIInstrument):
 
             # Make an empty quantity that size for the times and for the channel
             # values.
-            ts = pq.Quantity(np.empty((n_points,)), 'ms')
-            temps = pq.Quantity(np.empty((n_points,)), units)
+            ts = u.Quantity(np.empty((n_points,)), 'ms')
+            temps = u.Quantity(np.empty((n_points,)), units)
 
             # Reset the position to the first point, then save it.
             # pylint: disable=protected-access
@@ -309,7 +307,7 @@ class SRSCTC100(SCPIInstrument):
         Returns a dictionary from channel names to channel units, using the
         ``getOutput.units`` command. Unknown units and dimensionless quantities
         are presented the same way by the instrument, and so both are reported
-        using `pq.dimensionless`.
+        using `u.dimensionless`.
 
         :rtype: `dict` with channel names as keys and units as values
         """

--- a/instruments/srs/srsdg645.py
+++ b/instruments/srs/srsdg645.py
@@ -12,7 +12,7 @@ from builtins import map
 
 from enum import IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.abstract_instruments.comm import GPIBCommunicator
@@ -59,11 +59,11 @@ class _SRSDG645Channel(object):
         """
         Gets/sets the delay of this channel.
         Formatted as a two-tuple of the reference and the delay time.
-        For example, ``(SRSDG645.Channels.A, pq.Quantity(10, "ps"))``
+        For example, ``(SRSDG645.Channels.A, u.Quantity(10, "ps"))``
         indicates a delay of 10 picoseconds from delay channel A.
         """
         resp = self._ddg.query("DLAY?{}".format(int(self._chan))).split(",")
-        return SRSDG645.Channels(int(resp[0])), pq.Quantity(float(resp[1]), "s")
+        return SRSDG645.Channels(int(resp[0])), u.Quantity(float(resp[1]), "s")
 
     @delay.setter
     def delay(self, newval):
@@ -83,10 +83,10 @@ class SRSDG645(SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> srs = ik.srs.SRSDG645.open_gpibusb('/dev/ttyUSB0', 1)
-    >>> srs.channel["B"].delay = (srs.channel["A"], pq.Quantity(10, 'ns'))
-    >>> srs.output["AB"].level_amplitude = pq.Quantity(4.0, "V")
+    >>> srs.channel["B"].delay = (srs.channel["A"], u.Quantity(10, 'ns'))
+    >>> srs.output["AB"].level_amplitude = u.Quantity(4.0, "V")
 
     .. _user's guide: http://www.thinksrs.com/downloads/PDFs/Manuals/DG645m.pdf
     """
@@ -210,7 +210,7 @@ class SRSDG645(SCPIInstrument):
             :type: `float` or :class:`~quantities.Quantity`
             :units: As specified, or :math:`\\text{V}` by default.
             """
-            return pq.Quantity(
+            return u.Quantity(
                 float(self._parent.query('LAMP? {}'.format(self._idx))),
                 'V'
             )
@@ -228,7 +228,7 @@ class SRSDG645(SCPIInstrument):
             :type: `float` or :class:`~quantities.Quantity`
             :units: As specified, or :math:`\\text{V}` by default.
             """
-            return pq.Quantity(
+            return u.Quantity(
                 float(self._parent.query('LOFF? {}'.format(self._idx))),
                 'V'
             )
@@ -304,12 +304,12 @@ class SRSDG645(SCPIInstrument):
         :type: `~quantities.Quantity` or `float`
         :units: As passed or Hz if not specified.
         """
-        return pq.Quantity(float(self.query("TRAT?")), pq.Hz)
+        return u.Quantity(float(self.query("TRAT?")), u.Hz)
 
     @trigger_rate.setter
     def trigger_rate(self, newval):
-        newval = assume_units(newval, pq.Hz)
-        self.sendcmd("TRAT {}".format(newval.rescale(pq.Hz).magnitude))
+        newval = assume_units(newval, u.Hz)
+        self.sendcmd("TRAT {}".format(newval.rescale(u.Hz).magnitude))
 
     @property
     def trigger_source(self):
@@ -332,8 +332,8 @@ class SRSDG645(SCPIInstrument):
         :type: `~quantities.Quantity` or `float`
         :units: As passed, or s if not specified.
         """
-        return pq.Quantity(float(self.query("HOLD?")), pq.s)
+        return u.Quantity(float(self.query("HOLD?")), u.s)
 
     @holdoff.setter
     def holdoff(self, newval):
-        self.sendcmd("HOLD {}".format(newval.rescale(pq.s).magnitude))
+        self.sendcmd("HOLD {}".format(newval.rescale(u.s).magnitude))

--- a/instruments/tektronix/tekawg2000.py
+++ b/instruments/tektronix/tekawg2000.py
@@ -13,7 +13,7 @@ from builtins import range
 from enum import Enum
 
 import numpy as np
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import assume_units, ProxyList
@@ -68,16 +68,16 @@ class TekAWG2000(SCPIInstrument):
                 of units Volts.
             :type: `~quantities.Quantity` with units Volts peak-to-peak.
             """
-            return pq.Quantity(
+            return u.Quantity(
                 float(self._tek.query("FG:{}:AMPL?".format(self._name)).strip()),
-                pq.V
+                u.V
             )
 
         @amplitude.setter
         def amplitude(self, newval):
             self._tek.sendcmd("FG:{}:AMPL {}".format(
                 self._name,
-                assume_units(newval, pq.V).rescale(pq.V).magnitude
+                assume_units(newval, u.V).rescale(u.V).magnitude
             ))
 
         @property
@@ -89,16 +89,16 @@ class TekAWG2000(SCPIInstrument):
                 of units Volts.
             :type: `~quantities.Quantity` with units Volts.
             """
-            return pq.Quantity(
+            return u.Quantity(
                 float(self._tek.query("FG:{}:OFFS?".format(self._name)).strip()),
-                pq.V
+                u.V
             )
 
         @offset.setter
         def offset(self, newval):
             self._tek.sendcmd("FG:{}:OFFS {}".format(
                 self._name,
-                assume_units(newval, pq.V).rescale(pq.V).magnitude
+                assume_units(newval, u.V).rescale(u.V).magnitude
             ))
 
         @property
@@ -111,15 +111,15 @@ class TekAWG2000(SCPIInstrument):
                 of units Hertz.
             :type: `~quantities.Quantity` with units Hertz.
             """
-            return pq.Quantity(
+            return u.Quantity(
                 float(self._tek.query("FG:FREQ?").strip()),
-                pq.Hz
+                u.Hz
             )
 
         @frequency.setter
         def frequency(self, newval):
             self._tek.sendcmd("FG:FREQ {}HZ".format(
-                assume_units(newval, pq.Hz).rescale(pq.Hz).magnitude
+                assume_units(newval, u.Hz).rescale(u.Hz).magnitude
             ))
 
         @property

--- a/instruments/tektronix/tekdpo70000.py
+++ b/instruments/tektronix/tekdpo70000.py
@@ -15,7 +15,7 @@ import time
 from builtins import range
 from enum import Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import (
     Oscilloscope, OscilloscopeChannel, OscilloscopeDataSource
@@ -315,7 +315,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         filter_risetime = unitful_property(
             "FILT:RIS",
-            pq.second
+            u.second
         )
 
         label = string_property(
@@ -348,7 +348,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         spectral_center = unitful_property(
             "SPEC:CENTER",
-            pq.Hz,
+            u.Hz,
             doc="""
             The desired frequency of the spectral analyzer output data span
             in Hz.
@@ -357,7 +357,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         spectral_gatepos = unitful_property(
             "SPEC:GATEPOS",
-            pq.second,
+            u.second,
             doc="""
             The gate position. Units are represented in seconds, with respect
             to trigger position.
@@ -366,7 +366,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         spectral_gatewidth = unitful_property(
             "SPEC:GATEWIDTH",
-            pq.second,
+            u.second,
             doc="""
             The time across the 10-division screen in seconds.
             """
@@ -408,7 +408,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         spectral_resolution_bandwidth = unitful_property(
             "SPEC:RESB",
-            pq.Hz,
+            u.Hz,
             doc="""
             The desired resolution bandwidth value. Units are represented in
             Hertz.
@@ -417,7 +417,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         spectral_span = unitful_property(
             "SPEC:SPAN",
-            pq.Hz,
+            u.Hz,
             doc="""
             Specifies the frequency span of the output data vector from the
             spectral analyzer.
@@ -448,7 +448,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         threshhold = unitful_property(
             "THRESH",
-            pq.volt,
+            u.volt,
             doc="""
             The math threshhold in volts
             """
@@ -479,7 +479,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         scale = unitful_property(
             "VERT:SCALE",
-            pq.volt,
+            u.volt,
             doc="""
             The scale in volts per division. The range is from
             ``100e-36`` to ``100e+36``.
@@ -562,17 +562,17 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         bandwidth = unitful_property(
             'BAN',
-            pq.Hz
+            u.Hz
         )
 
         deskew = unitful_property(
             'DESK',
-            pq.second
+            u.second
         )
 
         termination = unitful_property(
             'TERM',
-            pq.ohm
+            u.ohm
         )
 
         label = string_property(
@@ -598,7 +598,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         offset = unitful_property(
             'OFFS',
-            pq.volt,
+            u.volt,
             doc="""
             The vertical offset in units of volts. Voltage is given by
             ``offset+scale*(5*raw/2^15 - position)``.
@@ -616,7 +616,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         scale = unitful_property(
             'SCALE',
-            pq.volt,
+            u.volt,
             doc="""
             Vertical channel scale in units volts/division. Voltage is given
             by ``offset+scale*(5*raw/2^15 - position)``.
@@ -810,7 +810,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
     horiz_acq_duration = unitful_property(
         'HOR:ACQDURATION',
-        pq.second,
+        u.second,
         readonly=True,
         doc="""
         The duration of the acquisition.
@@ -833,7 +833,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
     horiz_delay_pos = unitful_property(
         'HOR:DEL:POS',
-        pq.percent,
+        u.percent,
         doc="""
         The percentage of the waveform that is displayed left of the center
         graticule.
@@ -842,7 +842,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
     horiz_delay_time = unitful_property(
         'HOR:DEL:TIM',
-        pq.second,
+        u.second,
         doc="""
         The base trigger delay time setting.
         """
@@ -858,7 +858,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
     horiz_main_pos = unitful_property(
         'HOR:MAI:POS',
-        pq.percent,
+        u.percent,
         doc="""
         The percentage of the waveform that is displayed left of the center
         graticule.
@@ -890,7 +890,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
     horiz_sample_rate = unitful_property(
         'HOR:MODE:SAMPLER',
-        pq.Hz,
+        u.Hz,
         doc="""
         The sample rate in samples per second.
         """
@@ -898,7 +898,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
     horiz_scale = unitful_property(
         'HOR:MODE:SCA',
-        pq.second,
+        u.second,
         doc="""
         The horizontal scale in seconds per division. The horizontal scale is
         readonly when `horiz_mode` is manual.
@@ -907,7 +907,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
     horiz_pos = unitful_property(
         'HOR:POS',
-        pq.percent,
+        u.percent,
         doc="""
         The position of the trigger point on the screen, left is 0%, right
         is 100%.

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -14,7 +14,7 @@ from builtins import range, map
 from enum import Enum
 
 import numpy as np
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import (
     OscilloscopeChannel,
@@ -155,7 +155,7 @@ class TekTDS224(SCPIInstrument, Oscilloscope):
 
     def __init__(self, filelike):
         super(TekTDS224, self).__init__(filelike)
-        self._file.timeout = 3 * pq.second
+        self._file.timeout = 3 * u.second
 
     # ENUMS #
 

--- a/instruments/tests/test_abstract_inst/test_function_generator.py
+++ b/instruments/tests/test_abstract_inst/test_function_generator.py
@@ -9,7 +9,7 @@ Module containing tests for the abstract function generator class
 from __future__ import absolute_import
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 
@@ -107,7 +107,7 @@ def test_func_gen_two_channel_passes_thru_call_getter(fg, mocker):
 
 def test_func_gen_one_channel_passes_thru_call_getter(fg, mocker):
     mock_properties = [mocker.PropertyMock(return_value=1) for _ in range(4)]
-    mock_method = mocker.MagicMock(return_value=(1, pq.V))
+    mock_method = mocker.MagicMock(return_value=(1, u.V))
 
     mocker.patch("instruments.abstract_instruments.FunctionGenerator.frequency", new=mock_properties[0])
     mocker.patch("instruments.abstract_instruments.FunctionGenerator.function", new=mock_properties[1])

--- a/instruments/tests/test_agilent/test_agilent_33220a.py
+++ b/instruments/tests/test_agilent/test_agilent_33220a.py
@@ -8,7 +8,7 @@ Module containing tests for generic SCPI function generator instruments
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test
@@ -33,9 +33,9 @@ def test_agilent33220a_amplitude():
                 "+1.000000E+00"
             ]
     ) as fg:
-        assert fg.amplitude == (1 * pq.V, fg.VoltageMode.peak_to_peak)
-        fg.amplitude = 2 * pq.V
-        fg.amplitude = (1.5 * pq.V, fg.VoltageMode.dBm)
+        assert fg.amplitude == (1 * u.V, fg.VoltageMode.peak_to_peak)
+        fg.amplitude = 2 * u.V
+        fg.amplitude = (1.5 * u.V, fg.VoltageMode.dBm)
 
 
 def test_agilent33220a_frequency():
@@ -48,8 +48,8 @@ def test_agilent33220a_frequency():
                 "+1.234000E+03"
             ]
     ) as fg:
-        assert fg.frequency == 1234 * pq.Hz
-        fg.frequency = 100.5 * pq.Hz
+        assert fg.frequency == 1234 * u.Hz
+        fg.frequency = 100.5 * u.Hz
 
 
 def test_agilent33220a_function():
@@ -76,8 +76,8 @@ def test_agilent33220a_offset():
                 "+1.234000E+01",
             ]
     ) as fg:
-        assert fg.offset == 12.34 * pq.V
-        fg.offset = 0.4321 * pq.V
+        assert fg.offset == 12.34 * u.V
+        fg.offset = 0.4321 * u.V
 
 
 def test_agilent33220a_duty_cycle():
@@ -163,7 +163,7 @@ def test_agilent33220a_load_resistance():
                 "INF"
             ]
     ) as fg:
-        assert fg.load_resistance == 50 * pq.Ohm
+        assert fg.load_resistance == 50 * u.Ohm
         assert fg.load_resistance == fg.LoadResistance.high_impedance
-        fg.load_resistance = 100 * pq.Ohm
+        fg.load_resistance = 100 * u.Ohm
         fg.load_resistance = fg.LoadResistance.maximum

--- a/instruments/tests/test_agilent/test_agilent_34410a.py
+++ b/instruments/tests/test_agilent/test_agilent_34410a.py
@@ -9,11 +9,11 @@ Module containing tests for Agilent 34410a
 from __future__ import absolute_import
 from builtins import bytes
 
-import quantities as pq
 import numpy as np
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq
+import instruments.units as u
 
 # TESTS ######################################################################
 
@@ -31,7 +31,7 @@ def test_agilent34410a_read():
                 "+1.86850000E-03"
             ]
     ) as dmm:
-        unit_eq(dmm.read_meter(), +1.86850000E-03 * pq.volt)
+        unit_eq(dmm.read_meter(), +1.86850000E-03 * u.volt)
 
 
 def test_agilent34410a_data_point_count():
@@ -59,7 +59,7 @@ def test_agilent34410a_r():
                 b"#18" + bytes.fromhex("3FF0000000000000")
             ]
     ) as dmm:
-        unit_eq(dmm.r(1), np.array([1]) * pq.volt)
+        unit_eq(dmm.r(1), np.array([1]) * u.volt)
 
 
 def test_agilent34410a_fetch():
@@ -74,8 +74,8 @@ def test_agilent34410a_fetch():
             ]
     ) as dmm:
         data = dmm.fetch()
-        unit_eq(data[0], 4.27150000E-03 * pq.volt)
-        unit_eq(data[1], 5.27150000E-03 * pq.volt)
+        unit_eq(data[0], 4.27150000E-03 * u.volt)
+        unit_eq(data[1], 5.27150000E-03 * u.volt)
 
 
 def test_agilent34410a_read_data():
@@ -91,8 +91,8 @@ def test_agilent34410a_read_data():
             ]
     ) as dmm:
         data = dmm.read_data(2)
-        unit_eq(data[0], 4.27150000E-03 * pq.volt)
-        unit_eq(data[1], 5.27150000E-03 * pq.volt)
+        unit_eq(data[0], 4.27150000E-03 * u.volt)
+        unit_eq(data[1], 5.27150000E-03 * u.volt)
 
 
 def test_agilent34410a_read_data_nvmem():
@@ -107,8 +107,8 @@ def test_agilent34410a_read_data_nvmem():
             ]
     ) as dmm:
         data = dmm.read_data_nvmem()
-        unit_eq(data[0], 4.27150000E-03 * pq.volt)
-        unit_eq(data[1], 5.27150000E-03 * pq.volt)
+        unit_eq(data[0], 4.27150000E-03 * u.volt)
+        unit_eq(data[1], 5.27150000E-03 * u.volt)
 
 
 def test_agilent34410a_read_last_data():
@@ -120,4 +120,4 @@ def test_agilent34410a_read_last_data():
                 "+1.73730000E-03 VDC",
             ]
     ) as dmm:
-        unit_eq(dmm.read_last_data(), 1.73730000E-03 * pq.volt)
+        unit_eq(dmm.read_last_data(), 1.73730000E-03 * u.volt)

--- a/instruments/tests/test_comm/test_gpibusb.py
+++ b/instruments/tests/test_comm/test_gpibusb.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 import pytest
 import serial
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments.comm import GPIBCommunicator, SerialCommunicator
 from instruments.tests import unit_eq
@@ -38,7 +38,7 @@ def test_gpibusbcomm_init_correct_values_new_firmware():
     assert comm._version == 5
     assert comm._eos == "\n"
     assert comm._eoi is True
-    unit_eq(comm._timeout, 1000 * pq.millisecond)
+    unit_eq(comm._timeout, 1000 * u.millisecond)
 
 
 def test_gpibusbcomm_init_correct_values_old_firmware():
@@ -196,9 +196,9 @@ def test_gpibusbcomm_timeout():
     comm = GPIBCommunicator(mock.MagicMock(), 1)
     comm._version = 5
 
-    unit_eq(comm.timeout, 1000 * pq.millisecond)
+    unit_eq(comm.timeout, 1000 * u.millisecond)
 
-    comm.timeout = 5000 * pq.millisecond
+    comm.timeout = 5000 * u.millisecond
     comm._file.sendcmd.assert_called_with("++read_tmo_ms 5000")
 
 

--- a/instruments/tests/test_comm/test_serial.py
+++ b/instruments/tests/test_comm/test_serial.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 import pytest
 import serial
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments.comm import SerialCommunicator
 from instruments.tests import unit_eq
@@ -65,13 +65,13 @@ def test_serialcomm_timeout():
     timeout = mock.PropertyMock(return_value=30)
     type(comm._conn).timeout = timeout
 
-    unit_eq(comm.timeout, 30 * pq.second)
+    unit_eq(comm.timeout, 30 * u.second)
     timeout.assert_called_with()
 
     comm.timeout = 10
     timeout.assert_called_with(10)
 
-    comm.timeout = 1000 * pq.millisecond
+    comm.timeout = 1000 * u.millisecond
     timeout.assert_called_with(1)
 
 

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import socket
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments.comm import SocketCommunicator
 from instruments.tests import unit_eq
@@ -73,13 +73,13 @@ def test_socketcomm_timeout():
     comm._conn = mock.MagicMock()
     comm._conn.gettimeout.return_value = 1.234
 
-    unit_eq(comm.timeout, 1.234 * pq.second)
+    unit_eq(comm.timeout, 1.234 * u.second)
     comm._conn.gettimeout.assert_called_with()
 
     comm.timeout = 10
     comm._conn.settimeout.assert_called_with(10)
 
-    comm.timeout = 1000 * pq.millisecond
+    comm.timeout = 1000 * u.millisecond
     comm._conn.settimeout.assert_called_with(1)
 
 

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -10,11 +10,11 @@ from __future__ import absolute_import
 
 import pytest
 
-import quantities as pq
 from numpy import array
 
 from instruments.abstract_instruments.comm import USBTMCCommunicator
 from instruments.tests import unit_eq
+import instruments.units as u
 from .. import mock
 
 # TEST CASES #################################################################
@@ -70,13 +70,13 @@ def test_usbtmccomm_timeout(mock_usbtmc):
     timeout = mock.PropertyMock(return_value=1)
     type(comm._filelike).timeout = timeout
 
-    unit_eq(comm.timeout, 1 * pq.second)
+    unit_eq(comm.timeout, 1 * u.second)
     timeout.assert_called_with()
 
     comm.timeout = 10
     timeout.assert_called_with(array(10.0))
 
-    comm.timeout = 1000 * pq.millisecond
+    comm.timeout = 1000 * u.millisecond
     timeout.assert_called_with(array(1.0))
 
 

--- a/instruments/tests/test_config.py
+++ b/instruments/tests/test_config.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, unicode_literals
 
 from io import StringIO
 
-import quantities as pq
+import instruments.units as u
 
 from instruments import Instrument
 from instruments.config import (
@@ -48,8 +48,8 @@ a:
     d: !Q 98
 """)
     data = yaml.load(yaml_data, Loader=yaml.Loader)
-    assert data['a']['b'] == pq.Quantity(37, 'tesla')
-    assert data['a']['c'] == pq.Quantity(41.2, 'inches')
+    assert data['a']['b'] == u.Quantity(37, 'tesla')
+    assert data['a']['c'] == u.Quantity(41.2, 'inches')
     assert data['a']['d'] == 98
 
 def test_load_test_instrument_setattr():
@@ -61,4 +61,4 @@ test:
         foo: !Q 111 GHz
 """)
     insts = load_instruments(config_data)
-    assert insts['test'].foo == pq.Quantity(111, 'GHz')
+    assert insts['test'].foo == u.Quantity(111, 'GHz')

--- a/instruments/tests/test_fluke/test_fluke3000.py
+++ b/instruments/tests/test_fluke/test_fluke3000.py
@@ -8,7 +8,7 @@ Module containing tests for the Fluke 3000 FC multimeter
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -160,5 +160,5 @@ def test_measure():
             ],
             "\r"
     ) as inst:
-        assert inst.measure(inst.Mode.voltage_dc) == 0.509 * pq.volt
-        assert inst.measure(inst.Mode.temperature) == -25.3 * pq.celsius
+        assert inst.measure(inst.Mode.voltage_dc) == 0.509 * u.volt
+        assert inst.measure(inst.Mode.temperature) == -25.3 * u.celsius

--- a/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
@@ -8,7 +8,7 @@ Module containing tests for generic SCPI function generator instruments
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test
@@ -34,13 +34,13 @@ def test_scpi_func_gen_amplitude():
             ],
             repeat=2
     ) as fg:
-        assert fg.amplitude == (1 * pq.V, fg.VoltageMode.peak_to_peak)
-        fg.amplitude = 2 * pq.V
-        fg.amplitude = (1.5 * pq.V, fg.VoltageMode.dBm)
+        assert fg.amplitude == (1 * u.V, fg.VoltageMode.peak_to_peak)
+        fg.amplitude = 2 * u.V
+        fg.amplitude = (1.5 * u.V, fg.VoltageMode.dBm)
 
-        assert fg.channel[0].amplitude == (1 * pq.V, fg.VoltageMode.peak_to_peak)
-        fg.channel[0].amplitude = 2 * pq.V
-        fg.channel[0].amplitude = (1.5 * pq.V, fg.VoltageMode.dBm)
+        assert fg.channel[0].amplitude == (1 * u.V, fg.VoltageMode.peak_to_peak)
+        fg.channel[0].amplitude = 2 * u.V
+        fg.channel[0].amplitude = (1.5 * u.V, fg.VoltageMode.dBm)
 
 
 def test_scpi_func_gen_frequency():
@@ -54,11 +54,11 @@ def test_scpi_func_gen_frequency():
             ],
             repeat=2
     ) as fg:
-        assert fg.frequency == 1234 * pq.Hz
-        fg.frequency = 100.5 * pq.Hz
+        assert fg.frequency == 1234 * u.Hz
+        fg.frequency = 100.5 * u.Hz
 
-        assert fg.channel[0].frequency == 1234 * pq.Hz
-        fg.channel[0].frequency = 100.5 * pq.Hz
+        assert fg.channel[0].frequency == 1234 * u.Hz
+        fg.channel[0].frequency = 100.5 * u.Hz
 
 
 def test_scpi_func_gen_function():
@@ -90,8 +90,8 @@ def test_scpi_func_gen_offset():
             ],
             repeat=2
     ) as fg:
-        assert fg.offset == 12.34 * pq.V
-        fg.offset = 0.4321 * pq.V
+        assert fg.offset == 12.34 * u.V
+        fg.offset = 0.4321 * u.V
 
-        assert fg.channel[0].offset == 12.34 * pq.V
-        fg.channel[0].offset = 0.4321 * pq.V
+        assert fg.channel[0].offset == 12.34 * u.V
+        fg.channel[0].offset = 0.4321 * u.V

--- a/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
@@ -8,7 +8,7 @@ Module containing tests for generic SCPI multimeter instruments
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq
@@ -63,10 +63,10 @@ def test_scpi_multimeter_input_range():
                 "CURR:DC +1.000000E+01,+3.000000E-06"  # 4
             ]
     ) as dmm:
-        unit_eq(dmm.input_range, 1e1 * pq.amp)
+        unit_eq(dmm.input_range, 1e1 * u.amp)
         assert dmm.input_range == dmm.InputRange.automatic
         dmm.input_range = dmm.InputRange.minimum
-        dmm.input_range = 1 * pq.amp
+        dmm.input_range = 1 * u.amp
 
 
 def test_scpi_multimeter_resolution():
@@ -140,8 +140,8 @@ def test_scpi_multimeter_trigger_delay():
                 "+1",
             ]
     ) as dmm:
-        unit_eq(dmm.trigger_delay, 1 * pq.second)
-        dmm.trigger_delay = 1000 * pq.millisecond
+        unit_eq(dmm.trigger_delay, 1 * u.second)
+        dmm.trigger_delay = 1000 * u.millisecond
 
 
 def test_scpi_multimeter_sample_source():
@@ -168,8 +168,8 @@ def test_scpi_multimeter_sample_timer():
                 "+1",
             ]
     ) as dmm:
-        unit_eq(dmm.sample_timer, 1 * pq.second)
-        dmm.sample_timer = 1000 * pq.millisecond
+        unit_eq(dmm.sample_timer, 1 * u.second)
+        dmm.sample_timer = 1000 * u.millisecond
 
 
 def test_scpi_multimeter_measure():
@@ -181,4 +181,4 @@ def test_scpi_multimeter_measure():
                 "+4.23450000E-03",
             ]
     ) as dmm:
-        unit_eq(dmm.measure(dmm.Mode.voltage_dc), 4.2345e-03 * pq.volt)
+        unit_eq(dmm.measure(dmm.Mode.voltage_dc), 4.2345e-03 * u.volt)

--- a/instruments/tests/test_glassman/test_glassmanfr.py
+++ b/instruments/tests/test_glassman/test_glassmanfr.py
@@ -9,7 +9,7 @@ Module containing tests for the Glassman FR power supply
 from __future__ import absolute_import
 from builtins import round
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -22,8 +22,8 @@ def set_defaults(inst):
     Sets default values for the voltage and current range of the Glassman FR
     to be used to test the voltage and current property getters/setters.
     """
-    inst.voltage_max = 50.0 * pq.kilovolt
-    inst.current_max = 6.0 * pq.milliamp
+    inst.voltage_max = 50.0 * u.kilovolt
+    inst.current_max = 6.0 * u.milliamp
     inst.polarity = +1
 
 
@@ -52,8 +52,8 @@ def test_voltage():
             "\r"
     ) as inst:
         set_defaults(inst)
-        inst.voltage = 10.0 * pq.kilovolt
-        assert inst.voltage == 10.0 * pq.kilovolt
+        inst.voltage = 10.0 * u.kilovolt
+        assert inst.voltage == 10.0 * u.kilovolt
 
 
 def test_current():
@@ -70,8 +70,8 @@ def test_current():
             "\r"
     ) as inst:
         set_defaults(inst)
-        inst.current = 1.2 * pq.milliamp
-        assert inst.current == 1.2 * pq.milliamp
+        inst.current = 1.2 * u.milliamp
+        assert inst.current == 1.2 * u.milliamp
 
 
 def test_voltage_sense():
@@ -86,7 +86,7 @@ def test_voltage_sense():
             "\r"
     ) as inst:
         set_defaults(inst)
-        assert round(inst.voltage_sense) == 13.0 * pq.kilovolt
+        assert round(inst.voltage_sense) == 13.0 * u.kilovolt
 
 
 def test_current_sense():
@@ -101,7 +101,7 @@ def test_current_sense():
             "\r"
     ) as inst:
         set_defaults(inst)
-        assert inst.current_sense == 2.0 * pq.milliamp
+        assert inst.current_sense == 2.0 * u.milliamp
 
 
 def test_mode():
@@ -231,7 +231,7 @@ def test_set_status():
             "\r"
     ) as inst:
         set_defaults(inst)
-        inst.set_status(voltage=10*pq.kilovolt, current=1.2*pq.milliamp, output=True)
+        inst.set_status(voltage=10*u.kilovolt, current=1.2*u.milliamp, output=True)
         assert inst.output
-        assert inst.voltage == 10 * pq.kilovolt
-        assert inst.current == 1.2 * pq.milliamp
+        assert inst.voltage == 10 * u.kilovolt
+        assert inst.current == 1.2 * u.milliamp

--- a/instruments/tests/test_holzworth/test_holzworth_hs9000.py
+++ b/instruments/tests/test_holzworth/test_holzworth_hs9000.py
@@ -8,7 +8,7 @@ Unit tests for the Holzworth HS9000
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -119,7 +119,7 @@ def test_channel_temperature():
             sep="\n"
     ) as hs:
         channel = hs.channel[0]
-        assert channel.temperature == 10 * pq.degC
+        assert channel.temperature == 10 * u.degC
 
 
 def test_channel_frequency_getter():
@@ -140,9 +140,9 @@ def test_channel_frequency_getter():
             sep="\n"
     ) as hs:
         channel = hs.channel[0]
-        assert channel.frequency == 1 * pq.GHz
-        assert channel.frequency_min == 100 * pq.MHz
-        assert channel.frequency_max == 10 * pq.GHz
+        assert channel.frequency == 1 * u.GHz
+        assert channel.frequency_min == 100 * u.MHz
+        assert channel.frequency_max == 10 * u.GHz
 
 
 def test_channel_frequency_setter():
@@ -162,7 +162,7 @@ def test_channel_frequency_setter():
             sep="\n"
     ) as hs:
         channel = hs.channel[0]
-        channel.frequency = 1 * pq.GHz
+        channel.frequency = 1 * u.GHz
 
 
 def test_channel_power_getter():
@@ -226,9 +226,9 @@ def test_channel_phase_getter():
             sep="\n"
     ) as hs:
         channel = hs.channel[0]
-        assert channel.phase == 0 * pq.degree
-        assert channel.phase_min == -180 * pq.degree
-        assert channel.phase_max == 180 * pq.degree
+        assert channel.phase == 0 * u.degree
+        assert channel.phase_min == -180 * u.degree
+        assert channel.phase_max == 180 * u.degree
 
 
 def test_channel_phase_setter():
@@ -248,7 +248,7 @@ def test_channel_phase_setter():
             sep="\n"
     ) as hs:
         channel = hs.channel[0]
-        channel.phase = 0 * pq.degree
+        channel.phase = 0 * u.degree
 
 
 def test_channel_output():

--- a/instruments/tests/test_hp/test_hp3456a.py
+++ b/instruments/tests/test_hp/test_hp3456a.py
@@ -8,12 +8,12 @@ Unit tests for the HP 3456a digital voltmeter
 
 from __future__ import absolute_import
 
-import quantities as pq
 import numpy as np
 import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
+import instruments.units as u
 
 # TESTS #######################################################################
 
@@ -182,12 +182,12 @@ def test_hp3456a_fetch():
     ) as dmm:
         v = dmm.fetch(dmm.Mode.resistance_2wire)
         np.testing.assert_array_equal(
-            v, [0.1055, 0.1043, 0.1005, 0.1014] * pq.ohm
+            v, [0.1055, 0.1043, 0.1005, 0.1014] * u.ohm
         )
-        assert v[0].units == pq.ohm
+        assert v[0].units == u.ohm
         v = dmm.fetch()
         np.testing.assert_array_equal(
-            v, [0.1055, 0.1043, 0.1005, 0.1014] * pq.ohm
+            v, [0.1055, 0.1043, 0.1005, 0.1014] * u.ohm
         )
         assert isinstance(v[0], float)
 
@@ -247,7 +247,7 @@ def test_hp3456a_delay():
             sep="\r"
     ) as dmm:
         assert dmm.delay == 0
-        dmm.delay = 1 * pq.sec
+        dmm.delay = 1 * u.sec
 
 
 def test_hp3456a_lower():
@@ -327,8 +327,8 @@ def test_hp3456a_measure():
             sep="\r"
     ) as dmm:
         assert dmm.measure(dmm.Mode.ratio_dcv_dcv) == 0
-        assert dmm.measure(dmm.Mode.resistance_2wire) == +000.1010E+0 * pq.ohm
-        assert dmm.measure(dmm.Mode.dcv) == +000.0002E-3 * pq.volt
+        assert dmm.measure(dmm.Mode.resistance_2wire) == +000.1010E+0 * u.ohm
+        assert dmm.measure(dmm.Mode.dcv) == +000.0002E-3 * u.volt
         assert dmm.measure() == +000.0002E-3
 
 
@@ -344,8 +344,8 @@ def test_hp3456a_input_range():
             ],
             sep="\r"
     ) as dmm:
-        dmm.input_range = 10 ** -1 * pq.volt
-        dmm.input_range = 1e3 * pq.ohm
+        dmm.input_range = 10 ** -1 * u.volt
+        dmm.input_range = 1e3 * u.ohm
 
 
 def test_hp3456a_input_range_invalid_str():
@@ -365,7 +365,7 @@ def test_hp3456a_input_range_invalid_range():
             [],
             sep="\r"
     ) as dmm:
-        dmm.input_range = 1 * pq.ohm
+        dmm.input_range = 1 * u.ohm
 
 
 def test_hp3456a_input_range_bad_type():
@@ -385,7 +385,7 @@ def test_hp3456a_input_range_bad_units():
             [],
             sep="\r"
     ) as dmm:
-        dmm.input_range = 1 * pq.amp
+        dmm.input_range = 1 * u.amp
 
 
 def test_hp3456a_relative():

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -8,11 +8,11 @@ Unit tests for the HP 6624a power supply
 
 from __future__ import absolute_import
 
-import quantities as pq
 import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
+import instruments.units as u
 from .. import mock
 
 # TESTS #######################################################################
@@ -70,8 +70,8 @@ def test_channel_voltage():
             ],
             sep="\n"
     ) as hp:
-        assert hp.channel[0].voltage == 2 * pq.V
-        hp.channel[0].voltage = 5 * pq.V
+        assert hp.channel[0].voltage == 2 * u.V
+        hp.channel[0].voltage = 5 * u.V
 
 
 def test_channel_current():
@@ -86,8 +86,8 @@ def test_channel_current():
             ],
             sep="\n"
     ) as hp:
-        assert hp.channel[0].current == 2 * pq.amp
-        hp.channel[0].current = 5 * pq.amp
+        assert hp.channel[0].current == 2 * u.amp
+        hp.channel[0].current = 5 * u.amp
 
 
 def test_channel_voltage_sense():
@@ -101,7 +101,7 @@ def test_channel_voltage_sense():
             ],
             sep="\n"
     ) as hp:
-        assert hp.channel[0].voltage_sense == 2 * pq.V
+        assert hp.channel[0].voltage_sense == 2 * u.V
 
 
 def test_channel_current_sense():
@@ -115,7 +115,7 @@ def test_channel_current_sense():
             ],
             sep="\n"
     ) as hp:
-        assert hp.channel[0].current_sense == 2 * pq.A
+        assert hp.channel[0].current_sense == 2 * u.A
 
 
 def test_channel_overvoltage():
@@ -130,8 +130,8 @@ def test_channel_overvoltage():
             ],
             sep="\n"
     ) as hp:
-        assert hp.channel[0].overvoltage == 2 * pq.V
-        hp.channel[0].overvoltage = 5 * pq.V
+        assert hp.channel[0].overvoltage == 2 * u.V
+        hp.channel[0].overvoltage = 5 * u.V
 
 
 def test_channel_overcurrent():
@@ -201,9 +201,9 @@ def test_all_voltage():
             ],
             sep="\n"
     ) as hp:
-        assert sorted(hp.voltage) == sorted((2, 3, 4, 5) * pq.V)
-        hp.voltage = 5 * pq.V
-        hp.voltage = (1 * pq.V, 2 * pq.V, 3 * pq.V, 4 * pq.V)
+        assert sorted(hp.voltage) == sorted((2, 3, 4, 5) * u.V)
+        hp.voltage = 5 * u.V
+        hp.voltage = (1 * u.V, 2 * u.V, 3 * u.V, 4 * u.V)
 
 
 def test_all_voltage_wrong_length():
@@ -213,7 +213,7 @@ def test_all_voltage_wrong_length():
             [],
             sep="\n"
     ) as hp:
-        hp.voltage = (1 * pq.volt, 2 * pq.volt)
+        hp.voltage = (1 * u.volt, 2 * u.volt)
 
 
 def test_all_current():
@@ -243,9 +243,9 @@ def test_all_current():
             ],
             sep="\n"
     ) as hp:
-        assert sorted(hp.current) == sorted((2, 3, 4, 5) * pq.A)
-        hp.current = 5 * pq.A
-        hp.current = (1 * pq.A, 2 * pq.A, 3 * pq.A, 4 * pq.A)
+        assert sorted(hp.current) == sorted((2, 3, 4, 5) * u.A)
+        hp.current = 5 * u.A
+        hp.current = (1 * u.A, 2 * u.A, 3 * u.A, 4 * u.A)
 
 
 def test_all_current_wrong_length():
@@ -255,7 +255,7 @@ def test_all_current_wrong_length():
             [],
             sep="\n"
     ) as hp:
-        hp.current = (1 * pq.amp, 2 * pq.amp)
+        hp.current = (1 * u.amp, 2 * u.amp)
 
 
 def test_all_voltage_sense():
@@ -275,7 +275,7 @@ def test_all_voltage_sense():
             ],
             sep="\n"
     ) as hp:
-        assert sorted(hp.voltage_sense) == sorted((2, 3, 4, 5) * pq.V)
+        assert sorted(hp.voltage_sense) == sorted((2, 3, 4, 5) * u.V)
 
 
 def test_all_current_sense():
@@ -295,7 +295,7 @@ def test_all_current_sense():
             ],
             sep="\n"
     ) as hp:
-        assert sorted(hp.current_sense) == sorted((2, 3, 4, 5) * pq.A)
+        assert sorted(hp.current_sense) == sorted((2, 3, 4, 5) * u.A)
 
 
 def test_clear():

--- a/instruments/tests/test_hp/test_hp6632b.py
+++ b/instruments/tests/test_hp/test_hp6632b.py
@@ -8,7 +8,7 @@ Unit tests for the HP 6632b power supply
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq
@@ -69,8 +69,8 @@ def test_hp6632b_voltage():
                 "10.0"
             ]
     ) as psu:
-        unit_eq(psu.voltage, 10 * pq.volt)
-        psu.voltage = 1.0 * pq.volt
+        unit_eq(psu.voltage, 10 * u.volt)
+        psu.voltage = 1.0 * u.volt
 
 
 def test_hp6632b_voltage_sense():
@@ -82,7 +82,7 @@ def test_hp6632b_voltage_sense():
                 "10.0"
             ]
     ) as psu:
-        unit_eq(psu.voltage_sense, 10 * pq.volt)
+        unit_eq(psu.voltage_sense, 10 * u.volt)
 
 
 def test_hp6632b_overvoltage():
@@ -95,8 +95,8 @@ def test_hp6632b_overvoltage():
                 "10.0"
             ]
     ) as psu:
-        unit_eq(psu.overvoltage, 10 * pq.volt)
-        psu.overvoltage = 1.0 * pq.volt
+        unit_eq(psu.overvoltage, 10 * u.volt)
+        psu.overvoltage = 1.0 * u.volt
 
 
 def test_hp6632b_current():
@@ -109,8 +109,8 @@ def test_hp6632b_current():
                 "10.0"
             ]
     ) as psu:
-        unit_eq(psu.current, 10 * pq.amp)
-        psu.current = 1.0 * pq.amp
+        unit_eq(psu.current, 10 * u.amp)
+        psu.current = 1.0 * u.amp
 
 
 def test_hp6632b_current_sense():
@@ -122,7 +122,7 @@ def test_hp6632b_current_sense():
                 "10.0"
             ]
     ) as psu:
-        unit_eq(psu.current_sense, 10 * pq.amp)
+        unit_eq(psu.current_sense, 10 * u.amp)
 
 
 def test_hp6632b_overcurrent():
@@ -149,8 +149,8 @@ def test_hp6632b_current_sense_range():
                 "0.05"
             ]
     ) as psu:
-        unit_eq(psu.current_sense_range, 0.05 * pq.amp)
-        psu.current_sense_range = 1 * pq.amp
+        unit_eq(psu.current_sense_range, 0.05 * u.amp)
+        psu.current_sense_range = 1 * u.amp
 
 
 def test_hp6632b_output_dfi_source():
@@ -233,8 +233,8 @@ def test_hp6632b_sense_sweep_interval():
                 "1.56e-05"
             ]
     ) as psu:
-        unit_eq(psu.sense_sweep_interval, 1.56e-05 * pq.second)
-        psu.sense_sweep_interval = 1e-05 * pq.second
+        unit_eq(psu.sense_sweep_interval, 1.56e-05 * u.second)
+        psu.sense_sweep_interval = 1e-05 * u.second
 
 
 def test_hp6632b_sense_window():
@@ -261,8 +261,8 @@ def test_hp6632b_output_protection_delay():
                 "8e-02"
             ]
     ) as psu:
-        unit_eq(psu.output_protection_delay, 8e-02 * pq.second)
-        psu.output_protection_delay = 5e-02 * pq.second
+        unit_eq(psu.output_protection_delay, 8e-02 * u.second)
+        psu.output_protection_delay = 5e-02 * u.second
 
 
 def test_hp6632b_voltage_alc_bandwidth():
@@ -287,8 +287,8 @@ def test_hp6632b_voltage_trigger():
                 "1e+0"
             ]
     ) as psu:
-        unit_eq(psu.voltage_trigger, 1 * pq.volt)
-        psu.voltage_trigger = 1 * pq.volt
+        unit_eq(psu.voltage_trigger, 1 * u.volt)
+        psu.voltage_trigger = 1 * u.volt
 
 
 def test_hp6632b_current_trigger():
@@ -301,8 +301,8 @@ def test_hp6632b_current_trigger():
                 "1e-01"
             ]
     ) as psu:
-        unit_eq(psu.current_trigger, 0.1 * pq.amp)
-        psu.current_trigger = 0.1 * pq.amp
+        unit_eq(psu.current_trigger, 0.1 * u.amp)
+        psu.current_trigger = 0.1 * u.amp
 
 
 def test_hp6632b_init_output_trigger():

--- a/instruments/tests/test_hp/test_hpe3631a.py
+++ b/instruments/tests/test_hp/test_hpe3631a.py
@@ -8,7 +8,7 @@ Module containing tests for the HP E3631A power supply
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -78,16 +78,16 @@ def test_voltage():
                 "6.0"   # 6
             ]
     ) as inst:
-        assert inst.voltage_min == 0.0 * pq.volt
-        assert inst.voltage_max == 6.0 * pq.volt
-        inst.voltage = 3.0 * pq.volt
-        assert inst.voltage == 3.0 * pq.volt
+        assert inst.voltage_min == 0.0 * u.volt
+        assert inst.voltage_max == 6.0 * u.volt
+        inst.voltage = 3.0 * u.volt
+        assert inst.voltage == 3.0 * u.volt
         try:
-            inst.voltage = -1.0 * pq.volt
+            inst.voltage = -1.0 * u.volt
         except ValueError:
             pass
         try:
-            inst.voltage = 7.0 * pq.volt
+            inst.voltage = 7.0 * u.volt
         except ValueError:
             pass
 
@@ -118,16 +118,16 @@ def test_current():
                 "5.0"   # 6.2
             ]
     ) as inst:
-        assert inst.current_min == 0.0 * pq.amp
-        assert inst.current_max == 5.0 * pq.amp
-        inst.current = 2.0 * pq.amp
-        assert inst.current == 2.0 * pq.amp
+        assert inst.current_min == 0.0 * u.amp
+        assert inst.current_max == 5.0 * u.amp
+        inst.current = 2.0 * u.amp
+        assert inst.current == 2.0 * u.amp
         try:
-            inst.current = -1.0 * pq.amp
+            inst.current = -1.0 * u.amp
         except ValueError:
             pass
         try:
-            inst.current = 6.0 * pq.amp
+            inst.current = 6.0 * u.amp
         except ValueError:
             pass
 
@@ -143,7 +143,7 @@ def test_voltage_sense():
                 "1.234"  # 1
             ]
     ) as inst:
-        assert inst.voltage_sense == 1.234 * pq.volt
+        assert inst.voltage_sense == 1.234 * u.volt
 
 
 def test_current_sense():
@@ -157,4 +157,4 @@ def test_current_sense():
                 "1.234"  # 1
             ]
     ) as inst:
-        assert inst.current_sense == 1.234 * pq.amp
+        assert inst.current_sense == 1.234 * u.amp

--- a/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/tests/test_keithley/test_keithley2182.py
@@ -8,12 +8,12 @@ Unit tests for the Keithley 2182 nano-voltmeter
 
 from __future__ import absolute_import
 
-import quantities as pq
 import numpy as np
 import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
+import instruments.units as u
 
 # TESTS #######################################################################
 
@@ -51,7 +51,7 @@ def test_channel_measure_voltage():
             ]
     ) as inst:
         channel = inst.channel[0]
-        assert channel.measure() == 1.234 * pq.volt
+        assert channel.measure() == 1.234 * u.volt
 
 
 def test_channel_measure_temperature():
@@ -70,7 +70,7 @@ def test_channel_measure_temperature():
             ]
     ) as inst:
         channel = inst.channel[0]
-        assert channel.measure() == 1.234 * pq.celsius
+        assert channel.measure() == 1.234 * u.celsius
 
 
 def test_channel_measure_unknown_temperature_units():
@@ -128,7 +128,7 @@ def test_units():
         units = str(inst.units.units).split()[1]
         assert units == "K"
 
-        assert inst.units == pq.volt
+        assert inst.units == u.volt
 
 
 def test_fetch():
@@ -144,7 +144,7 @@ def test_fetch():
             ]
     ) as inst:
         np.testing.assert_array_equal(
-            inst.fetch(), [1.234, 1, 5.678] * pq.volt
+            inst.fetch(), [1.234, 1, 5.678] * u.volt
         )
 
 
@@ -162,7 +162,7 @@ def test_measure():
                 "VOLT"
             ]
     ) as inst:
-        assert inst.measure() == 1.234 * pq.volt
+        assert inst.measure() == 1.234 * u.volt
 
 
 def test_measure_invalid_mode():

--- a/instruments/tests/test_keithley/test_keithley485.py
+++ b/instruments/tests/test_keithley/test_keithley485.py
@@ -8,7 +8,7 @@ Module containing tests for the Keithley 485 picoammeter
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -61,7 +61,7 @@ def test_input_range():
     ) as inst:
         inst.input_range = "auto"
         inst.input_range = 2e-3
-        assert inst.input_range == 2. * pq.milliamp
+        assert inst.input_range == 2. * u.milliamp
 
 
 def test_relative():
@@ -149,5 +149,5 @@ def test_measure():
                 "NDCL-9.0000E+0"
             ]
     ) as inst:
-        assert inst.measure() == 1.2345 * pq.nanoamp
-        assert inst.measure() == 1. * pq.nanoamp
+        assert inst.measure() == 1.2345 * u.nanoamp
+        assert inst.measure() == 1. * u.nanoamp

--- a/instruments/tests/test_keithley/test_keithley6220.py
+++ b/instruments/tests/test_keithley/test_keithley6220.py
@@ -8,7 +8,7 @@ Unit tests for the Keithley 6220 constant current supply
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -32,10 +32,10 @@ def test_current():
                 "0.1",
             ]
     ) as inst:
-        assert inst.current == 100 * pq.milliamp
-        assert inst.current_min == -105 * pq.milliamp
-        assert inst.current_max == +105 * pq.milliamp
-        inst.current = 50 * pq.milliamp
+        assert inst.current == 100 * u.milliamp
+        assert inst.current_min == -105 * u.milliamp
+        assert inst.current_max == +105 * u.milliamp
+        inst.current = 50 * u.milliamp
 
 
 def test_disable():

--- a/instruments/tests/test_keithley/test_keithley6514.py
+++ b/instruments/tests/test_keithley/test_keithley6514.py
@@ -8,11 +8,11 @@ Unit tests for the Keithley 6514 electrometer
 
 from __future__ import absolute_import
 
-import quantities as pq
 import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
+import instruments.units as u
 
 # TESTS #######################################################################
 
@@ -44,7 +44,7 @@ def test_parse_measurement():
             ]
     ) as inst:
         reading, timestamp, status = inst._parse_measurement("1.0,1234,5678")
-        assert reading == 1.0 * pq.volt
+        assert reading == 1.0 * u.volt
         assert timestamp == 1234
         assert status == 5678
 
@@ -134,7 +134,7 @@ def test_unit():
                 '"VOLT:DC"'
             ]
     ) as inst:
-        assert inst.unit == pq.volt
+        assert inst.unit == u.volt
 
 
 def test_auto_range():
@@ -171,8 +171,8 @@ def test_input_range():
                 '"VOLT:DC"'
             ]
     ) as inst:
-        assert inst.input_range == 10 * pq.volt
-        inst.input_range = 20 * pq.volt
+        assert inst.input_range == 10 * u.volt
+        inst.input_range = 20 * u.volt
 
 
 def test_input_range_invalid():
@@ -185,7 +185,7 @@ def test_input_range_invalid():
                 '"VOLT:DC"'
             ]
     ) as inst:
-        inst.input_range = 10 * pq.volt
+        inst.input_range = 10 * u.volt
 
 
 def test_auto_config():
@@ -212,7 +212,7 @@ def test_fetch():
             ]
     ) as inst:
         reading, timestamp = inst.fetch()
-        assert reading == 1.0 * pq.volt
+        assert reading == 1.0 * u.volt
         assert timestamp == 1234
 
 
@@ -229,5 +229,5 @@ def test_read():
             ]
     ) as inst:
         reading, timestamp = inst.read_measurements()
-        assert reading == 1.0 * pq.volt
+        assert reading == 1.0 * u.volt
         assert timestamp == 1234

--- a/instruments/tests/test_minghe/test_minghe_mhs5200a.py
+++ b/instruments/tests/test_minghe/test_minghe_mhs5200a.py
@@ -9,7 +9,7 @@ Module containing tests for the MingHe MHS52000a
 from __future__ import absolute_import
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -35,10 +35,10 @@ def test_mhs_amplitude():
             ],
             sep="\r\n"
     ) as mhs:
-        assert mhs.channel[0].amplitude[0] == 3.3*pq.V
-        assert mhs.channel[1].amplitude[0] == 5.0*pq.V
-        mhs.channel[0].amplitude = 6.6*pq.V
-        mhs.channel[1].amplitude = 8.0*pq.V
+        assert mhs.channel[0].amplitude[0] == 3.3*u.V
+        assert mhs.channel[1].amplitude[0] == 5.0*u.V
+        mhs.channel[0].amplitude = 6.6*u.V
+        mhs.channel[1].amplitude = 8.0*u.V
 
 
 def test_mhs_amplitude_dbm_notimplemented():
@@ -117,10 +117,10 @@ def test_mhs_frequency():
             ],
             sep="\r\n"
     ) as mhs:
-        assert mhs.channel[0].frequency == 33.0*pq.kHz
-        assert mhs.channel[1].frequency == 500.0*pq.kHz
-        mhs.channel[0].frequency = 6*pq.kHz
-        mhs.channel[1].frequency = 8*pq.kHz
+        assert mhs.channel[0].frequency == 33.0*u.kHz
+        assert mhs.channel[1].frequency == 500.0*u.kHz
+        mhs.channel[0].frequency = 6*u.kHz
+        mhs.channel[1].frequency = 8*u.kHz
 
 
 def test_mhs_offset():

--- a/instruments/tests/test_oxford/test_oxforditc503.py
+++ b/instruments/tests/test_oxford/test_oxforditc503.py
@@ -8,7 +8,7 @@ Unit tests for the Oxford ITC 503 temperature controller
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -42,4 +42,4 @@ def test_sensor_temperature():
             sep="\r"
     ) as inst:
         sensor = inst.sensor[0]
-        assert sensor.temperature == 123 * pq.kelvin
+        assert sensor.temperature == 123 * u.kelvin

--- a/instruments/tests/test_phasematrix/test_phasematrix_fsw0020.py
+++ b/instruments/tests/test_phasematrix/test_phasematrix_fsw0020.py
@@ -8,7 +8,7 @@ Unit tests for the Phasematrix FSW0020
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -33,14 +33,14 @@ def test_frequency():
             ik.phasematrix.PhaseMatrixFSW0020,
             [
                 "04.",
-                "0C{:012X}.".format(int((10 * pq.GHz).rescale(mHz).magnitude))
+                "0C{:012X}.".format(int((10 * u.GHz).rescale(mHz).magnitude))
             ],
             [
                 "00E8D4A51000"
             ]
     ) as inst:
-        assert inst.frequency == 1 * pq.GHz
-        inst.frequency = 10 * pq.GHz
+        assert inst.frequency == 1 * u.GHz
+        inst.frequency = 10 * u.GHz
 
 
 def test_power():

--- a/instruments/tests/test_picowatt/test_picowatt_avs47.py
+++ b/instruments/tests/test_picowatt/test_picowatt_avs47.py
@@ -8,7 +8,7 @@ Unit tests for the Picowatt AVS47
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -46,7 +46,7 @@ def test_sensor_resistance_same_channel():
                 "123"
             ]
     ) as inst:
-        assert inst.sensor[0].resistance == 123 * pq.ohm
+        assert inst.sensor[0].resistance == 123 * u.ohm
 
 
 def test_sensor_resistance_different_channel():
@@ -66,7 +66,7 @@ def test_sensor_resistance_different_channel():
                 "123"
             ]
     ) as inst:
-        assert inst.sensor[0].resistance == 123 * pq.ohm
+        assert inst.sensor[0].resistance == 123 * u.ohm
 
 
 def test_remote():

--- a/instruments/tests/test_property_factories/test_bounded_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_bounded_unitful_property.py
@@ -9,7 +9,7 @@ Module containing tests for the bounded unitful property factories
 from __future__ import absolute_import
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 from instruments.util_fns import bounded_unitful_property
 from . import MockInstrument
@@ -24,17 +24,17 @@ def test_bounded_unitful_property_basics():
     class BoundedUnitfulMock(MockInstrument):
         property, property_min, property_max = bounded_unitful_property(
             'MOCK',
-            units=pq.hertz
+            units=u.hertz
         )
 
     mock_inst = BoundedUnitfulMock(
         {'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
 
-    assert mock_inst.property == 1000 * pq.hertz
-    assert mock_inst.property_min == 10 * pq.hertz
-    assert mock_inst.property_max == 9999 * pq.hertz
+    assert mock_inst.property == 1000 * u.hertz
+    assert mock_inst.property_min == 10 * u.hertz
+    assert mock_inst.property_max == 9999 * u.hertz
 
-    mock_inst.property = 1000 * pq.hertz
+    mock_inst.property = 1000 * u.hertz
 
 
 def test_bounded_unitful_property_set_outside_max():
@@ -42,13 +42,13 @@ def test_bounded_unitful_property_set_outside_max():
         class BoundedUnitfulMock(MockInstrument):
             property, property_min, property_max = bounded_unitful_property(
                 'MOCK',
-                units=pq.hertz
+                units=u.hertz
             )
 
         mock_inst = BoundedUnitfulMock(
             {'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
 
-        mock_inst.property = 10000 * pq.hertz  # Should raise ValueError
+        mock_inst.property = 10000 * u.hertz  # Should raise ValueError
 
 
 def test_bounded_unitful_property_set_outside_min():
@@ -56,26 +56,26 @@ def test_bounded_unitful_property_set_outside_min():
         class BoundedUnitfulMock(MockInstrument):
             property, property_min, property_max = bounded_unitful_property(
                 'MOCK',
-                units=pq.hertz
+                units=u.hertz
             )
 
         mock_inst = BoundedUnitfulMock(
             {'MOCK?': '1000', 'MOCK:MIN?': '10', 'MOCK:MAX?': '9999'})
 
-        mock_inst.property = 1 * pq.hertz  # Should raise ValueError
+        mock_inst.property = 1 * u.hertz  # Should raise ValueError
 
 
 def test_bounded_unitful_property_min_fmt_str():
     class BoundedUnitfulMock(MockInstrument):
         property, property_min, property_max = bounded_unitful_property(
             'MOCK',
-            units=pq.hertz,
+            units=u.hertz,
             min_fmt_str="{} MIN?"
         )
 
     mock_inst = BoundedUnitfulMock({'MOCK MIN?': '10'})
 
-    assert mock_inst.property_min == 10 * pq.Hz
+    assert mock_inst.property_min == 10 * u.Hz
     assert mock_inst.value == 'MOCK MIN?\n'
 
 
@@ -83,13 +83,13 @@ def test_bounded_unitful_property_max_fmt_str():
     class BoundedUnitfulMock(MockInstrument):
         property, property_min, property_max = bounded_unitful_property(
             'MOCK',
-            units=pq.hertz,
+            units=u.hertz,
             max_fmt_str="{} MAX?"
         )
 
     mock_inst = BoundedUnitfulMock({'MOCK MAX?': '9999'})
 
-    assert mock_inst.property_max == 9999 * pq.Hz
+    assert mock_inst.property_max == 9999 * u.Hz
     assert mock_inst.value == 'MOCK MAX?\n'
 
 
@@ -97,40 +97,40 @@ def test_bounded_unitful_property_static_range():
     class BoundedUnitfulMock(MockInstrument):
         property, property_min, property_max = bounded_unitful_property(
             'MOCK',
-            units=pq.hertz,
+            units=u.hertz,
             valid_range=(10, 9999)
         )
 
     mock_inst = BoundedUnitfulMock()
 
-    assert mock_inst.property_min == 10 * pq.Hz
-    assert mock_inst.property_max == 9999 * pq.Hz
+    assert mock_inst.property_min == 10 * u.Hz
+    assert mock_inst.property_max == 9999 * u.Hz
 
 
 def test_bounded_unitful_property_static_range_with_units():
     class BoundedUnitfulMock(MockInstrument):
         property, property_min, property_max = bounded_unitful_property(
             'MOCK',
-            units=pq.hertz,
-            valid_range=(10 * pq.kilohertz, 9999 * pq.kilohertz)
+            units=u.hertz,
+            valid_range=(10 * u.kilohertz, 9999 * u.kilohertz)
         )
 
     mock_inst = BoundedUnitfulMock()
 
-    assert mock_inst.property_min == 10 * 1000 * pq.Hz
-    assert mock_inst.property_max == 9999 * 1000 * pq.Hz
+    assert mock_inst.property_min == 10 * 1000 * u.Hz
+    assert mock_inst.property_max == 9999 * 1000 * u.Hz
 
 
 @mock.patch("instruments.util_fns.unitful_property")
 def test_bounded_unitful_property_passes_kwargs(mock_unitful_property):
     bounded_unitful_property(
         command='MOCK',
-        units=pq.Hz,
+        units=u.Hz,
         derp="foobar"
     )
     mock_unitful_property.assert_called_with(
         'MOCK',
-        pq.Hz,
+        u.Hz,
         derp="foobar",
         valid_range=(mock.ANY, mock.ANY)
     )
@@ -140,12 +140,12 @@ def test_bounded_unitful_property_passes_kwargs(mock_unitful_property):
 def test_bounded_unitful_property_valid_range_none(mock_unitful_property):
     bounded_unitful_property(
         command='MOCK',
-        units=pq.Hz,
+        units=u.Hz,
         valid_range=(None, None)
     )
     mock_unitful_property.assert_called_with(
         'MOCK',
-        pq.Hz,
+        u.Hz,
         valid_range=(None, None)
     )
 
@@ -154,7 +154,7 @@ def test_bounded_unitful_property_returns_none():
     class BoundedUnitfulMock(MockInstrument):
         property, property_min, property_max = bounded_unitful_property(
             'MOCK',
-            units=pq.hertz,
+            units=u.hertz,
             valid_range=(None, None)
         )
 

--- a/instruments/tests/test_property_factories/test_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_unitful_property.py
@@ -9,7 +9,7 @@ Module containing tests for the unitful property factories
 from __future__ import absolute_import
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 from instruments.util_fns import unitful_property
 from . import MockInstrument
@@ -21,40 +21,40 @@ from . import MockInstrument
 
 def test_unitful_property_basics():
     class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property('MOCK', units=pq.hertz)
+        unitful_property = unitful_property('MOCK', units=u.hertz)
 
     mock_inst = UnitfulMock({'MOCK?': '1000'})
 
-    assert mock_inst.unitful_property == 1000 * pq.hertz
+    assert mock_inst.unitful_property == 1000 * u.hertz
 
-    mock_inst.unitful_property = 1000 * pq.hertz
+    mock_inst.unitful_property = 1000 * u.hertz
     assert mock_inst.value == 'MOCK?\nMOCK {:e}\n'.format(1000)
 
 
 def test_unitful_property_format_code():
     class UnitfulMock(MockInstrument):
         unitful_property = unitful_property(
-            'MOCK', pq.hertz, format_code='{:f}')
+            'MOCK', u.hertz, format_code='{:f}')
 
     mock_inst = UnitfulMock()
 
-    mock_inst.unitful_property = 1000 * pq.hertz
+    mock_inst.unitful_property = 1000 * u.hertz
     assert mock_inst.value == 'MOCK {:f}\n'.format(1000)
 
 
 def test_unitful_property_rescale_units():
     class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property('MOCK', pq.hertz)
+        unitful_property = unitful_property('MOCK', u.hertz)
 
     mock_inst = UnitfulMock()
 
-    mock_inst.unitful_property = 1 * pq.kilohertz
+    mock_inst.unitful_property = 1 * u.kilohertz
     assert mock_inst.value == 'MOCK {:e}\n'.format(1000)
 
 
 def test_unitful_property_no_units_on_set():
     class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property('MOCK', pq.hertz)
+        unitful_property = unitful_property('MOCK', u.hertz)
 
     mock_inst = UnitfulMock()
 
@@ -65,17 +65,17 @@ def test_unitful_property_no_units_on_set():
 def test_unitful_property_wrong_units():
     with pytest.raises(ValueError):
         class UnitfulMock(MockInstrument):
-            unitful_property = unitful_property('MOCK', pq.hertz)
+            unitful_property = unitful_property('MOCK', u.hertz)
 
         mock_inst = UnitfulMock()
 
-        mock_inst.unitful_property = 1 * pq.volt
+        mock_inst.unitful_property = 1 * u.volt
 
 
 def test_unitful_property_writeonly_reading_fails():
     with pytest.raises(AttributeError):
         class UnitfulMock(MockInstrument):
-            unitful_property = unitful_property('MOCK', pq.hertz, writeonly=True)
+            unitful_property = unitful_property('MOCK', u.hertz, writeonly=True)
 
         mock_inst = UnitfulMock()
 
@@ -84,37 +84,37 @@ def test_unitful_property_writeonly_reading_fails():
 
 def test_unitful_property_writeonly_writing_passes():
     class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property('MOCK', pq.hertz, writeonly=True)
+        unitful_property = unitful_property('MOCK', u.hertz, writeonly=True)
 
     mock_inst = UnitfulMock()
 
-    mock_inst.unitful_property = 1 * pq.hertz
+    mock_inst.unitful_property = 1 * u.hertz
     assert mock_inst.value == 'MOCK {:e}\n'.format(1)
 
 
 def test_unitful_property_readonly_writing_fails():
     with pytest.raises(AttributeError):
         class UnitfulMock(MockInstrument):
-            unitful_property = unitful_property('MOCK', pq.hertz, readonly=True)
+            unitful_property = unitful_property('MOCK', u.hertz, readonly=True)
 
         mock_inst = UnitfulMock({'MOCK?': '1'})
 
-        mock_inst.unitful_property = 1 * pq.hertz
+        mock_inst.unitful_property = 1 * u.hertz
 
 
 def test_unitful_property_readonly_reading_passes():
     class UnitfulMock(MockInstrument):
-        unitful_property = unitful_property('MOCK', pq.hertz, readonly=True)
+        unitful_property = unitful_property('MOCK', u.hertz, readonly=True)
 
     mock_inst = UnitfulMock({'MOCK?': '1'})
 
-    assert mock_inst.unitful_property == 1 * pq.hertz
+    assert mock_inst.unitful_property == 1 * u.hertz
 
 
 def test_unitful_property_valid_range():
     class UnitfulMock(MockInstrument):
         unitful_property = unitful_property(
-            'MOCK', pq.hertz, valid_range=(0, 10))
+            'MOCK', u.hertz, valid_range=(0, 10))
 
     mock_inst = UnitfulMock()
 
@@ -134,7 +134,7 @@ def test_unitful_property_valid_range_functions():
             return 10
 
         unitful_property = unitful_property(
-            'MOCK', pq.hertz, valid_range=(min_value, max_value))
+            'MOCK', u.hertz, valid_range=(min_value, max_value))
 
     mock_inst = UnitfulMock()
 
@@ -148,7 +148,7 @@ def test_unitful_property_minimum_value():
     with pytest.raises(ValueError):
         class UnitfulMock(MockInstrument):
             unitful_property = unitful_property(
-                'MOCK', pq.hertz, valid_range=(0, 10))
+                'MOCK', u.hertz, valid_range=(0, 10))
 
         mock_inst = UnitfulMock()
 
@@ -159,7 +159,7 @@ def test_unitful_property_maximum_value():
     with pytest.raises(ValueError):
         class UnitfulMock(MockInstrument):
             unitful_property = unitful_property(
-                'MOCK', pq.hertz, valid_range=(0, 10))
+                'MOCK', u.hertz, valid_range=(0, 10))
 
         mock_inst = UnitfulMock()
 
@@ -174,13 +174,13 @@ def test_unitful_property_input_decoration():
             return '1'
         a = unitful_property(
             'MOCK:A',
-            pq.hertz,
+            u.hertz,
             input_decoration=_input_decorator
         )
 
     mock_instrument = UnitfulMock({'MOCK:A?': 'garbage'})
 
-    assert mock_instrument.a == 1 * pq.Hz
+    assert mock_instrument.a == 1 * u.Hz
 
 
 def test_unitful_property_input_decoration_not_a_function():
@@ -188,13 +188,13 @@ def test_unitful_property_input_decoration_not_a_function():
 
         a = unitful_property(
             'MOCK:A',
-            pq.hertz,
+            u.hertz,
             input_decoration=float
         )
 
     mock_instrument = UnitfulMock({'MOCK:A?': '.123'})
 
-    assert mock_instrument.a == 0.123 * pq.Hz
+    assert mock_instrument.a == 0.123 * u.Hz
 
 
 def test_unitful_property_output_decoration():
@@ -205,13 +205,13 @@ def test_unitful_property_output_decoration():
             return '1'
         a = unitful_property(
             'MOCK:A',
-            pq.hertz,
+            u.hertz,
             output_decoration=_output_decorator
         )
 
     mock_instrument = UnitfulMock()
 
-    mock_instrument.a = 345 * pq.hertz
+    mock_instrument.a = 345 * u.hertz
 
     assert mock_instrument.value == 'MOCK:A 1\n'
 
@@ -221,13 +221,13 @@ def test_unitful_property_output_decoration_not_a_function():
 
         a = unitful_property(
             'MOCK:A',
-            pq.hertz,
+            u.hertz,
             output_decoration=bool
         )
 
     mock_instrument = UnitfulMock()
 
-    mock_instrument.a = 1 * pq.hertz
+    mock_instrument.a = 1 * u.hertz
 
     assert mock_instrument.value == 'MOCK:A True\n'
 
@@ -235,25 +235,25 @@ def test_unitful_property_output_decoration_not_a_function():
 def test_unitful_property_split_str():
     class UnitfulMock(MockInstrument):
         unitful_property = unitful_property(
-            'MOCK', pq.hertz, valid_range=(0, 10))
+            'MOCK', u.hertz, valid_range=(0, 10))
 
     mock_inst = UnitfulMock({"MOCK?": "1 kHz"})
 
     value = mock_inst.unitful_property
     assert value.magnitude == 1000
-    assert value.units == pq.hertz
+    assert value.units == u.hertz
 
 
 def test_unitful_property_name_read_not_none():
     class UnitfulMock(MockInstrument):
         a = unitful_property(
             'MOCK',
-            units=pq.hertz,
+            units=u.hertz,
             set_cmd='FOOBAR'
         )
 
     mock_inst = UnitfulMock({'MOCK?': '1000'})
-    assert mock_inst.a == 1000 * pq.hertz
-    mock_inst.a = 1000 * pq.hertz
+    assert mock_inst.a == 1000 * u.hertz
+    mock_inst.a = 1000 * u.hertz
 
     assert mock_inst.value == 'MOCK?\nFOOBAR {:e}\n'.format(1000)

--- a/instruments/tests/test_property_factories/test_unitless_property.py
+++ b/instruments/tests/test_property_factories/test_unitless_property.py
@@ -9,7 +9,7 @@ Module containing tests for the unitless property factory
 from __future__ import absolute_import
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 from instruments.util_fns import unitless_property
 from . import MockInstrument
@@ -38,7 +38,7 @@ def test_unitless_property_units():
 
         mock_inst = UnitlessMock({'MOCK?': '1'})
 
-        mock_inst.mock_property = 1 * pq.volt
+        mock_inst.mock_property = 1 * u.volt
 
 
 def test_unitless_property_format_code():

--- a/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
@@ -9,7 +9,7 @@ Module containing tests for the Qubitekk CC1
 from __future__ import absolute_import
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, unit_eq
@@ -52,7 +52,7 @@ def test_cc1_window():
             ],
             sep="\n"
     ) as cc:
-        unit_eq(cc.window, pq.Quantity(2, "ns"))
+        unit_eq(cc.window, u.Quantity(2, "ns"))
         cc.window = 7
 
 
@@ -90,7 +90,7 @@ def test_cc1_delay():
             ],
             sep="\n"
     ) as cc:
-        unit_eq(cc.delay, pq.Quantity(8, "ns"))
+        unit_eq(cc.delay, u.Quantity(8, "ns"))
         cc.delay = 2
 
 
@@ -145,7 +145,7 @@ def test_cc1_dwell_old_firmware():
             ],
             sep="\n"
     ) as cc:
-        unit_eq(cc.dwell_time, pq.Quantity(8, "s"))
+        unit_eq(cc.dwell_time, u.Quantity(8, "s"))
         cc.dwell_time = 2
 
 
@@ -165,7 +165,7 @@ def test_cc1_dwell_new_firmware():
             ],
             sep="\n"
     ) as cc:
-        unit_eq(cc.dwell_time, pq.Quantity(8, "s"))
+        unit_eq(cc.dwell_time, u.Quantity(8, "s"))
         cc.dwell_time = 2
 
 

--- a/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 import pytest
 
-import quantities as pq
+import instruments.units as u
 import instruments as ik
 from instruments.tests import expected_protocol
 
@@ -48,7 +48,7 @@ def test_mc1_internal_position():
             ],
             sep="\r"
     ) as mc:
-        assert mc.internal_position == -100*pq.ms
+        assert mc.internal_position == -100*u.ms
 
 
 def test_mc1_metric_position():
@@ -62,7 +62,7 @@ def test_mc1_metric_position():
             ],
             sep="\r"
     ) as mc:
-        assert mc.metric_position == -3.14159*pq.mm
+        assert mc.metric_position == -3.14159*u.mm
 
 
 def test_mc1_direction():
@@ -118,7 +118,7 @@ def test_mc1_step():
             ],
             sep="\r"
     ) as mc:
-        assert mc.step_size == 20*pq.ms
+        assert mc.step_size == 20*u.ms
 
 
 def test_mc1_motor():
@@ -148,7 +148,7 @@ def test_mc1_move_timeout():
             ],
             sep="\r"
     ) as mc:
-        assert mc.move_timeout == 200*pq.ms
+        assert mc.move_timeout == 200*u.ms
 
 
 def test_mc1_is_centering():

--- a/instruments/tests/test_split_str.py
+++ b/instruments/tests/test_split_str.py
@@ -8,10 +8,9 @@ Module containing tests for the util_fns.split_unit_str utility function
 
 from __future__ import absolute_import
 
-import quantities as pq
-
 import pytest
 
+import instruments.units as u
 from instruments.util_fns import (
     split_unit_str
 )
@@ -85,15 +84,15 @@ def test_split_unit_str_scientific_notation():
     # No signs, no units
     mag, units = split_unit_str("123E1")
     assert mag == 1230
-    assert units == pq.dimensionless
+    assert units == u.dimensionless
     # Negative exponential, no units
     mag, units = split_unit_str("123E-1")
     assert mag == 12.3
-    assert units == pq.dimensionless
+    assert units == u.dimensionless
     # Negative magnitude, no units
     mag, units = split_unit_str("-123E1")
     assert mag == -1230
-    assert units == pq.dimensionless
+    assert units == u.dimensionless
     # No signs, with units
     mag, units = split_unit_str("123E1 foobars")
     assert mag == 1230
@@ -105,7 +104,7 @@ def test_split_unit_str_scientific_notation():
     # Lower case e
     mag, units = split_unit_str("123e1")
     assert mag == 1230
-    assert units == pq.dimensionless
+    assert units == u.dimensionless
 
 
 def test_split_unit_str_empty_string():

--- a/instruments/tests/test_srs/test_srs345.py
+++ b/instruments/tests/test_srs/test_srs345.py
@@ -8,11 +8,11 @@ Unit tests for the SRS 345 function generator
 
 from __future__ import absolute_import
 
-import quantities as pq
 import numpy as np
 
 import instruments as ik
 from instruments.tests import expected_protocol
+import instruments.units as u
 
 # TESTS #######################################################################
 
@@ -30,10 +30,10 @@ def test_amplitude():
             ]
     ) as inst:
         np.testing.assert_array_equal(
-            inst.amplitude, (1.234 * pq.V, inst.VoltageMode.peak_to_peak)
+            inst.amplitude, (1.234 * u.V, inst.VoltageMode.peak_to_peak)
         )
-        inst.amplitude = 0.1 * pq.V
-        inst.amplitude = (0.1 * pq.V, inst.VoltageMode.rms)
+        inst.amplitude = 0.1 * u.V
+        inst.amplitude = (0.1 * u.V, inst.VoltageMode.rms)
 
 
 def test_frequency():
@@ -47,8 +47,8 @@ def test_frequency():
                 "1.234",
             ]
     ) as inst:
-        assert inst.frequency == 1.234 * pq.Hz
-        inst.frequency = 0.1 * pq.Hz
+        assert inst.frequency == 1.234 * u.Hz
+        inst.frequency = 0.1 * u.Hz
 
 
 def test_function():
@@ -77,8 +77,8 @@ def test_offset():
                 "1.234",
             ]
     ) as inst:
-        assert inst.offset == 1.234 * pq.V
-        inst.offset = 0.1 * pq.V
+        assert inst.offset == 1.234 * u.V
+        inst.offset = 0.1 * u.V
 
 
 def test_phase():
@@ -92,5 +92,5 @@ def test_phase():
                 "1.234",
             ]
     ) as inst:
-        assert inst.phase == 1.234 * pq.degree
-        inst.phase = 0.1 * pq.degree
+        assert inst.phase == 1.234 * u.degree
+        inst.phase = 0.1 * u.degree

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -8,12 +8,12 @@ Unit tests for the SRS 830 lock-in amplifier
 
 from __future__ import absolute_import
 
-import quantities as pq
 import numpy as np
 import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
+import instruments.units as u
 
 # TESTS #######################################################################
 
@@ -44,8 +44,8 @@ def test_frequency():
                 "12.34",
             ]
     ) as inst:
-        assert inst.frequency == 12.34 * pq.Hz
-        inst.frequency = 1 * pq.kHz
+        assert inst.frequency == 12.34 * u.Hz
+        inst.frequency = 1 * u.kHz
 
 
 def test_phase():
@@ -59,8 +59,8 @@ def test_phase():
                 "-45",
             ]
     ) as inst:
-        assert inst.phase == -45 * pq.degrees
-        inst.phase = 10 * pq.degrees
+        assert inst.phase == -45 * u.degrees
+        inst.phase = 10 * u.degrees
 
 
 def test_amplitude():
@@ -74,8 +74,8 @@ def test_amplitude():
                 "0.1",
             ]
     ) as inst:
-        assert inst.amplitude == 0.1 * pq.V
-        inst.amplitude = 1 * pq.V
+        assert inst.amplitude == 0.1 * u.V
+        inst.amplitude = 1 * u.V
 
 
 def test_input_shield_ground():
@@ -122,7 +122,7 @@ def test_sample_rate():  # sends index of VALID_SAMPLE_RATES
                 "14"
             ]
     ) as inst:
-        assert inst.sample_rate == 16 * pq.Hz
+        assert inst.sample_rate == 16 * u.Hz
         assert inst.sample_rate == "trigger"
         inst.sample_rate = 2
         inst.sample_rate = "trigger"

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -8,7 +8,7 @@ Module containing tests for the SRS DG645
 
 from __future__ import absolute_import
 
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq
@@ -32,7 +32,7 @@ def test_srsdg645_output_level():
                 "3.2"
             ]
     ) as ddg:
-        unit_eq(ddg.output["AB"].level_amplitude, pq.Quantity(3.2, "V"))
+        unit_eq(ddg.output["AB"].level_amplitude, u.Quantity(3.2, "V"))
         ddg.output["AB"].level_amplitude = 4.0
 
 
@@ -50,7 +50,7 @@ def test_srsdg645_output_offset():
                 "1.2"
             ]
     ) as ddg:
-        unit_eq(ddg.output["AB"].level_offset, pq.Quantity(1.2, "V"))
+        unit_eq(ddg.output["AB"].level_offset, u.Quantity(1.2, "V"))
         ddg.output["AB"].level_offset = 2.0
 
 
@@ -76,5 +76,5 @@ def test_srsdg645_trigger_source():
     with expected_protocol(ik.srs.SRSDG645, "DLAY?2\nDLAY 3,2,60.0\n", "0,42\n") as ddg:
         ref, t = ddg.channel["A"].delay
         assert ref == ddg.Channels.T0
-        assert abs((t - pq.Quantity(42, "s")).magnitude) < 1e5
-        ddg.channel["B"].delay = (ddg.channel["A"], pq.Quantity(1, "minute"))
+        assert abs((t - u.Quantity(42, "s")).magnitude) < 1e5
+        ddg.channel["B"].delay = (ddg.channel["A"], u.Quantity(1, "minute"))

--- a/instruments/tests/test_thorlabs/test_thorlabs_apt.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_apt.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import
 import struct
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.thorlabs._packets import ThorLabsPacket, hw_info_data

--- a/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
@@ -9,7 +9,7 @@ Module containing tests for the Thorlabs LCC25
 from __future__ import absolute_import
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, unit_eq
@@ -49,7 +49,7 @@ def test_lcc25_frequency():
             ],
             sep="\r"
     ) as lcc:
-        unit_eq(lcc.frequency, pq.Quantity(20, "Hz"))
+        unit_eq(lcc.frequency, u.Quantity(20, "Hz"))
         lcc.frequency = 10.0
 
 
@@ -210,7 +210,7 @@ def test_lcc25_voltage1():
             ],
             sep="\r"
     ) as lcc:
-        unit_eq(lcc.voltage1, pq.Quantity(20, "V"))
+        unit_eq(lcc.voltage1, u.Quantity(20, "V"))
         lcc.voltage1 = 10.0
 
 
@@ -235,7 +235,7 @@ def test_lcc25_voltage2():
             ],
             sep="\r"
     ) as lcc:
-        unit_eq(lcc.voltage2, pq.Quantity(20, "V"))
+        unit_eq(lcc.voltage2, u.Quantity(20, "V"))
         lcc.voltage2 = 10.0
 
 
@@ -254,7 +254,7 @@ def test_lcc25_minvoltage():
             ],
             sep="\r"
     ) as lcc:
-        unit_eq(lcc.min_voltage, pq.Quantity(20, "V"))
+        unit_eq(lcc.min_voltage, u.Quantity(20, "V"))
         lcc.min_voltage = 10.0
 
 
@@ -273,7 +273,7 @@ def test_lcc25_maxvoltage():
             ],
             sep="\r"
     ) as lcc:
-        unit_eq(lcc.max_voltage, pq.Quantity(20, "V"))
+        unit_eq(lcc.max_voltage, u.Quantity(20, "V"))
         lcc.max_voltage = 10.0
 
 
@@ -292,7 +292,7 @@ def test_lcc25_dwell():
             ],
             sep="\r"
     ) as lcc:
-        unit_eq(lcc.dwell, pq.Quantity(20, "ms"))
+        unit_eq(lcc.dwell, u.Quantity(20, "ms"))
         lcc.dwell = 10
 
 
@@ -326,7 +326,7 @@ def test_lcc25_increment():
             ],
             sep="\r"
     ) as lcc:
-        unit_eq(lcc.increment, pq.Quantity(20, "V"))
+        unit_eq(lcc.increment, u.Quantity(20, "V"))
         lcc.increment = 10.0
 
 

--- a/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
@@ -9,7 +9,7 @@ Module containing tests for the Thorlabs SC10
 from __future__ import absolute_import
 
 import pytest
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, unit_eq
@@ -173,7 +173,7 @@ def test_sc10_open_time():
             ],
             sep="\r"
     ) as sc:
-        unit_eq(sc.open_time, pq.Quantity(20, "ms"))
+        unit_eq(sc.open_time, u.Quantity(20, "ms"))
         sc.open_time = 10
 
 
@@ -192,7 +192,7 @@ def test_sc10_shut_time():
             ],
             sep="\r"
     ) as sc:
-        unit_eq(sc.shut_time, pq.Quantity(20, "ms"))
+        unit_eq(sc.shut_time, u.Quantity(20, "ms"))
         sc.shut_time = 10.0
 
 

--- a/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 
 from enum import IntEnum
 import pytest
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -142,7 +142,7 @@ def test_tc200_temperature():
             ],
             sep="\r"
     ) as tc:
-        assert tc.temperature == 30.0 * pq.degC
+        assert tc.temperature == 30.0 * u.degC
 
 
 def test_tc200_temperature_set():
@@ -163,8 +163,8 @@ def test_tc200_temperature_set():
             ],
             sep="\r"
     ) as tc:
-        assert tc.temperature_set == 30.0 * pq.degC
-        tc.temperature_set = 40 * pq.degC
+        assert tc.temperature_set == 30.0 * u.degC
+        tc.temperature_set = 40 * u.degC
 
 
 def test_tc200_temperature_range():
@@ -180,7 +180,7 @@ def test_tc200_temperature_range():
             ],
             sep="\r"
     ) as tc:
-        tc.temperature_set = 50 * pq.degC
+        tc.temperature_set = 50 * u.degC
 
 
 def test_tc200_pid():
@@ -381,11 +381,11 @@ def test_tc200_degrees():
     ) as tc:
         assert str(tc.degrees).split(" ")[1] == "K"
         assert str(tc.degrees).split(" ")[1] == "degC"
-        assert tc.degrees == pq.degF
+        assert tc.degrees == u.degF
 
-        tc.degrees = pq.degC
-        tc.degrees = pq.degF
-        tc.degrees = pq.degK
+        tc.degrees = u.degC
+        tc.degrees = u.degF
+        tc.degrees = u.degK
 
 
 def test_tc200_degrees_invalid():
@@ -502,8 +502,8 @@ def test_tc200_max_power():
             ],
             sep="\r"
     ) as tc:
-        assert tc.max_power == 15.0 * pq.W
-        tc.max_power = 12 * pq.W
+        assert tc.max_power == 15.0 * u.W
+        tc.max_power = 12 * u.W
 
 
 def test_tc200_power_min():
@@ -551,8 +551,8 @@ def test_tc200_max_temperature():
             ],
             sep="\r"
     ) as tc:
-        assert tc.max_temperature == 200.0 * pq.degC
-        tc.max_temperature = 180 * pq.degC
+        assert tc.max_temperature == 200.0 * u.degC
+        tc.max_temperature = 180 * u.degC
 
 
 def test_tc200_temp_min():

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -9,7 +9,7 @@ Module containing tests for the Toptica Topmode
 from __future__ import absolute_import
 from datetime import datetime
 import pytest
-import quantities as pq
+import instruments.units as u
 
 
 import instruments as ik
@@ -74,8 +74,8 @@ def test_wavelength():
             ],
             sep="\r\n"
     ) as tm:
-        assert tm.laser[0].wavelength == 640 * pq.nm
-        assert tm.laser[1].wavelength == 405.3 * pq.nm
+        assert tm.laser[0].wavelength == 640 * u.nm
+        assert tm.laser[1].wavelength == 405.3 * u.nm
 
 
 def test_laser_enable():
@@ -387,7 +387,7 @@ def test_laser_ontime():
             ],
             sep="\r\n"
     ) as tm:
-        assert tm.laser[0].on_time == 10000 * pq.s
+        assert tm.laser[0].on_time == 10000 * u.s
 
 
 def test_laser_charm_status():

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -9,11 +9,11 @@ Module containing tests for util_fns.py
 from __future__ import absolute_import
 
 from builtins import range
-
 from enum import Enum
-import quantities as pq
+
 import pytest
 
+import instruments.units as u
 from instruments.util_fns import (
     ProxyList,
     assume_units, convert_temperature,
@@ -126,7 +126,7 @@ def test_ProxyList_invalid_idx():
 
 
 def test_assume_units_correct():
-    m = pq.Quantity(1, 'm')
+    m = u.Quantity(1, 'm')
 
     # Check that unitful quantities are kept unitful.
     assert assume_units(m, 'mm').rescale('mm').magnitude == 1000
@@ -136,35 +136,35 @@ def test_assume_units_correct():
 
 
 def test_temperature_conversion():
-    blo = 70.0 * pq.degF
-    out = convert_temperature(blo, pq.degC)
+    blo = 70.0 * u.degF
+    out = convert_temperature(blo, u.degC)
     assert out.magnitude == 21.11111111111111
-    out = convert_temperature(blo, pq.degK)
+    out = convert_temperature(blo, u.degK)
     assert out.magnitude == 294.2055555555555
-    out = convert_temperature(blo, pq.degF)
+    out = convert_temperature(blo, u.degF)
     assert out.magnitude == 70.0
 
-    blo = 20.0 * pq.degC
-    out = convert_temperature(blo, pq.degF)
+    blo = 20.0 * u.degC
+    out = convert_temperature(blo, u.degF)
     assert out.magnitude == 68
-    out = convert_temperature(blo, pq.degC)
+    out = convert_temperature(blo, u.degC)
     assert out.magnitude == 20.0
-    out = convert_temperature(blo, pq.degK)
+    out = convert_temperature(blo, u.degK)
     assert out.magnitude == 293.15
 
-    blo = 270 * pq.degK
-    out = convert_temperature(blo, pq.degC)
+    blo = 270 * u.degK
+    out = convert_temperature(blo, u.degC)
     assert out.magnitude == -3.1499999999999773
-    out = convert_temperature(blo, pq.degF)
+    out = convert_temperature(blo, u.degF)
     assert out.magnitude == 141.94736842105263
-    out = convert_temperature(blo, pq.K)
+    out = convert_temperature(blo, u.K)
     assert out.magnitude == 270
 
 
 def test_temperater_conversion_failure():
     with pytest.raises(ValueError):
-        blo = 70.0 * pq.degF
-        convert_temperature(blo, pq.V)
+        blo = 70.0 * u.degF
+        convert_temperature(blo, u.V)
 
 
 def test_assume_units_failures():

--- a/instruments/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/instruments/tests/test_yokogawa/test_yokogawa_6370.py
@@ -15,7 +15,7 @@ from hypothesis import (
     strategies as st,
 )
 import numpy as np
-import quantities as pq
+import instruments.units as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -94,8 +94,8 @@ def test_start_wavelength(value):
                 "6.000000e-06"
             ]
     ) as inst:
-        assert inst.start_wl == 6e-6 * pq.meter
-        inst.start_wl = value * pq.meter
+        assert inst.start_wl == 6e-6 * u.meter
+        inst.start_wl = value * u.meter
 
 
 @given(value=st.floats(min_value=600e-9, max_value=1700e-9))
@@ -111,8 +111,8 @@ def test_end_wavelength(value):
                 "6.000000e-06"
             ]
     ) as inst:
-        assert inst.stop_wl == 6e-6 * pq.meter
-        inst.stop_wl = value * pq.meter
+        assert inst.stop_wl == 6e-6 * u.meter
+        inst.stop_wl = value * u.meter
 
 
 def test_bandwidth():
@@ -127,8 +127,8 @@ def test_bandwidth():
                 "6.000000e-06"
             ]
     ) as inst:
-        assert inst.bandwidth == 6e-6 * pq.meter
-        inst.bandwidth = 1e-6 * pq.meter
+        assert inst.bandwidth == 6e-6 * u.meter
+        inst.bandwidth = 1e-6 * u.meter
 
 
 def test_span():
@@ -143,8 +143,8 @@ def test_span():
                 "6.000000e-06"
             ]
     ) as inst:
-        assert inst.span == 6e-6 * pq.meter
-        inst.span = 1e-6 * pq.meter
+        assert inst.span == 6e-6 * u.meter
+        inst.span = 1e-6 * u.meter
 
 
 def test_center_wl():
@@ -159,8 +159,8 @@ def test_center_wl():
                 "6.000000e-06"
             ]
     ) as inst:
-        assert inst.center_wl == 6e-6 * pq.meter
-        inst.center_wl = 1e-6 * pq.meter
+        assert inst.center_wl == 6e-6 * u.meter
+        inst.center_wl = 1e-6 * u.meter
 
 
 def test_points():

--- a/instruments/thorlabs/lcc25.py
+++ b/instruments/thorlabs/lcc25.py
@@ -14,7 +14,7 @@ from __future__ import division
 from builtins import range
 from enum import IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.thorlabs.thorlabs_utils import check_cmd
 
@@ -67,7 +67,7 @@ class LCC25(Instrument):
 
     frequency = unitful_property(
         "freq",
-        pq.Hz,
+        u.Hz,
         format_code="{:.1f}",
         set_fmt="{}={}",
         valid_range=(5, 150),
@@ -139,7 +139,7 @@ class LCC25(Instrument):
 
     voltage1 = unitful_property(
         "volt1",
-        pq.V,
+        u.V,
         format_code="{:.1f}",
         set_fmt="{}={}",
         valid_range=(0, 25),
@@ -154,7 +154,7 @@ class LCC25(Instrument):
 
     voltage2 = unitful_property(
         "volt2",
-        pq.V,
+        u.V,
         format_code="{:.1f}",
         set_fmt="{}={}",
         valid_range=(0, 25),
@@ -169,7 +169,7 @@ class LCC25(Instrument):
 
     min_voltage = unitful_property(
         "min",
-        pq.V,
+        u.V,
         format_code="{:.1f}",
         set_fmt="{}={}",
         valid_range=(0, 25),
@@ -184,7 +184,7 @@ class LCC25(Instrument):
 
     max_voltage = unitful_property(
         "max",
-        pq.V,
+        u.V,
         format_code="{:.1f}",
         set_fmt="{}={}",
         valid_range=(0, 25),
@@ -200,7 +200,7 @@ class LCC25(Instrument):
 
     dwell = unitful_property(
         "dwell",
-        units=pq.ms,
+        units=u.ms,
         format_code="{:n}",
         set_fmt="{}={}",
         valid_range=(0, None),
@@ -215,7 +215,7 @@ class LCC25(Instrument):
 
     increment = unitful_property(
         "increment",
-        units=pq.V,
+        units=u.V,
         format_code="{:.1f}",
         set_fmt="{}={}",
         valid_range=(0, None),

--- a/instruments/thorlabs/pm100usb.py
+++ b/instruments/thorlabs/pm100usb.py
@@ -14,7 +14,7 @@ from collections import defaultdict, namedtuple
 
 from enum import Enum, IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import enum_property
@@ -213,12 +213,12 @@ class PM100USB(SCPIInstrument):
 
     # METHODS ##
 
-    _READ_UNITS = defaultdict(lambda: pq.dimensionless)
+    _READ_UNITS = defaultdict(lambda: u.dimensionless)
     _READ_UNITS.update({
-        MeasurementConfiguration.power: pq.W,
-        MeasurementConfiguration.current: pq.A,
-        MeasurementConfiguration.frequency: pq.Hz,
-        MeasurementConfiguration.voltage: pq.V,
+        MeasurementConfiguration.power: u.W,
+        MeasurementConfiguration.current: u.A,
+        MeasurementConfiguration.frequency: u.Hz,
+        MeasurementConfiguration.voltage: u.V,
 
     })
 

--- a/instruments/thorlabs/sc10.py
+++ b/instruments/thorlabs/sc10.py
@@ -13,7 +13,7 @@ from __future__ import division
 from builtins import range
 
 from enum import IntEnum
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import (
@@ -133,7 +133,7 @@ class SC10(Instrument):
 
     open_time = unitful_property(
         "open",
-        pq.ms,
+        u.ms,
         format_code="{:.0f}",
         set_fmt="{}={}",
         valid_range=(0, 999999),
@@ -148,7 +148,7 @@ class SC10(Instrument):
 
     shut_time = unitful_property(
         "shut",
-        pq.ms,
+        u.ms,
         format_code="{:.0f}",
         set_fmt="{}={}",
         valid_range=(0, 999999),

--- a/instruments/thorlabs/tc200.py
+++ b/instruments/thorlabs/tc200.py
@@ -14,7 +14,7 @@ from __future__ import division
 from builtins import range, map
 from enum import IntEnum, Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import convert_temperature
@@ -151,7 +151,7 @@ class TC200(Instrument):
 
     temperature = unitful_property(
         "tact",
-        units=pq.degC,
+        units=u.degC,
         readonly=True,
         input_decoration=lambda x: x.replace(
             " C", "").replace(" F", "").replace(" K", ""),
@@ -168,10 +168,10 @@ class TC200(Instrument):
 
     max_temperature = unitful_property(
         "tmax",
-        units=pq.degC,
+        units=u.degC,
         format_code="{:.1f}",
         set_fmt="{}={}",
-        valid_range=(20*pq.degC, 205*pq.degC),
+        valid_range=(20*u.degC, 205*u.degC),
         doc="""
         Gets/sets the maximum temperature
 
@@ -195,12 +195,12 @@ class TC200(Instrument):
         """
         response = self.query("tset?").replace(
             " C", "").replace(" F", "").replace(" K", "")
-        return float(response) * pq.degC
+        return float(response) * u.degC
 
     @temperature_set.setter
     def temperature_set(self, newval):
         # the set temperature is always in celsius
-        newval = convert_temperature(newval, pq.degC).magnitude
+        newval = convert_temperature(newval, u.degC).magnitude
         if newval < 20.0 or newval > self.max_temperature:
             raise ValueError("Temperature set is out of range.")
         out_query = "tset={}".format(newval)
@@ -289,19 +289,19 @@ class TC200(Instrument):
         """
         response = self.status
         if (response >> 4) % 2 and (response >> 5) % 2:
-            return pq.degC
+            return u.degC
         elif (response >> 5) % 2:
-            return pq.degK
+            return u.degK
 
-        return pq.degF
+        return u.degF
 
     @degrees.setter
     def degrees(self, newval):
-        if newval is pq.degC:
+        if newval is u.degC:
             self.sendcmd("unit=c")
-        elif newval is pq.degF:
+        elif newval is u.degF:
             self.sendcmd("unit=f")
-        elif newval is pq.degK:
+        elif newval is u.degK:
             self.sendcmd("unit=k")
         else:
             raise TypeError("Invalid temperature type")
@@ -337,10 +337,10 @@ class TC200(Instrument):
 
     max_power = unitful_property(
         "pmax",
-        units=pq.W,
+        units=u.W,
         format_code="{:.1f}",
         set_fmt="{}={}",
-        valid_range=(0.1*pq.W, 18.0*pq.W),
+        valid_range=(0.1*u.W, 18.0*u.W),
         doc="""
         Gets/sets the maximum power
 

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -14,7 +14,7 @@ from __future__ import unicode_literals
 
 from builtins import range, map
 from enum import IntEnum
-import quantities as pq
+import instruments.units as u
 
 from instruments.toptica.toptica_utils import convert_toptica_boolean as ctbool
 from instruments.toptica.toptica_utils import convert_toptica_datetime as ctdate
@@ -109,7 +109,7 @@ class TopMode(Instrument):
             :units: Nanometers (nm)
             :type: `~quantities.quantity.Quantity`
             """
-            return float(self.parent.reference(self.name + ":wavelength")) * pq.nm
+            return float(self.parent.reference(self.name + ":wavelength")) * u.nm
 
         @property
         def production_date(self):
@@ -163,7 +163,7 @@ class TopMode(Instrument):
             :units: Seconds (s)
             :type: `~quantities.quantity.Quantity`
             """
-            return float(self.parent.reference(self.name + ":ontime")) * pq.s
+            return float(self.parent.reference(self.name + ":ontime")) * u.s
 
         @property
         def charm_status(self):
@@ -364,7 +364,7 @@ class TopMode(Instrument):
         For example, the following would print the wavelength from laser 1:
 
         >>> import instruments as ik
-        >>> import quantities as pq
+        >>> import instruments.units as u
         >>> tm = ik.toptica.TopMode.open_serial('/dev/ttyUSB0', 115200)
         >>> print(tm.laser[0].wavelength)
 

--- a/instruments/units.py
+++ b/instruments/units.py
@@ -6,10 +6,12 @@ Module containing custom units used by various instruments.
 
 # IMPORTS #####################################################################
 
+# pylint: disable=unused-wildcard-import, wildcard-import
+
 from __future__ import absolute_import
 from __future__ import division
 
-from quantities import Hz, milli, UnitQuantity
+from quantities import *
 from quantities.unitquantity import IrreducibleUnit
 
 # UNITS #######################################################################

--- a/instruments/util_fns.py
+++ b/instruments/util_fns.py
@@ -12,7 +12,7 @@ from __future__ import division
 import re
 
 from enum import Enum, IntEnum
-import quantities as pq
+import instruments.units as u
 
 # CONSTANTS ###################################################################
 
@@ -36,8 +36,8 @@ def assume_units(value, units):
         ``units``, depending on if ``value`` is unitful.
     :rtype: `Quantity`
     """
-    if not isinstance(value, pq.Quantity):
-        value = pq.Quantity(value, units)
+    if not isinstance(value, u.Quantity):
+        value = u.Quantity(value, units)
     return value
 
 
@@ -86,22 +86,22 @@ def convert_temperature(temperature, base):
     """
     # quantities reports equivalence between degC and degK, so a string
     # comparison is needed
-    newval = assume_units(temperature, pq.degC)
-    if newval.units == pq.degF and str(base).split(" ")[1] == 'degC':
+    newval = assume_units(temperature, u.degC)
+    if newval.units == u.degF and str(base).split(" ")[1] == 'degC':
         return_val = ((newval.magnitude - 32.0) * 5.0 / 9.0) * base
     elif str(newval.units).split(" ")[1] == 'K' and str(base).split(" ")[1] == 'degC':
         return_val = (newval.magnitude - 273.15) * base
-    elif str(newval.units).split(" ")[1] == 'K' and base == pq.degF:
+    elif str(newval.units).split(" ")[1] == 'K' and base == u.degF:
         return_val = (newval.magnitude / 1.8 - 459 / 57) * base
-    elif str(newval.units).split(" ")[1] == 'degC' and base == pq.degF:
+    elif str(newval.units).split(" ")[1] == 'degC' and base == u.degF:
         return_val = (newval.magnitude * 9.0 / 5.0 + 32.0) * base
-    elif newval.units == pq.degF and str(base).split(" ")[1] == 'K':
+    elif newval.units == u.degF and str(base).split(" ")[1] == 'K':
         return_val = ((newval.magnitude + 459.57) * 5.0 / 9.0) * base
     elif str(newval.units).split(" ")[1] == 'degC' and str(base).split(" ")[1] == 'K':
         return_val = (newval.magnitude + 273.15) * base
     elif str(newval.units).split(" ")[1] == 'degC' and str(base).split(" ")[1] == 'degC':
         return_val = newval
-    elif newval.units == pq.degF and base == pq.degF:
+    elif newval.units == u.degF and base == u.degF:
         return_val = newval
     elif str(newval.units).split(" ")[1] == 'K' and str(base).split(" ")[1] == 'K':
         return_val = newval
@@ -110,16 +110,16 @@ def convert_temperature(temperature, base):
     return return_val
 
 
-def split_unit_str(s, default_units=pq.dimensionless, lookup=None):
+def split_unit_str(s, default_units=u.dimensionless, lookup=None):
     """
     Given a string of the form "12 C" or "14.7 GHz", returns a tuple of the
     numeric part and the unit part, irrespective of how many (if any) whitespace
     characters appear between.
 
     By design, the tuple should be such that it can be unpacked into
-    :func:`pq.Quantity`::
+    :func:`u.Quantity`::
 
-        >>> pq.Quantity(*split_unit_str("1 s"))
+        >>> u.Quantity(*split_unit_str("1 s"))
         array(1) * s
 
     For this reason, the second element of the tuple may be a unit or
@@ -131,7 +131,7 @@ def split_unit_str(s, default_units=pq.dimensionless, lookup=None):
     :param callable lookup: If specified, this function is called on the
         units part of the input string. If `None`, no lookup is performed.
         Lookups are never performed on the default units.
-    :rtype: `tuple` of a `float` and a `str` or `pq.Quantity`
+    :rtype: `tuple` of a `float` and a `str` or `u.Quantity`
     """
     if lookup is None:
         lookup = lambda x: x
@@ -340,8 +340,8 @@ def unitless_property(command, set_cmd=None, format_code='{:e}', doc=None,
         return float(raw)
 
     def _setter(self, newval):
-        if isinstance(newval, pq.Quantity):
-            if newval.units == pq.dimensionless:
+        if isinstance(newval, u.Quantity):
+            if newval.units == u.dimensionless:
                 newval = float(newval.magnitude)
             else:
                 raise ValueError
@@ -470,7 +470,7 @@ def unitful_property(command, units, set_cmd=None, format_code='{:e}', doc=None,
 
     def _getter(self):
         raw = _in_decor_fcn(self.query("{}?".format(command)))
-        return pq.Quantity(*split_unit_str(raw, units)).rescale(units)
+        return u.Quantity(*split_unit_str(raw, units)).rescale(units)
 
     def _setter(self, newval):
         min_value, max_value = valid_range
@@ -545,13 +545,13 @@ def bounded_unitful_property(command, units, min_fmt_str="{}:MIN?",
 
     def _min_getter(self):
         if valid_range[0] == "query":
-            return pq.Quantity(*split_unit_str(self.query(min_fmt_str.format(command)), units))
+            return u.Quantity(*split_unit_str(self.query(min_fmt_str.format(command)), units))
 
         return assume_units(valid_range[0], units).rescale(units)
 
     def _max_getter(self):
         if valid_range[1] == "query":
-            return pq.Quantity(*split_unit_str(self.query(max_fmt_str.format(command)), units))
+            return u.Quantity(*split_unit_str(self.query(max_fmt_str.format(command)), units))
 
         return assume_units(valid_range[1], units).rescale(units)
 

--- a/instruments/yokogawa/yokogawa6370.py
+++ b/instruments/yokogawa/yokogawa6370.py
@@ -11,7 +11,7 @@ from __future__ import division
 
 from enum import IntEnum, Enum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import (
     OpticalSpectrumAnalyzer,
@@ -33,9 +33,9 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> inst = ik.yokogawa.Yokogawa6370.open_visa('TCPIP0:192.168.0.35')
-    >>> inst.start_wl = 1030e-9 * pq.m
+    >>> inst.start_wl = 1030e-9 * u.m
     """
 
     def __init__(self, *args, **kwargs):
@@ -115,7 +115,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
 
     start_wl, start_wl_min, start_wl_max = bounded_unitful_property(
         ":SENS:WAV:STAR",
-        pq.meter,
+        u.meter,
         doc="""
         The start wavelength in m.
         """,
@@ -124,7 +124,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
 
     stop_wl, stop_wl_min, stop_wl_max = bounded_unitful_property(
         ":SENS:WAV:STOP",
-        pq.meter,
+        u.meter,
         doc="""
         The stop wavelength in m.
         """,
@@ -133,7 +133,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
 
     bandwidth = unitful_property(
         ":SENS:BAND:RES",
-        pq.meter,
+        u.meter,
         doc="""
         The bandwidth in m.
         """
@@ -141,7 +141,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
 
     span = unitful_property(
         ":SENS:WAV:SPAN",
-        pq.meter,
+        u.meter,
         doc="""
         A floating point property that controls the wavelength span in m.
         """
@@ -149,7 +149,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
 
     center_wl = unitful_property(
         ":SENS:WAV:CENT",
-        pq.meter,
+        u.meter,
         doc="""
          A floating point property that controls the center wavelength m.
         """

--- a/instruments/yokogawa/yokogawa7651.py
+++ b/instruments/yokogawa/yokogawa7651.py
@@ -11,7 +11,7 @@ from __future__ import division
 
 from enum import IntEnum
 
-import quantities as pq
+import instruments.units as u
 
 from instruments.abstract_instruments import (
     PowerSupply,
@@ -31,9 +31,9 @@ class Yokogawa7651(PowerSupply, Instrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import quantities as pq
+    >>> import instruments.units as u
     >>> inst = ik.yokogawa.Yokogawa7651.open_gpibusb("/dev/ttyUSB0", 1)
-    >>> inst.voltage = 10 * pq.V
+    >>> inst.voltage = 10 * u.V
     """
 
     # INNER CLASSES #
@@ -93,7 +93,7 @@ class Yokogawa7651(PowerSupply, Instrument):
 
         @voltage.setter
         def voltage(self, newval):
-            newval = assume_units(newval, pq.volt).rescale(pq.volt).magnitude
+            newval = assume_units(newval, u.volt).rescale(u.volt).magnitude
             self.mode = self._parent.Mode.voltage
             self._parent.sendcmd('SA{};'.format(newval))
             self._parent.trigger()
@@ -115,7 +115,7 @@ class Yokogawa7651(PowerSupply, Instrument):
 
         @current.setter
         def current(self, newval):
-            newval = assume_units(newval, pq.amp).rescale(pq.amp).magnitude
+            newval = assume_units(newval, u.amp).rescale(u.amp).magnitude
             self.mode = self._parent.Mode.current
             self._parent.sendcmd('SA{};'.format(newval))
             self._parent.trigger()


### PR DESCRIPTION
First step in implementing #92 , this PR changes all the units-related references within the project to `instruments/units.py` so that we have one spot where we can manage them.