### PR TITLE
Remove all __future__ imports

### DIFF
--- a/instruments/__init__.py
+++ b/instruments/__init__.py
@@ -6,7 +6,6 @@ Defines globally-available subpackages and symbols for the instruments package.
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 from . import abstract_instruments
 from .abstract_instruments import Instrument

--- a/instruments/abstract_instruments/__init__.py
+++ b/instruments/abstract_instruments/__init__.py
@@ -4,7 +4,6 @@
 Module containing instrument abstract base classes and communication layers
 """
 
-from __future__ import absolute_import
 
 from .instrument import Instrument
 from .multimeter import Multimeter

--- a/instruments/abstract_instruments/comm/__init__.py
+++ b/instruments/abstract_instruments/comm/__init__.py
@@ -4,7 +4,6 @@
 Module containing communication layers
 """
 
-from __future__ import absolute_import
 
 from .abstract_comm import AbstractCommunicator
 

--- a/instruments/abstract_instruments/comm/abstract_comm.py
+++ b/instruments/abstract_instruments/comm/abstract_comm.py
@@ -6,9 +6,6 @@ Provides an abstract base class for file-like communication layer classes
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import abc
 import codecs

--- a/instruments/abstract_instruments/comm/file_communicator.py
+++ b/instruments/abstract_instruments/comm/file_communicator.py
@@ -6,9 +6,6 @@ Provides a communication layer for an instrument with a file on the filesystem
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import errno
 import io

--- a/instruments/abstract_instruments/comm/gpib_communicator.py
+++ b/instruments/abstract_instruments/comm/gpib_communicator.py
@@ -7,9 +7,6 @@ Industries or Prologix GPIB adapter.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from enum import Enum
 import io

--- a/instruments/abstract_instruments/comm/loopback_communicator.py
+++ b/instruments/abstract_instruments/comm/loopback_communicator.py
@@ -7,10 +7,6 @@ test connections to explore the InstrumentKit API.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import io
 import sys

--- a/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/abstract_instruments/comm/serial_communicator.py
@@ -7,9 +7,6 @@ connections.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import io
 

--- a/instruments/abstract_instruments/comm/serial_manager.py
+++ b/instruments/abstract_instruments/comm/serial_manager.py
@@ -10,8 +10,6 @@ pyserial connections can be open at the same time to the same serial port.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import weakref
 import serial

--- a/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/instruments/abstract_instruments/comm/socket_communicator.py
@@ -7,9 +7,6 @@ raw ethernet connections.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import io
 import socket

--- a/instruments/abstract_instruments/comm/usb_communicator.py
+++ b/instruments/abstract_instruments/comm/usb_communicator.py
@@ -7,9 +7,6 @@ connections.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import io
 from builtins import str

--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -7,9 +7,6 @@ instruments.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import io
 from builtins import str, bytes

--- a/instruments/abstract_instruments/comm/visa_communicator.py
+++ b/instruments/abstract_instruments/comm/visa_communicator.py
@@ -9,9 +9,6 @@ library.
 
 # pylint: disable=wrong-import-position
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import io
 from builtins import str

--- a/instruments/abstract_instruments/comm/vxi11_communicator.py
+++ b/instruments/abstract_instruments/comm/vxi11_communicator.py
@@ -7,9 +7,6 @@ VXI11 devices.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import io
 import logging

--- a/instruments/abstract_instruments/electrometer.py
+++ b/instruments/abstract_instruments/electrometer.py
@@ -6,8 +6,6 @@ Provides an abstract base class for electrometer instruments
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import abc
 from future.utils import with_metaclass

--- a/instruments/abstract_instruments/function_generator.py
+++ b/instruments/abstract_instruments/function_generator.py
@@ -6,8 +6,6 @@ Provides an abstract base class for function generator instruments
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import abc
 from enum import Enum

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -8,9 +8,6 @@ Provides the base Instrument class for all instruments.
 
 # pylint: disable=wrong-import-position
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 import os
 import collections

--- a/instruments/abstract_instruments/multimeter.py
+++ b/instruments/abstract_instruments/multimeter.py
@@ -6,8 +6,6 @@ Provides an abstract base class for multimeter instruments
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import abc
 

--- a/instruments/abstract_instruments/optical_spectrum_analyzer.py
+++ b/instruments/abstract_instruments/optical_spectrum_analyzer.py
@@ -6,8 +6,6 @@ Provides an abstract base class for optical spectrum analyzer instruments
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import abc
 
@@ -76,7 +74,6 @@ class OpticalSpectrumAnalyzer(with_metaclass(abc.ABCMeta, Instrument)):
         """
         raise NotImplementedError
 
-
     @property
     @abc.abstractmethod
     def start_wl(self):
@@ -124,7 +121,6 @@ class OpticalSpectrumAnalyzer(with_metaclass(abc.ABCMeta, Instrument)):
     @abc.abstractmethod
     def bandwidth(self, newval):
         raise NotImplementedError
-
 
     # METHODS #
 

--- a/instruments/abstract_instruments/oscilloscope.py
+++ b/instruments/abstract_instruments/oscilloscope.py
@@ -6,8 +6,6 @@ Provides an abstract base class for oscilloscope instruments
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import abc
 

--- a/instruments/abstract_instruments/power_supply.py
+++ b/instruments/abstract_instruments/power_supply.py
@@ -6,8 +6,6 @@ Provides an abstract base class for power supply instruments
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import abc
 

--- a/instruments/abstract_instruments/signal_generator/__init__.py
+++ b/instruments/abstract_instruments/signal_generator/__init__.py
@@ -4,7 +4,6 @@
 Module containing signal generator abstract base classes
 """
 
-from __future__ import absolute_import
 
 from .signal_generator import SignalGenerator
 from .single_channel_sg import SingleChannelSG

--- a/instruments/abstract_instruments/signal_generator/channel.py
+++ b/instruments/abstract_instruments/signal_generator/channel.py
@@ -6,8 +6,6 @@ Provides an abstract base class for signal generator output channels
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import abc
 

--- a/instruments/abstract_instruments/signal_generator/signal_generator.py
+++ b/instruments/abstract_instruments/signal_generator/signal_generator.py
@@ -6,8 +6,6 @@ Provides an abstract base class for signal generator instruments
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import abc
 

--- a/instruments/abstract_instruments/signal_generator/single_channel_sg.py
+++ b/instruments/abstract_instruments/signal_generator/single_channel_sg.py
@@ -7,8 +7,6 @@ output channel.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from instruments.abstract_instruments.signal_generator import SignalGenerator
 from instruments.abstract_instruments.signal_generator.channel import SGChannel

--- a/instruments/agilent/__init__.py
+++ b/instruments/agilent/__init__.py
@@ -4,7 +4,6 @@
 Module containing Agilent instruments
 """
 
-from __future__ import absolute_import
 
 from instruments.agilent.agilent33220a import Agilent33220a
 from instruments.agilent.agilent34410a import Agilent34410a

--- a/instruments/agilent/agilent33220a.py
+++ b/instruments/agilent/agilent33220a.py
@@ -6,8 +6,6 @@ Provides support for the Agilent 33220a function generator.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range
 
 from enum import Enum

--- a/instruments/agilent/agilent34410a.py
+++ b/instruments/agilent/agilent34410a.py
@@ -6,8 +6,6 @@ Provides support for the Agilent 34410a digital multimeter.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import map
 
 import instruments.units as u

--- a/instruments/config.py
+++ b/instruments/config.py
@@ -6,8 +6,6 @@ Module containing support for loading instruments from configuration files.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import warnings
 
@@ -169,6 +167,5 @@ def load_instruments(conf_file_name, conf_path="/"):
             warnings.warn("Exception occured loading device with URI "
                           "{}:\n\t{}.".format(value["uri"], ex), RuntimeWarning)
             inst_dict[name] = None
-
 
     return inst_dict

--- a/instruments/errors.py
+++ b/instruments/errors.py
@@ -6,7 +6,6 @@ Module containing custom exception errors used by various instruments.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 # CLASSES #####################################################################
 

--- a/instruments/fluke/__init__.py
+++ b/instruments/fluke/__init__.py
@@ -4,6 +4,5 @@
 Module containing Fluke instruments
 """
 
-from __future__ import absolute_import
 
 from .fluke3000 import Fluke3000

--- a/instruments/fluke/fluke3000.py
+++ b/instruments/fluke/fluke3000.py
@@ -33,8 +33,6 @@ Kit project.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 import time
 from builtins import range
 

--- a/instruments/generic_scpi/__init__.py
+++ b/instruments/generic_scpi/__init__.py
@@ -4,7 +4,6 @@
 Module containing generic SCPI instruments
 """
 
-from __future__ import absolute_import
 
 from .scpi_instrument import SCPIInstrument
 from .scpi_multimeter import SCPIMultimeter

--- a/instruments/generic_scpi/scpi_function_generator.py
+++ b/instruments/generic_scpi/scpi_function_generator.py
@@ -6,8 +6,6 @@ Provides support for SCPI compliant function generators
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import instruments.units as u
 

--- a/instruments/generic_scpi/scpi_instrument.py
+++ b/instruments/generic_scpi/scpi_instrument.py
@@ -6,8 +6,6 @@ Provides support for SCPI compliant instruments
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from builtins import map
 

--- a/instruments/generic_scpi/scpi_multimeter.py
+++ b/instruments/generic_scpi/scpi_multimeter.py
@@ -6,8 +6,6 @@ Provides support for SCPI compliant multimeters
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from enum import Enum
 

--- a/instruments/glassman/__init__.py
+++ b/instruments/glassman/__init__.py
@@ -4,6 +4,5 @@
 Module containing Glassman power supplies
 """
 
-from __future__ import absolute_import
 
 from .glassmanfr import GlassmanFR

--- a/instruments/glassman/glassmanfr.py
+++ b/instruments/glassman/glassmanfr.py
@@ -32,8 +32,6 @@ Kit project.
 """
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import bytes, round
 from struct import unpack
 

--- a/instruments/holzworth/__init__.py
+++ b/instruments/holzworth/__init__.py
@@ -4,6 +4,5 @@
 Module containing Holzworth instruments
 """
 
-from __future__ import absolute_import
 
 from .holzworth_hs9000 import HS9000

--- a/instruments/holzworth/holzworth_hs9000.py
+++ b/instruments/holzworth/holzworth_hs9000.py
@@ -6,8 +6,6 @@ Provides support for the Holzworth HS9000
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import instruments.units as u
 

--- a/instruments/hp/__init__.py
+++ b/instruments/hp/__init__.py
@@ -4,7 +4,6 @@
 Module containing HP instruments
 """
 
-from __future__ import absolute_import
 
 from .hp3456a import HP3456a
 from .hp6624a import HP6624a

--- a/instruments/hp/hp3456a.py
+++ b/instruments/hp/hp3456a.py
@@ -32,8 +32,6 @@ Kit project.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 import time
 from builtins import range
 

--- a/instruments/hp/hp6624a.py
+++ b/instruments/hp/hp6624a.py
@@ -6,8 +6,6 @@ Provides support for the HP6624a power supply
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from builtins import range
 from enum import Enum

--- a/instruments/hp/hp6632b.py
+++ b/instruments/hp/hp6632b.py
@@ -32,8 +32,6 @@ Kit project.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range
 
 from enum import Enum, IntEnum

--- a/instruments/hp/hp6652a.py
+++ b/instruments/hp/hp6652a.py
@@ -8,8 +8,6 @@ Originally contributed by Wil Langford (wil.langford+instrumentkit@gmail.com)
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import instruments.units as u
 

--- a/instruments/hp/hpe3631a.py
+++ b/instruments/hp/hpe3631a.py
@@ -33,8 +33,6 @@ Kit project.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 import time
 
 import instruments.units as u

--- a/instruments/keithley/__init__.py
+++ b/instruments/keithley/__init__.py
@@ -4,7 +4,6 @@
 Module containing Keithley instruments
 """
 
-from __future__ import absolute_import
 
 from .keithley195 import Keithley195
 from .keithley485 import Keithley485

--- a/instruments/keithley/keithley195.py
+++ b/instruments/keithley/keithley195.py
@@ -6,8 +6,6 @@ Driver for the Keithley 195 digital multimeter
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import time
 import struct

--- a/instruments/keithley/keithley2182.py
+++ b/instruments/keithley/keithley2182.py
@@ -6,8 +6,6 @@ Driver for the Keithley 2182 nano-voltmeter
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range, map
 
 from enum import Enum

--- a/instruments/keithley/keithley485.py
+++ b/instruments/keithley/keithley485.py
@@ -33,8 +33,6 @@ Kit project.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import bytes
 from struct import unpack
 

--- a/instruments/keithley/keithley580.py
+++ b/instruments/keithley/keithley580.py
@@ -33,8 +33,6 @@ Kit project.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 import time
 import struct
 

--- a/instruments/keithley/keithley6220.py
+++ b/instruments/keithley/keithley6220.py
@@ -6,8 +6,6 @@ Provides support for the Keithley 6220 constant current supply
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import instruments.units as u
 

--- a/instruments/keithley/keithley6514.py
+++ b/instruments/keithley/keithley6514.py
@@ -6,8 +6,6 @@ Provides support for the Keithley 6514 electrometer
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import map
 
 from enum import Enum

--- a/instruments/lakeshore/__init__.py
+++ b/instruments/lakeshore/__init__.py
@@ -4,7 +4,6 @@
 Module containing Lakeshore instruments
 """
 
-from __future__ import absolute_import
 
 from instruments.lakeshore.lakeshore340 import Lakeshore340
 from instruments.lakeshore.lakeshore370 import Lakeshore370

--- a/instruments/lakeshore/lakeshore340.py
+++ b/instruments/lakeshore/lakeshore340.py
@@ -6,8 +6,6 @@ Provides support for the Lakeshore 340 cryogenic temperature controller.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range
 
 import instruments.units as u

--- a/instruments/lakeshore/lakeshore370.py
+++ b/instruments/lakeshore/lakeshore370.py
@@ -6,8 +6,6 @@ Provides support for the Lakeshore 370 AC resistance bridge.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range
 
 import instruments.units as u

--- a/instruments/lakeshore/lakeshore475.py
+++ b/instruments/lakeshore/lakeshore475.py
@@ -6,8 +6,6 @@ Provides support for the Lakeshore 475 Gaussmeter.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from builtins import range
 from enum import IntEnum

--- a/instruments/minghe/__init__.py
+++ b/instruments/minghe/__init__.py
@@ -3,5 +3,4 @@
 """
 Module containing MingHe instruments
 """
-from __future__ import absolute_import
 from .mhs5200a import MHS5200

--- a/instruments/minghe/mhs5200a.py
+++ b/instruments/minghe/mhs5200a.py
@@ -8,8 +8,6 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from builtins import range
 from enum import Enum

--- a/instruments/named_struct.py
+++ b/instruments/named_struct.py
@@ -6,8 +6,6 @@ Class for quickly defining C-like structures with named fields.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import struct
 from collections import OrderedDict

--- a/instruments/newport/__init__.py
+++ b/instruments/newport/__init__.py
@@ -4,7 +4,6 @@
 Module containing Newport instruments
 """
 
-from __future__ import absolute_import
 
 from .errors import NewportError
 from .newportesp301 import (

--- a/instruments/newport/errors.py
+++ b/instruments/newport/errors.py
@@ -6,8 +6,6 @@ Provides common error handling for Newport devices.
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import datetime
 

--- a/instruments/newport/newportesp301.py
+++ b/instruments/newport/newportesp301.py
@@ -10,8 +10,6 @@ likely contains bugs and non-complete behaviour.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from functools import reduce
 from time import time, sleep
 from contextlib import contextmanager

--- a/instruments/ondax/__init__.py
+++ b/instruments/ondax/__init__.py
@@ -3,5 +3,4 @@
 """
 Module containing Ondax Instruments
 """
-from __future__ import absolute_import
 from .lm import LM

--- a/instruments/ondax/lm.py
+++ b/instruments/ondax/lm.py
@@ -8,8 +8,6 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from enum import IntEnum
 

--- a/instruments/oxford/__init__.py
+++ b/instruments/oxford/__init__.py
@@ -5,6 +5,4 @@ Module containing Oxford instruments
 """
 
 
-from __future__ import absolute_import
-
 from .oxforditc503 import OxfordITC503

--- a/instruments/oxford/oxforditc503.py
+++ b/instruments/oxford/oxforditc503.py
@@ -6,8 +6,6 @@ Provides support for the Oxford ITC 503 temperature controller.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range
 
 import instruments.units as u

--- a/instruments/phasematrix/__init__.py
+++ b/instruments/phasematrix/__init__.py
@@ -4,6 +4,5 @@
 Module containing Phase Matrix instruments
 """
 
-from __future__ import absolute_import
 
 from .phasematrix_fsw0020 import PhaseMatrixFSW0020

--- a/instruments/phasematrix/phasematrix_fsw0020.py
+++ b/instruments/phasematrix/phasematrix_fsw0020.py
@@ -6,8 +6,6 @@ Provides support for the Phase Matrix FSW0020 signal generator.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from quantities import GHz
 

--- a/instruments/picowatt/__init__.py
+++ b/instruments/picowatt/__init__.py
@@ -4,6 +4,5 @@
 Module containing Picowatt instruments
 """
 
-from __future__ import absolute_import
 
 from .picowattavs47 import PicowattAVS47

--- a/instruments/picowatt/picowattavs47.py
+++ b/instruments/picowatt/picowattavs47.py
@@ -6,8 +6,6 @@ Provides support for the Picowatt AVS 47 resistance bridge
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from builtins import range
 from enum import IntEnum

--- a/instruments/qubitekk/__init__.py
+++ b/instruments/qubitekk/__init__.py
@@ -4,7 +4,6 @@
 Module containing Qubitekk instruments
 """
 
-from __future__ import absolute_import
 
 from .cc1 import CC1
 from .mc1 import MC1

--- a/instruments/qubitekk/cc1.py
+++ b/instruments/qubitekk/cc1.py
@@ -8,8 +8,6 @@ CC1 Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range, map
 
 from enum import Enum

--- a/instruments/qubitekk/mc1.py
+++ b/instruments/qubitekk/mc1.py
@@ -8,7 +8,6 @@ MC1 Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import, division
 
 from builtins import range, map
 from enum import Enum

--- a/instruments/rigol/__init__.py
+++ b/instruments/rigol/__init__.py
@@ -4,6 +4,5 @@
 Module containing Rigol instruments
 """
 
-from __future__ import absolute_import
 
 from .rigolds1000 import RigolDS1000Series

--- a/instruments/rigol/rigolds1000.py
+++ b/instruments/rigol/rigolds1000.py
@@ -6,8 +6,6 @@ Provides support for Rigol DS-1000 series oscilloscopes.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range
 
 from enum import Enum

--- a/instruments/srs/__init__.py
+++ b/instruments/srs/__init__.py
@@ -4,7 +4,6 @@
 Module containing Lakeshore instruments
 """
 
-from __future__ import absolute_import
 
 from .srs345 import SRS345
 from .srs830 import SRS830

--- a/instruments/srs/srs345.py
+++ b/instruments/srs/srs345.py
@@ -6,8 +6,6 @@ Provides support for the SRS 345 function generator.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from enum import IntEnum
 

--- a/instruments/srs/srs830.py
+++ b/instruments/srs/srs830.py
@@ -6,8 +6,6 @@ Provides support for the SRS 830 lock-in amplifier.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import math
 import time

--- a/instruments/srs/srsctc100.py
+++ b/instruments/srs/srsctc100.py
@@ -6,8 +6,6 @@ Provides support for the SRS CTC-100 cryogenic temperature controller.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from contextlib import contextmanager
 from builtins import range
 from enum import Enum

--- a/instruments/srs/srsdg645.py
+++ b/instruments/srs/srsdg645.py
@@ -6,8 +6,6 @@ Provides support for the SRS DG645 digital delay generator.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import map
 
 from enum import IntEnum

--- a/instruments/tektronix/__init__.py
+++ b/instruments/tektronix/__init__.py
@@ -4,7 +4,6 @@
 Module containing Tektronix instruments
 """
 
-from __future__ import absolute_import
 
 from .tekdpo4104 import (
     TekDPO4104,

--- a/instruments/tektronix/tekawg2000.py
+++ b/instruments/tektronix/tekawg2000.py
@@ -6,8 +6,6 @@ Provides support for the Tektronix AWG2000 series arbitrary wave generators.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range
 
 from enum import Enum

--- a/instruments/tektronix/tekdpo4104.py
+++ b/instruments/tektronix/tekdpo4104.py
@@ -6,8 +6,6 @@ Provides support for the Tektronix DPO 4104 oscilloscope
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from time import sleep
 from builtins import range, map

--- a/instruments/tektronix/tekdpo70000.py
+++ b/instruments/tektronix/tekdpo70000.py
@@ -6,8 +6,6 @@ Provides support for the Tektronix DPO 70000 oscilloscope series
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import abc
 import time

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -6,8 +6,6 @@ Provides support for the Tektronix TDS 224 oscilloscope
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 import time
 
 from builtins import range, map

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -33,8 +33,6 @@ Based off of tektds224.py written by Steven Casagrande.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from functools import reduce
 
 import time

--- a/instruments/tests/__init__.py
+++ b/instruments/tests/__init__.py
@@ -9,8 +9,6 @@ unit tests.
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 import contextlib
 from io import BytesIO

--- a/instruments/tests/test_abstract_inst/test_function_generator.py
+++ b/instruments/tests/test_abstract_inst/test_function_generator.py
@@ -6,7 +6,6 @@ Module containing tests for the abstract function generator class
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import instruments.units as u

--- a/instruments/tests/test_agilent/test_agilent_33220a.py
+++ b/instruments/tests/test_agilent/test_agilent_33220a.py
@@ -6,7 +6,6 @@ Module containing tests for generic SCPI function generator instruments
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_agilent/test_agilent_34410a.py
+++ b/instruments/tests/test_agilent/test_agilent_34410a.py
@@ -6,7 +6,6 @@ Module containing tests for Agilent 34410a
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 from builtins import bytes
 
 import numpy as np

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -6,7 +6,6 @@ Module containing tests for the base Instrument class
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import socket
 import io

--- a/instruments/tests/test_comm/test_file.py
+++ b/instruments/tests/test_comm/test_file.py
@@ -6,7 +6,6 @@ Unit tests for the file communication layer
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_comm/test_gpibusb.py
+++ b/instruments/tests/test_comm/test_gpibusb.py
@@ -6,7 +6,6 @@ Unit tests for the GPIBUSB communication layer
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import serial

--- a/instruments/tests/test_comm/test_loopback.py
+++ b/instruments/tests/test_comm/test_loopback.py
@@ -6,7 +6,6 @@ Unit tests for the loopback communication layer
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_comm/test_serial.py
+++ b/instruments/tests/test_comm/test_serial.py
@@ -6,7 +6,6 @@ Unit tests for the serial communication layer
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import serial

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -6,7 +6,6 @@ Unit tests for the socket communication layer
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import socket
 

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -6,7 +6,6 @@ Unit tests for the USBTMC communication layer
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_comm/test_vxi11.py
+++ b/instruments/tests/test_comm/test_vxi11.py
@@ -6,7 +6,6 @@ Unit tests for the VXI11 communication layer
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_config.py
+++ b/instruments/tests/test_config.py
@@ -6,7 +6,6 @@ Module containing tests for util_fns.py
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import, unicode_literals
 
 from io import StringIO
 

--- a/instruments/tests/test_fluke/test_fluke3000.py
+++ b/instruments/tests/test_fluke/test_fluke3000.py
@@ -6,7 +6,6 @@ Module containing tests for the Fluke 3000 FC multimeter
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
@@ -6,7 +6,6 @@ Module containing tests for generic SCPI function generator instruments
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
@@ -6,7 +6,6 @@ Module containing tests for generic SCPI multimeter instruments
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_glassman/test_glassmanfr.py
+++ b/instruments/tests/test_glassman/test_glassmanfr.py
@@ -6,7 +6,6 @@ Module containing tests for the Glassman FR power supply
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 from builtins import round
 
 import instruments.units as u

--- a/instruments/tests/test_holzworth/test_holzworth_hs9000.py
+++ b/instruments/tests/test_holzworth/test_holzworth_hs9000.py
@@ -6,7 +6,6 @@ Unit tests for the Holzworth HS9000
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_hp/test_hp3456a.py
+++ b/instruments/tests/test_hp/test_hp3456a.py
@@ -6,7 +6,6 @@ Unit tests for the HP 3456a digital voltmeter
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import numpy as np
 import pytest

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -6,7 +6,6 @@ Unit tests for the HP 6624a power supply
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_hp/test_hp6632b.py
+++ b/instruments/tests/test_hp/test_hp6632b.py
@@ -6,7 +6,6 @@ Unit tests for the HP 6632b power supply
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_hp/test_hp6652a.py
+++ b/instruments/tests/test_hp/test_hp6652a.py
@@ -6,7 +6,6 @@ Unit tests for the HP 6652a single output power supply
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import instruments as ik
 from instruments.tests import expected_protocol

--- a/instruments/tests/test_hp/test_hpe3631a.py
+++ b/instruments/tests/test_hp/test_hpe3631a.py
@@ -6,7 +6,6 @@ Module containing tests for the HP E3631A power supply
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/tests/test_keithley/test_keithley2182.py
@@ -6,7 +6,6 @@ Unit tests for the Keithley 2182 nano-voltmeter
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import numpy as np
 import pytest

--- a/instruments/tests/test_keithley/test_keithley485.py
+++ b/instruments/tests/test_keithley/test_keithley485.py
@@ -6,7 +6,6 @@ Module containing tests for the Keithley 485 picoammeter
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_keithley/test_keithley6220.py
+++ b/instruments/tests/test_keithley/test_keithley6220.py
@@ -6,7 +6,6 @@ Unit tests for the Keithley 6220 constant current supply
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_keithley/test_keithley6514.py
+++ b/instruments/tests/test_keithley/test_keithley6514.py
@@ -6,7 +6,6 @@ Unit tests for the Keithley 6514 electrometer
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_minghe/test_minghe_mhs5200a.py
+++ b/instruments/tests/test_minghe/test_minghe_mhs5200a.py
@@ -6,7 +6,6 @@ Module containing tests for the MingHe MHS52000a
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import instruments.units as u

--- a/instruments/tests/test_named_struct.py
+++ b/instruments/tests/test_named_struct.py
@@ -6,7 +6,6 @@ Module containing tests for named structures.
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import, unicode_literals
 
 from unittest import TestCase
 

--- a/instruments/tests/test_newport/test_newportesp301.py
+++ b/instruments/tests/test_newport/test_newportesp301.py
@@ -6,7 +6,6 @@ Unit tests for the Newport ESP 301 axis controller
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import instruments as ik
 from instruments.tests import expected_protocol

--- a/instruments/tests/test_ondax/test_lm.py
+++ b/instruments/tests/test_ondax/test_lm.py
@@ -6,7 +6,6 @@ Unit tests for the Ondax Laser Module
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 
@@ -154,7 +153,6 @@ def test_apc_enable_not_boolean():
                 sep="\r"
         ) as lm:
             lm.apc.enabled = "foobar"
-
 
 
 def test_apc_start():

--- a/instruments/tests/test_oxford/test_oxforditc503.py
+++ b/instruments/tests/test_oxford/test_oxforditc503.py
@@ -6,7 +6,6 @@ Unit tests for the Oxford ITC 503 temperature controller
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_phasematrix/test_phasematrix_fsw0020.py
+++ b/instruments/tests/test_phasematrix/test_phasematrix_fsw0020.py
@@ -6,7 +6,6 @@ Unit tests for the Phasematrix FSW0020
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_picowatt/test_picowatt_avs47.py
+++ b/instruments/tests/test_picowatt/test_picowatt_avs47.py
@@ -6,7 +6,6 @@ Unit tests for the Picowatt AVS47
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_property_factories/__init__.py
+++ b/instruments/tests/test_property_factories/__init__.py
@@ -6,8 +6,6 @@ Module containing common code for testing the property factories
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
 
 from io import StringIO
 

--- a/instruments/tests/test_property_factories/test_bool_property.py
+++ b/instruments/tests/test_property_factories/test_bool_property.py
@@ -6,7 +6,6 @@ Module containing tests for the bool property factories
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_property_factories/test_bounded_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_bounded_unitful_property.py
@@ -6,7 +6,6 @@ Module containing tests for the bounded unitful property factories
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import instruments.units as u

--- a/instruments/tests/test_property_factories/test_enum_property.py
+++ b/instruments/tests/test_property_factories/test_enum_property.py
@@ -6,7 +6,6 @@ Module containing tests for the enum property factories
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 from enum import Enum, IntEnum
 import pytest

--- a/instruments/tests/test_property_factories/test_int_property.py
+++ b/instruments/tests/test_property_factories/test_int_property.py
@@ -6,7 +6,6 @@ Module containing tests for the int property factories
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_property_factories/test_rproperty.py
+++ b/instruments/tests/test_property_factories/test_rproperty.py
@@ -6,7 +6,6 @@ Module containing tests for the property factories
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_property_factories/test_string_property.py
+++ b/instruments/tests/test_property_factories/test_string_property.py
@@ -6,7 +6,6 @@ Module containing tests for the string property factories
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 from instruments.util_fns import string_property
 from . import MockInstrument

--- a/instruments/tests/test_property_factories/test_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_unitful_property.py
@@ -6,7 +6,6 @@ Module containing tests for the unitful property factories
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import instruments.units as u

--- a/instruments/tests/test_property_factories/test_unitless_property.py
+++ b/instruments/tests/test_property_factories/test_unitless_property.py
@@ -6,7 +6,6 @@ Module containing tests for the unitless property factory
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import instruments.units as u

--- a/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
@@ -6,7 +6,6 @@ Module containing tests for the Qubitekk CC1
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import instruments.units as u

--- a/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
@@ -6,7 +6,6 @@ Module containing tests for the Qubitekk MC1
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_split_str.py
+++ b/instruments/tests/test_split_str.py
@@ -6,7 +6,6 @@ Module containing tests for the util_fns.split_unit_str utility function
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 

--- a/instruments/tests/test_srs/test_srs345.py
+++ b/instruments/tests/test_srs/test_srs345.py
@@ -6,7 +6,6 @@ Unit tests for the SRS 345 function generator
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import numpy as np
 

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -6,7 +6,6 @@ Unit tests for the SRS 830 lock-in amplifier
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import numpy as np
 import pytest

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -6,7 +6,6 @@ Module containing tests for the SRS DG645
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import instruments.units as u
 

--- a/instruments/tests/test_tektronix/test_tektronix_tds224.py
+++ b/instruments/tests/test_tektronix/test_tektronix_tds224.py
@@ -6,7 +6,6 @@ Module containing tests for the Tektronix TDS224
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 from builtins import bytes
 
 import numpy as np

--- a/instruments/tests/test_thorlabs/test_thorlabs_apt.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_apt.py
@@ -8,7 +8,6 @@ Module containing tests for the Thorlabs TC200
 
 # pylint: disable=unused-import
 
-from __future__ import absolute_import
 
 import struct
 

--- a/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
@@ -6,7 +6,6 @@ Module containing tests for the Thorlabs LCC25
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import instruments.units as u

--- a/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
@@ -6,7 +6,6 @@ Module containing tests for the Thorlabs SC10
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import pytest
 import instruments.units as u

--- a/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
@@ -6,7 +6,6 @@ Module containing tests for the Thorlabs TC200
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 from enum import IntEnum
 import pytest

--- a/instruments/tests/test_thorlabs/test_utils.py
+++ b/instruments/tests/test_thorlabs/test_utils.py
@@ -6,7 +6,6 @@ Module containing tests for the Thorlabs util functions
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 import instruments as ik
 

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -6,7 +6,6 @@ Module containing tests for the Toptica Topmode
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 from datetime import datetime
 import pytest
 import instruments.units as u

--- a/instruments/tests/test_toptica/test_toptica_utils.py
+++ b/instruments/tests/test_toptica/test_toptica_utils.py
@@ -6,7 +6,6 @@ Module containing tests for Topical util functions
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 import datetime
 
 import pytest

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -6,7 +6,6 @@ Module containing tests for util_fns.py
 
 # IMPORTS ####################################################################
 
-from __future__ import absolute_import
 
 from builtins import range
 from enum import Enum

--- a/instruments/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/instruments/tests/test_yokogawa/test_yokogawa_6370.py
@@ -6,7 +6,6 @@ Unit tests for the Yokogawa 6370
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
 
 import struct
 

--- a/instruments/thorlabs/__init__.py
+++ b/instruments/thorlabs/__init__.py
@@ -4,7 +4,6 @@
 Module containing Thorlabs instruments
 """
 
-from __future__ import absolute_import
 
 from .thorlabsapt import (
     ThorLabsAPT, APTPiezoStage, APTStrainGaugeReader, APTMotorController

--- a/instruments/thorlabs/_abstract.py
+++ b/instruments/thorlabs/_abstract.py
@@ -6,8 +6,6 @@ Defines a generic Thorlabs instrument to define some common functionality.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import time
 

--- a/instruments/thorlabs/_cmds.py
+++ b/instruments/thorlabs/_cmds.py
@@ -8,8 +8,6 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from enum import IntEnum
 
 # CLASSES #####################################################################

--- a/instruments/thorlabs/_packets.py
+++ b/instruments/thorlabs/_packets.py
@@ -6,8 +6,6 @@ Module for working with ThorLabs packets.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import struct
 

--- a/instruments/thorlabs/lcc25.py
+++ b/instruments/thorlabs/lcc25.py
@@ -8,8 +8,6 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from builtins import range
 from enum import IntEnum

--- a/instruments/thorlabs/pm100usb.py
+++ b/instruments/thorlabs/pm100usb.py
@@ -6,8 +6,6 @@ Provides the support for the Thorlabs PM100USB power meter.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import logging
 from collections import defaultdict, namedtuple

--- a/instruments/thorlabs/sc10.py
+++ b/instruments/thorlabs/sc10.py
@@ -8,8 +8,6 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 from builtins import range
 
 from enum import IntEnum

--- a/instruments/thorlabs/tc200.py
+++ b/instruments/thorlabs/tc200.py
@@ -8,8 +8,6 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from builtins import range, map
 from enum import IntEnum, Enum

--- a/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/thorlabs/thorlabsapt.py
@@ -6,8 +6,6 @@ Provides the support for the Thorlabs APT Controller.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import re
 import struct
@@ -577,7 +575,6 @@ class APTMotorController(ThorLabsAPT):
         def motor_model(self, newval):
             self._set_scale(newval)
             self._motor_model = newval
-
 
         # MOTOR COMMANDS #
 

--- a/instruments/toptica/__init__.py
+++ b/instruments/toptica/__init__.py
@@ -4,6 +4,5 @@
 Module containing Toptica instruments
 """
 
-from __future__ import absolute_import
 
 from .topmode import TopMode

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -8,9 +8,6 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 
 from builtins import range, map
 from enum import IntEnum

--- a/instruments/toptica/toptica_utils.py
+++ b/instruments/toptica/toptica_utils.py
@@ -5,7 +5,6 @@
 Contains common utility functions for Toptica-brand instruments
 """
 
-from __future__ import absolute_import
 from datetime import datetime
 
 

--- a/instruments/units.py
+++ b/instruments/units.py
@@ -8,8 +8,6 @@ Module containing custom units used by various instruments.
 
 # pylint: disable=unused-wildcard-import, wildcard-import
 
-from __future__ import absolute_import
-from __future__ import division
 
 from quantities import *
 from quantities.unitquantity import IrreducibleUnit

--- a/instruments/util_fns.py
+++ b/instruments/util_fns.py
@@ -6,8 +6,6 @@ Module containing various utility functions
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 import re
 

--- a/instruments/yokogawa/__init__.py
+++ b/instruments/yokogawa/__init__.py
@@ -4,7 +4,6 @@
 Module containing Yokogawa instruments
 """
 
-from __future__ import absolute_import
 
 from .yokogawa6370 import Yokogawa6370
 from .yokogawa7651 import Yokogawa7651

--- a/instruments/yokogawa/yokogawa6370.py
+++ b/instruments/yokogawa/yokogawa6370.py
@@ -6,8 +6,6 @@ Provides support for the Yokogawa 6370 optical spectrum analyzer.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from enum import IntEnum, Enum
 

--- a/instruments/yokogawa/yokogawa7651.py
+++ b/instruments/yokogawa/yokogawa7651.py
@@ -6,8 +6,6 @@ Provides support for the Yokogawa 7651 power supply.
 
 # IMPORTS #####################################################################
 
-from __future__ import absolute_import
-from __future__ import division
 
 from enum import IntEnum
 


### PR DESCRIPTION
Part of the cleanup from dropping Py27, this PR removes all `__future__` references