### PR TITLE
Remove py2/3 compat code

### DIFF
--- a/doc/examples/ex_hp3456.py
+++ b/doc/examples/ex_hp3456.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, print_function
-
 import logging
 import time
 import instruments as ik

--- a/doc/source/devguide/code_style.rst
+++ b/doc/source/devguide/code_style.rst
@@ -92,7 +92,7 @@ For example::
 	class SomeInstrument(Instrument):
 		# If there's a more appropriate base class, please use it
 		# in preference to object!
-		class Channel(object):
+		class Channel:
 			# We use a three-argument initializer,
 			# to remember which instrument this channel belongs to,
 			# as well as its index or label on that instrument.
@@ -114,7 +114,7 @@ and appears with the instrument in documentation.
 Since this convention is somewhat recent, you may find older code that uses
 a style more like this::
 
-	class _SomeInstrumentChannel(object):
+	class _SomeInstrumentChannel:
 		# stuff
 
 	class SomeInstrument(Instrument):
@@ -126,7 +126,7 @@ This can be redefined in a backwards-compatible way by bringing the channel
 class inside, then defining a new module-level variable for the old name::
 
 	class SomeInstrument(Instrument):
-		class Channel(object):
+		class Channel:
 			# stuff
 
 		@property

--- a/doc/source/intro.rst
+++ b/doc/source/intro.rst
@@ -30,7 +30,6 @@ $ pip install -r requirements.txt
 - NumPy
 - `PySerial`_
 - `quantities`_
-- `future`_
 - `python-vxi11`_
 - `PyUSB`_ (version 1.0a or higher, required for raw USB support)
 - `python-usbtmc`_
@@ -42,7 +41,6 @@ Optional Dependencies
 
 .. _PySerial: http://pyserial.sourceforge.net/
 .. _quantities: http://pythonhosted.org/quantities/
-.. _future: https://pypi.python.org/pypi/future
 .. _ruamel.yaml: http://yaml.readthedocs.io
 .. _PyUSB: http://sourceforge.net/apps/trac/pyusb/
 .. _PyVISA: http://pyvisa.sourceforge.net/

--- a/instruments/abstract_instruments/comm/abstract_comm.py
+++ b/instruments/abstract_instruments/comm/abstract_comm.py
@@ -12,12 +12,10 @@ import codecs
 import logging
 import struct
 
-from future.utils import with_metaclass
-
 # CLASSES ####################################################################
 
 
-class AbstractCommunicator(with_metaclass(abc.ABCMeta, object)):
+class AbstractCommunicator(metaclass=abc.ABCMeta):
 
     """
     Abstract base class for electrometer instruments.

--- a/instruments/abstract_instruments/comm/file_communicator.py
+++ b/instruments/abstract_instruments/comm/file_communicator.py
@@ -12,8 +12,6 @@ import io
 import time
 import logging
 
-from builtins import str, bytes
-
 from instruments.abstract_instruments.comm import AbstractCommunicator
 
 logger = logging.getLogger(__name__)

--- a/instruments/abstract_instruments/comm/gpib_communicator.py
+++ b/instruments/abstract_instruments/comm/gpib_communicator.py
@@ -12,7 +12,6 @@ from enum import Enum
 import io
 import time
 
-from builtins import chr, str, bytes
 import instruments.units as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator

--- a/instruments/abstract_instruments/comm/loopback_communicator.py
+++ b/instruments/abstract_instruments/comm/loopback_communicator.py
@@ -11,8 +11,6 @@ test connections to explore the InstrumentKit API.
 import io
 import sys
 
-from builtins import input, bytes, str
-
 from instruments.abstract_instruments.comm import AbstractCommunicator
 
 # CLASSES #####################################################################

--- a/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/abstract_instruments/comm/serial_communicator.py
@@ -9,8 +9,6 @@ connections.
 
 
 import io
-
-from builtins import bytes, str
 import serial
 
 import instruments.units as u

--- a/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/instruments/abstract_instruments/comm/socket_communicator.py
@@ -11,7 +11,6 @@ raw ethernet connections.
 import io
 import socket
 
-from builtins import str, bytes
 import instruments.units as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator

--- a/instruments/abstract_instruments/comm/usb_communicator.py
+++ b/instruments/abstract_instruments/comm/usb_communicator.py
@@ -9,7 +9,6 @@ connections.
 
 
 import io
-from builtins import str
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 

--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -9,13 +9,12 @@ instruments.
 
 
 import io
-from builtins import str, bytes
 
 import usbtmc
-import instruments.units as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
+import instruments.units as u
 
 # CLASSES #####################################################################
 

--- a/instruments/abstract_instruments/comm/visa_communicator.py
+++ b/instruments/abstract_instruments/comm/visa_communicator.py
@@ -7,24 +7,14 @@ library.
 
 # IMPORTS #####################################################################
 
-# pylint: disable=wrong-import-position
-
 
 import io
-from builtins import str
 
-import instruments.units as u
+import visa
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
-
-if not getattr(__builtins__, "WindowsError", None):
-    class WindowsError(OSError):
-        pass
-try:
-    import visa
-except (ImportError, WindowsError, OSError):
-    visa = None
+import instruments.units as u
 
 # CLASSES #####################################################################
 

--- a/instruments/abstract_instruments/comm/vxi11_communicator.py
+++ b/instruments/abstract_instruments/comm/vxi11_communicator.py
@@ -11,8 +11,6 @@ VXI11 devices.
 import io
 import logging
 
-from builtins import str, bytes
-
 import vxi11
 
 from instruments.abstract_instruments.comm import AbstractCommunicator

--- a/instruments/abstract_instruments/electrometer.py
+++ b/instruments/abstract_instruments/electrometer.py
@@ -8,14 +8,13 @@ Provides an abstract base class for electrometer instruments
 
 
 import abc
-from future.utils import with_metaclass
 
 from instruments.abstract_instruments import Instrument
 
 # CLASSES #####################################################################
 
 
-class Electrometer(with_metaclass(abc.ABCMeta, Instrument)):
+class Electrometer(Instrument, metaclass=abc.ABCMeta):
 
     """
     Abstract base class for electrometer instruments.

--- a/instruments/abstract_instruments/function_generator.py
+++ b/instruments/abstract_instruments/function_generator.py
@@ -10,8 +10,6 @@ Provides an abstract base class for function generator instruments
 import abc
 from enum import Enum
 
-from future.utils import with_metaclass
-
 from instruments.abstract_instruments import Instrument
 import instruments.units as u
 from instruments.util_fns import assume_units, ProxyList
@@ -19,7 +17,7 @@ from instruments.util_fns import assume_units, ProxyList
 # CLASSES #####################################################################
 
 
-class FunctionGenerator(with_metaclass(abc.ABCMeta, Instrument)):
+class FunctionGenerator(Instrument, metaclass=abc.ABCMeta):
 
     """
     Abstract base class for function generator instruments.
@@ -33,7 +31,7 @@ class FunctionGenerator(with_metaclass(abc.ABCMeta, Instrument)):
         self._channel_count = 1
 
     # pylint:disable=protected-access
-    class Channel(with_metaclass(abc.ABCMeta, object)):
+    class Channel(metaclass=abc.ABCMeta):
         """
         Abstract base class for physical channels on a function generator.
 

--- a/instruments/abstract_instruments/function_generator.py
+++ b/instruments/abstract_instruments/function_generator.py
@@ -10,7 +10,6 @@ Provides an abstract base class for function generator instruments
 import abc
 from enum import Enum
 
-from builtins import range
 from future.utils import with_metaclass
 
 from instruments.abstract_instruments import Instrument

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -39,7 +39,7 @@ _DEFAULT_FORMATS.update({
 # CLASSES #####################################################################
 
 
-class Instrument(object):
+class Instrument:
 
     """
     This is the base instrument class from which all others are derived from.

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -6,34 +6,19 @@ Provides the base Instrument class for all instruments.
 
 # IMPORTS #####################################################################
 
-# pylint: disable=wrong-import-position
-
 
 import os
 import collections
 import socket
+import urllib.parse as parse
 
-from builtins import map
 from serial import SerialException
 from serial.tools.list_ports import comports
-
-from future.standard_library import install_aliases
 import numpy as np
-
+import visa
 import usb
 import usb.core
 import usb.util
-
-install_aliases()
-import urllib.parse as parse  # pylint: disable=wrong-import-order,import-error
-
-if not getattr(__builtins__, "WindowsError", None):
-    class WindowsError(OSError):
-        pass
-try:
-    import visa
-except (ImportError, WindowsError, OSError):
-    visa = None
 
 from instruments.abstract_instruments.comm import (
     SocketCommunicator, USBCommunicator, VisaCommunicator, FileCommunicator,

--- a/instruments/abstract_instruments/multimeter.py
+++ b/instruments/abstract_instruments/multimeter.py
@@ -9,14 +9,12 @@ Provides an abstract base class for multimeter instruments
 
 import abc
 
-from future.utils import with_metaclass
-
 from instruments.abstract_instruments import Instrument
 
 # CLASSES #####################################################################
 
 
-class Multimeter(with_metaclass(abc.ABCMeta, Instrument)):
+class Multimeter(Instrument, metaclass=abc.ABCMeta):
 
     """
     Abstract base class for multimeter instruments.

--- a/instruments/abstract_instruments/optical_spectrum_analyzer.py
+++ b/instruments/abstract_instruments/optical_spectrum_analyzer.py
@@ -9,14 +9,12 @@ Provides an abstract base class for optical spectrum analyzer instruments
 
 import abc
 
-from future.utils import with_metaclass
-
 from instruments.abstract_instruments import Instrument
 
 # CLASSES #####################################################################
 
 
-class OSAChannel(with_metaclass(abc.ABCMeta, object)):
+class OSAChannel(metaclass=abc.ABCMeta):
 
     """
     Abstract base class for physical channels on an optical spectrum analyzer.
@@ -54,7 +52,7 @@ class OSAChannel(with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
 
-class OpticalSpectrumAnalyzer(with_metaclass(abc.ABCMeta, Instrument)):
+class OpticalSpectrumAnalyzer(Instrument, metaclass=abc.ABCMeta):
 
     """
     Abstract base class for optical spectrum analyzer instruments.

--- a/instruments/abstract_instruments/oscilloscope.py
+++ b/instruments/abstract_instruments/oscilloscope.py
@@ -9,14 +9,12 @@ Provides an abstract base class for oscilloscope instruments
 
 import abc
 
-from future.utils import with_metaclass
-
 from instruments.abstract_instruments import Instrument
 
 # CLASSES #####################################################################
 
 
-class OscilloscopeDataSource(with_metaclass(abc.ABCMeta, object)):
+class OscilloscopeDataSource(metaclass=abc.ABCMeta):
 
     """
     Abstract base class for data sources (physical channels, math, ref) on
@@ -79,7 +77,7 @@ class OscilloscopeDataSource(with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
 
-class OscilloscopeChannel(with_metaclass(abc.ABCMeta, object)):
+class OscilloscopeChannel(metaclass=abc.ABCMeta):
 
     """
     Abstract base class for physical channels on an oscilloscope.
@@ -107,7 +105,7 @@ class OscilloscopeChannel(with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
 
-class Oscilloscope(with_metaclass(abc.ABCMeta, Instrument)):
+class Oscilloscope(Instrument, metaclass=abc.ABCMeta):
 
     """
     Abstract base class for oscilloscope instruments.

--- a/instruments/abstract_instruments/power_supply.py
+++ b/instruments/abstract_instruments/power_supply.py
@@ -6,17 +6,14 @@ Provides an abstract base class for power supply instruments
 
 # IMPORTS #####################################################################
 
-
 import abc
-
-from future.utils import with_metaclass
 
 from instruments.abstract_instruments import Instrument
 
 # CLASSES #####################################################################
 
 
-class PowerSupplyChannel(with_metaclass(abc.ABCMeta, object)):
+class PowerSupplyChannel(metaclass=abc.ABCMeta):
 
     """
     Abstract base class for power supply output channels.
@@ -88,7 +85,7 @@ class PowerSupplyChannel(with_metaclass(abc.ABCMeta, object)):
         pass
 
 
-class PowerSupply(with_metaclass(abc.ABCMeta, Instrument)):
+class PowerSupply(Instrument, metaclass=abc.ABCMeta):
 
     """
     Abstract base class for power supply instruments.

--- a/instruments/abstract_instruments/signal_generator/channel.py
+++ b/instruments/abstract_instruments/signal_generator/channel.py
@@ -6,15 +6,12 @@ Provides an abstract base class for signal generator output channels
 
 # IMPORTS #####################################################################
 
-
 import abc
-
-from future.utils import with_metaclass
 
 # CLASSES #####################################################################
 
 
-class SGChannel(with_metaclass(abc.ABCMeta, object)):
+class SGChannel(metaclass=abc.ABCMeta):
 
     """
     Python abstract base class representing a single channel for a signal

--- a/instruments/abstract_instruments/signal_generator/signal_generator.py
+++ b/instruments/abstract_instruments/signal_generator/signal_generator.py
@@ -9,14 +9,12 @@ Provides an abstract base class for signal generator instruments
 
 import abc
 
-from future.utils import with_metaclass
-
 from instruments.abstract_instruments import Instrument
 
 # CLASSES #####################################################################
 
 
-class SignalGenerator(with_metaclass(abc.ABCMeta, Instrument)):
+class SignalGenerator(Instrument, metaclass=abc.ABCMeta):
 
     """
     Python abstract base class for signal generators (eg microwave sources).

--- a/instruments/agilent/agilent33220a.py
+++ b/instruments/agilent/agilent33220a.py
@@ -6,13 +6,11 @@ Provides support for the Agilent 33220a function generator.
 
 # IMPORTS #####################################################################
 
-from builtins import range
-
 from enum import Enum
 
-import instruments.units as u
 
 from instruments.generic_scpi import SCPIFunctionGenerator
+import instruments.units as u
 from instruments.util_fns import (
     enum_property, int_property, bool_property, assume_units
 )

--- a/instruments/agilent/agilent34410a.py
+++ b/instruments/agilent/agilent34410a.py
@@ -6,11 +6,8 @@ Provides support for the Agilent 34410a digital multimeter.
 
 # IMPORTS #####################################################################
 
-from builtins import map
-
-import instruments.units as u
-
 from instruments.generic_scpi import SCPIMultimeter
+import instruments.units as u
 
 # CLASSES #####################################################################
 

--- a/instruments/config.py
+++ b/instruments/config.py
@@ -21,8 +21,6 @@ except ImportError:
     # the import-error check should be re-enabled.
     import ruamel_yaml as yaml  # pylint: disable=import-error
 
-from future.builtins import str
-
 import instruments.units as u
 from instruments.util_fns import setattr_expression, split_unit_str
 

--- a/instruments/fluke/fluke3000.py
+++ b/instruments/fluke/fluke3000.py
@@ -34,13 +34,10 @@ Kit project.
 # IMPORTS #####################################################################
 
 import time
-from builtins import range
-
 from enum import Enum
 
-import instruments.units as u
-
 from instruments.abstract_instruments import Multimeter
+import instruments.units as u
 
 # CLASSES #####################################################################
 

--- a/instruments/generic_scpi/scpi_instrument.py
+++ b/instruments/generic_scpi/scpi_instrument.py
@@ -6,13 +6,10 @@ Provides support for SCPI compliant instruments
 
 # IMPORTS #####################################################################
 
-
-from builtins import map
-
 from enum import IntEnum
-import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
+import instruments.units as u
 from instruments.util_fns import assume_units
 
 # CLASSES #####################################################################

--- a/instruments/glassman/glassmanfr.py
+++ b/instruments/glassman/glassmanfr.py
@@ -32,17 +32,14 @@ Kit project.
 """
 # IMPORTS #####################################################################
 
-from builtins import bytes, round
 from struct import unpack
-
 from enum import Enum
-
-import instruments.units as u
 
 from instruments.abstract_instruments import (
     PowerSupply,
     PowerSupplyChannel
 )
+import instruments.units as u
 from instruments.util_fns import assume_units
 
 # CLASSES #####################################################################

--- a/instruments/hp/hp3456a.py
+++ b/instruments/hp/hp3456a.py
@@ -33,13 +33,10 @@ Kit project.
 # IMPORTS #####################################################################
 
 import time
-from builtins import range
-
 from enum import Enum, IntEnum
 
-import instruments.units as u
-
 from instruments.abstract_instruments import Multimeter
+import instruments.units as u
 from instruments.util_fns import assume_units, bool_property, enum_property
 
 # CLASSES #####################################################################

--- a/instruments/hp/hp6624a.py
+++ b/instruments/hp/hp6624a.py
@@ -6,16 +6,13 @@ Provides support for the HP6624a power supply
 
 # IMPORTS #####################################################################
 
-
-from builtins import range
 from enum import Enum
-
-import instruments.units as u
 
 from instruments.abstract_instruments import (
     PowerSupply,
     PowerSupplyChannel
 )
+import instruments.units as u
 from instruments.util_fns import ProxyList, unitful_property, bool_property
 
 # CLASSES #####################################################################

--- a/instruments/hp/hp6632b.py
+++ b/instruments/hp/hp6632b.py
@@ -32,13 +32,11 @@ Kit project.
 
 # IMPORTS #####################################################################
 
-from builtins import range
-
 from enum import Enum, IntEnum
-import instruments.units as u
 
 from instruments.generic_scpi.scpi_instrument import SCPIInstrument
 from instruments.hp.hp6652a import HP6652a
+import instruments.units as u
 from instruments.util_fns import (unitful_property, unitless_property,
                                   bool_property, enum_property, int_property)
 

--- a/instruments/hp/hpe3631a.py
+++ b/instruments/hp/hpe3631a.py
@@ -91,7 +91,7 @@ class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
 
     # INNER CLASSES #
 
-    class Channel(object):
+    class Channel:
         """
         Class representing a power output channel on the HPe3631a.
 

--- a/instruments/keithley/keithley2182.py
+++ b/instruments/keithley/keithley2182.py
@@ -6,8 +6,6 @@ Driver for the Keithley 2182 nano-voltmeter
 
 # IMPORTS #####################################################################
 
-from builtins import range, map
-
 from enum import Enum
 import instruments.units as u
 

--- a/instruments/keithley/keithley485.py
+++ b/instruments/keithley/keithley485.py
@@ -33,14 +33,11 @@ Kit project.
 
 # IMPORTS #####################################################################
 
-from builtins import bytes
 from struct import unpack
-
 from enum import Enum
 
-import instruments.units as u
-
 from instruments.abstract_instruments import Instrument
+import instruments.units as u
 
 # CLASSES #####################################################################
 

--- a/instruments/keithley/keithley6514.py
+++ b/instruments/keithley/keithley6514.py
@@ -6,14 +6,11 @@ Provides support for the Keithley 6514 electrometer
 
 # IMPORTS #####################################################################
 
-from builtins import map
-
 from enum import Enum
-
-import instruments.units as u
 
 from instruments.abstract_instruments import Electrometer
 from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import bool_property, enum_property
 
 # CLASSES #####################################################################

--- a/instruments/lakeshore/lakeshore340.py
+++ b/instruments/lakeshore/lakeshore340.py
@@ -6,11 +6,8 @@ Provides support for the Lakeshore 340 cryogenic temperature controller.
 
 # IMPORTS #####################################################################
 
-from builtins import range
-
-import instruments.units as u
-
 from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################

--- a/instruments/lakeshore/lakeshore340.py
+++ b/instruments/lakeshore/lakeshore340.py
@@ -29,7 +29,7 @@ class Lakeshore340(SCPIInstrument):
 
     # INNER CLASSES ##
 
-    class Sensor(object):
+    class Sensor:
 
         """
         Class representing a sensor attached to the Lakeshore 340.

--- a/instruments/lakeshore/lakeshore370.py
+++ b/instruments/lakeshore/lakeshore370.py
@@ -6,11 +6,8 @@ Provides support for the Lakeshore 370 AC resistance bridge.
 
 # IMPORTS #####################################################################
 
-from builtins import range
-
-import instruments.units as u
-
 from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################

--- a/instruments/lakeshore/lakeshore370.py
+++ b/instruments/lakeshore/lakeshore370.py
@@ -33,7 +33,7 @@ class Lakeshore370(SCPIInstrument):
 
     # INNER CLASSES ##
 
-    class Channel(object):
+    class Channel:
 
         """
         Class representing a sensor attached to the Lakeshore 370.

--- a/instruments/lakeshore/lakeshore475.py
+++ b/instruments/lakeshore/lakeshore475.py
@@ -6,13 +6,10 @@ Provides support for the Lakeshore 475 Gaussmeter.
 
 # IMPORTS #####################################################################
 
-
-from builtins import range
 from enum import IntEnum
 
-import instruments.units as u
-
 from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import assume_units, bool_property
 
 # CONSTANTS ###################################################################

--- a/instruments/minghe/mhs5200a.py
+++ b/instruments/minghe/mhs5200a.py
@@ -8,12 +8,10 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-
-from builtins import range
 from enum import Enum
 
-import instruments.units as u
 from instruments.abstract_instruments import FunctionGenerator
+import instruments.units as u
 from instruments.util_fns import ProxyList, assume_units
 
 # CLASSES #####################################################################

--- a/instruments/named_struct.py
+++ b/instruments/named_struct.py
@@ -10,8 +10,6 @@ Class for quickly defining C-like structures with named fields.
 import struct
 from collections import OrderedDict
 
-from future.utils import with_metaclass
-
 # DESIGN NOTES ################################################################
 
 # This class uses the Django-like strategy described at
@@ -224,7 +222,7 @@ class HasFields(type):
         return cls
 
 
-class NamedStruct(with_metaclass(HasFields, object)):
+class NamedStruct(metaclass=HasFields):
     """
     Represents a C-style struct with one or more named fields,
     useful for packing and unpacking serialized data documented

--- a/instruments/newport/newportesp301.py
+++ b/instruments/newport/newportesp301.py
@@ -10,17 +10,14 @@ likely contains bugs and non-complete behaviour.
 
 # IMPORTS #####################################################################
 
+from contextlib import contextmanager
+from enum import IntEnum
 from functools import reduce
 from time import time, sleep
-from contextlib import contextmanager
-
-from builtins import range, map
-from enum import IntEnum
-
-import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
 from instruments.newport.errors import NewportError
+import instruments.units as u
 from instruments.util_fns import assume_units, ProxyList
 
 # ENUMS #######################################################################

--- a/instruments/newport/newportesp301.py
+++ b/instruments/newport/newportesp301.py
@@ -290,7 +290,7 @@ class NewportESP301(Instrument):
 
 
 # pylint: disable=too-many-public-methods,too-many-instance-attributes
-class NewportESP301Axis(object):
+class NewportESP301Axis:
 
     """
     Encapsulates communication concerning a single axis

--- a/instruments/ondax/lm.py
+++ b/instruments/ondax/lm.py
@@ -53,7 +53,7 @@ class LM(Instrument):
 
     # INNER CLASSES #
 
-    class _AutomaticCurrentControl(object):
+    class _AutomaticCurrentControl:
         """
         Options and functions related to the laser diode's automatic current
         control driver.
@@ -142,7 +142,7 @@ class LM(Instrument):
             """
             self._parent.sendcmd("lcoff")
 
-    class _AutomaticPowerControl(object):
+    class _AutomaticPowerControl:
         """
         Options and functions related to the laser diode's automatic power
         control driver.
@@ -231,7 +231,7 @@ class LM(Instrument):
             """
             self._parent.sendcmd("cps")
 
-    class _Modulation(object):
+    class _Modulation:
         """
         Options and functions related to the laser's optical output modulation.
 
@@ -327,7 +327,7 @@ class LM(Instrument):
                 self._parent.sendcmd("ctm")
             self._enabled = newval
 
-    class _ThermoElectricCooler(object):
+    class _ThermoElectricCooler:
         """
         Options and functions relating to the laser diode's thermo electric
         cooler.

--- a/instruments/oxford/oxforditc503.py
+++ b/instruments/oxford/oxforditc503.py
@@ -33,7 +33,7 @@ class OxfordITC503(Instrument):
 
     # INNER CLASSES #
 
-    class Sensor(object):
+    class Sensor:
 
         """
         Class representing a probe sensor on the Oxford ITC 503.

--- a/instruments/oxford/oxforditc503.py
+++ b/instruments/oxford/oxforditc503.py
@@ -6,11 +6,8 @@ Provides support for the Oxford ITC 503 temperature controller.
 
 # IMPORTS #####################################################################
 
-from builtins import range
-
-import instruments.units as u
-
 from instruments.abstract_instruments import Instrument
+import instruments.units as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################

--- a/instruments/picowatt/picowattavs47.py
+++ b/instruments/picowatt/picowattavs47.py
@@ -35,7 +35,7 @@ class PicowattAVS47(SCPIInstrument):
 
     # INNER CLASSES #
 
-    class Sensor(object):
+    class Sensor:
 
         """
         Class representing a sensor on the PicowattAVS47

--- a/instruments/picowatt/picowattavs47.py
+++ b/instruments/picowatt/picowattavs47.py
@@ -6,13 +6,10 @@ Provides support for the Picowatt AVS 47 resistance bridge
 
 # IMPORTS #####################################################################
 
-
-from builtins import range
 from enum import IntEnum
 
-import instruments.units as u
-
 from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import (enum_property, bool_property, int_property,
                                   ProxyList)
 

--- a/instruments/qubitekk/cc1.py
+++ b/instruments/qubitekk/cc1.py
@@ -8,12 +8,10 @@ CC1 Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from builtins import range, map
-
 from enum import Enum
-import instruments.units as u
 
 from instruments.generic_scpi.scpi_instrument import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import (
     ProxyList, assume_units, split_unit_str
 )

--- a/instruments/qubitekk/cc1.py
+++ b/instruments/qubitekk/cc1.py
@@ -86,7 +86,7 @@ class CC1(SCPIInstrument):
 
     # INNER CLASSES #
 
-    class Channel(object):
+    class Channel:
 
         """
         Class representing a channel on the Qubitekk CC1.

--- a/instruments/qubitekk/mc1.py
+++ b/instruments/qubitekk/mc1.py
@@ -8,13 +8,10 @@ MC1 Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-
-from builtins import range, map
 from enum import Enum
 
-import instruments.units as u
-
 from instruments.abstract_instruments import Instrument
+import instruments.units as u
 from instruments.util_fns import (
     int_property, enum_property, unitful_property, assume_units
 )

--- a/instruments/rigol/rigolds1000.py
+++ b/instruments/rigol/rigolds1000.py
@@ -6,8 +6,6 @@ Provides support for Rigol DS-1000 series oscilloscopes.
 
 # IMPORTS #####################################################################
 
-from builtins import range
-
 from enum import Enum
 
 from instruments.abstract_instruments import (

--- a/instruments/srs/srs830.py
+++ b/instruments/srs/srs830.py
@@ -10,19 +10,17 @@ Provides support for the SRS 830 lock-in amplifier.
 import math
 import time
 import warnings
-
-from builtins import range, map
 from enum import Enum, IntEnum
 
 import numpy as np
-import instruments.units as u
 
-from instruments.generic_scpi import SCPIInstrument
 from instruments.abstract_instruments.comm import (
     GPIBCommunicator,
     SerialCommunicator,
     LoopbackCommunicator
 )
+from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import (
     bool_property, bounded_unitful_property, enum_property, unitful_property
 )

--- a/instruments/srs/srsctc100.py
+++ b/instruments/srs/srsctc100.py
@@ -7,7 +7,6 @@ Provides support for the SRS CTC-100 cryogenic temperature controller.
 # IMPORTS #####################################################################
 
 from contextlib import contextmanager
-from builtins import range
 from enum import Enum
 
 import numpy as np

--- a/instruments/srs/srsctc100.py
+++ b/instruments/srs/srsctc100.py
@@ -56,7 +56,7 @@ class SRSCTC100(SCPIInstrument):
         diode = 'Diode'
         rox = 'ROX'
 
-    class Channel(object):
+    class Channel:
 
         """
         Represents an input or output channel on an SRS CTC-100 cryogenic

--- a/instruments/srs/srsdg645.py
+++ b/instruments/srs/srsdg645.py
@@ -16,7 +16,7 @@ from instruments.util_fns import assume_units, ProxyList
 # CLASSES #####################################################################
 
 
-class _SRSDG645Channel(object):
+class _SRSDG645Channel:
 
     """
     Class representing a sensor attached to the SRS DG645.
@@ -166,7 +166,7 @@ class SRSDG645(SCPIInstrument):
 
     # INNER CLASSES #
 
-    class Output(object):
+    class Output:
 
         """
         An output from the DDG.

--- a/instruments/srs/srsdg645.py
+++ b/instruments/srs/srsdg645.py
@@ -6,14 +6,11 @@ Provides support for the SRS DG645 digital delay generator.
 
 # IMPORTS #####################################################################
 
-from builtins import map
-
 from enum import IntEnum
 
-import instruments.units as u
-
-from instruments.generic_scpi import SCPIInstrument
 from instruments.abstract_instruments.comm import GPIBCommunicator
+from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import assume_units, ProxyList
 
 # CLASSES #####################################################################

--- a/instruments/tektronix/tekawg2000.py
+++ b/instruments/tektronix/tekawg2000.py
@@ -26,7 +26,7 @@ class TekAWG2000(SCPIInstrument):
 
     # INNER CLASSES #
 
-    class Channel(object):
+    class Channel:
 
         """
         Class representing a physical channel on the Tektronix AWG 2000

--- a/instruments/tektronix/tekawg2000.py
+++ b/instruments/tektronix/tekawg2000.py
@@ -6,14 +6,12 @@ Provides support for the Tektronix AWG2000 series arbitrary wave generators.
 
 # IMPORTS #####################################################################
 
-from builtins import range
-
 from enum import Enum
 
 import numpy as np
-import instruments.units as u
 
 from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import assume_units, ProxyList
 
 # CLASSES #####################################################################

--- a/instruments/tektronix/tekdpo4104.py
+++ b/instruments/tektronix/tekdpo4104.py
@@ -8,9 +8,8 @@ Provides support for the Tektronix DPO 4104 oscilloscope
 
 
 from time import sleep
-from builtins import range, map
-
 from enum import Enum
+
 import numpy as np
 
 from instruments.abstract_instruments import (

--- a/instruments/tektronix/tekdpo70000.py
+++ b/instruments/tektronix/tekdpo70000.py
@@ -6,19 +6,15 @@ Provides support for the Tektronix DPO 70000 oscilloscope series
 
 # IMPORTS #####################################################################
 
-
 import abc
-import time
-
-from builtins import range
 from enum import Enum
-
-import instruments.units as u
+import time
 
 from instruments.abstract_instruments import (
     Oscilloscope, OscilloscopeChannel, OscilloscopeDataSource
 )
 from instruments.generic_scpi import SCPIInstrument
+import instruments.units as u
 from instruments.util_fns import (
     enum_property, string_property, int_property, unitful_property,
     unitless_property, bool_property, ProxyList

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -8,11 +8,9 @@ Provides support for the Tektronix TDS 224 oscilloscope
 
 import time
 
-from builtins import range, map
 from enum import Enum
 
 import numpy as np
-import instruments.units as u
 
 from instruments.abstract_instruments import (
     OscilloscopeChannel,
@@ -21,6 +19,7 @@ from instruments.abstract_instruments import (
 )
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import ProxyList
+import instruments.units as u
 
 
 # CLASSES #####################################################################

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -54,7 +54,7 @@ from instruments.util_fns import ProxyList
 # CLASSES #####################################################################
 
 
-class _TekTDS5xxMeasurement(object):
+class _TekTDS5xxMeasurement:
 
     """
     Class representing a measurement channel on the Tektronix TDS5xx

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -33,16 +33,13 @@ Based off of tektds224.py written by Steven Casagrande.
 
 # IMPORTS #####################################################################
 
-from functools import reduce
-
-import time
-from time import sleep
 from datetime import datetime
+from enum import Enum
+from functools import reduce
 import operator
 import struct
-
-from builtins import range, map, round
-from enum import Enum
+import time
+from time import sleep
 
 import numpy as np
 

--- a/instruments/tests/__init__.py
+++ b/instruments/tests/__init__.py
@@ -12,13 +12,7 @@ unit tests.
 
 import contextlib
 from io import BytesIO
-
-from builtins import bytes, str
-
-try:
-    from unittest import mock  # from Python 3.3 onward, this is in the stdlib
-except ImportError:
-    import mock
+from unittest import mock
 
 # FUNCTIONS ##################################################################
 

--- a/instruments/tests/test_agilent/test_agilent_34410a.py
+++ b/instruments/tests/test_agilent/test_agilent_34410a.py
@@ -6,8 +6,6 @@ Module containing tests for Agilent 34410a
 
 # IMPORTS ####################################################################
 
-from builtins import bytes
-
 import numpy as np
 
 import instruments as ik

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -111,7 +111,7 @@ def test_instrument_open_serial(mock_serial_manager):
     )
 
 
-class fake_serial(object):
+class fake_serial:
     """
     Create a fake serial.Serial() object so that tests can be run without
     accessing a non-existant port.

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -9,8 +9,6 @@ Module containing tests for the base Instrument class
 
 import socket
 import io
-
-from builtins import bytes
 import serial
 from serial.tools.list_ports_common import ListPortInfo
 

--- a/instruments/tests/test_glassman/test_glassmanfr.py
+++ b/instruments/tests/test_glassman/test_glassmanfr.py
@@ -6,12 +6,9 @@ Module containing tests for the Glassman FR power supply
 
 # IMPORTS ####################################################################
 
-from builtins import round
-
-import instruments.units as u
-
 import instruments as ik
 from instruments.tests import expected_protocol
+import instruments.units as u
 
 
 # TESTS ######################################################################

--- a/instruments/tests/test_property_factories/__init__.py
+++ b/instruments/tests/test_property_factories/__init__.py
@@ -14,7 +14,7 @@ from io import StringIO
 # pylint: disable=missing-docstring
 
 
-class MockInstrument(object):
+class MockInstrument:
 
     """
     Mock class that admits sendcmd/query but little else such that property

--- a/instruments/tests/test_tektronix/test_tektronix_tds224.py
+++ b/instruments/tests/test_tektronix/test_tektronix_tds224.py
@@ -6,8 +6,6 @@ Module containing tests for the Tektronix TDS224
 
 # IMPORTS ####################################################################
 
-from builtins import bytes
-
 import numpy as np
 
 import instruments as ik

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -23,7 +23,7 @@ from instruments.util_fns import (
 
 
 def test_ProxyList_basics():
-    class ProxyChild(object):
+    class ProxyChild:
 
         def __init__(self, parent, name):
             self._parent = parent
@@ -39,7 +39,7 @@ def test_ProxyList_basics():
 
 
 def test_ProxyList_valid_range_is_enum():
-    class ProxyChild(object):
+    class ProxyChild:
 
         def __init__(self, parent, name):
             self._parent = parent
@@ -58,7 +58,7 @@ def test_ProxyList_valid_range_is_enum():
 
 
 def test_ProxyList_length():
-    class ProxyChild(object):
+    class ProxyChild:
 
         def __init__(self, parent, name):
             self._parent = parent
@@ -72,7 +72,7 @@ def test_ProxyList_length():
 
 
 def test_ProxyList_iterator():
-    class ProxyChild(object):
+    class ProxyChild:
 
         def __init__(self, parent, name):
             self._parent = parent
@@ -90,7 +90,7 @@ def test_ProxyList_iterator():
 
 def test_ProxyList_invalid_idx_enum():
     with pytest.raises(IndexError):
-        class ProxyChild(object):
+        class ProxyChild:
 
             def __init__(self, parent, name):
                 self._parent = parent
@@ -109,7 +109,7 @@ def test_ProxyList_invalid_idx_enum():
 
 def test_ProxyList_invalid_idx():
     with pytest.raises(IndexError):
-        class ProxyChild(object):
+        class ProxyChild:
 
             def __init__(self, parent, name):
                 self._parent = parent
@@ -169,7 +169,7 @@ def test_assume_units_failures():
         assume_units(1, 'm').rescale('s')
 
 def test_setattr_expression_simple():
-    class A(object):
+    class A:
         x = 'x'
         y = 'y'
         z = 'z'
@@ -179,7 +179,7 @@ def test_setattr_expression_simple():
     assert a.x == 'foo'
 
 def test_setattr_expression_index():
-    class A(object):
+    class A:
         x = ['x', 'y', 'z']
 
     a = A()
@@ -187,9 +187,9 @@ def test_setattr_expression_index():
     assert a.x[1] == 'foo'
 
 def test_setattr_expression_nested():
-    class B(object):
+    class B:
         x = 'x'
-    class A(object):
+    class A:
         b = None
         def __init__(self):
             self.b = B()
@@ -199,9 +199,9 @@ def test_setattr_expression_nested():
     assert a.b.x == 'foo'
 
 def test_setattr_expression_both():
-    class B(object):
+    class B:
         x = 'x'
-    class A(object):
+    class A:
         b = None
         def __init__(self):
             self.b = [B()]

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -6,8 +6,6 @@ Module containing tests for util_fns.py
 
 # IMPORTS ####################################################################
 
-
-from builtins import range
 from enum import Enum
 
 import pytest

--- a/instruments/thorlabs/_packets.py
+++ b/instruments/thorlabs/_packets.py
@@ -29,7 +29,7 @@ hw_info_data = struct.Struct(
 # CLASSES #####################################################################
 
 
-class ThorLabsPacket(object):
+class ThorLabsPacket:
 
     """
     This class is used to wrap data to-/from- the instrument. Because of the

--- a/instruments/thorlabs/lcc25.py
+++ b/instruments/thorlabs/lcc25.py
@@ -8,15 +8,12 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-
-from builtins import range
 from enum import IntEnum
-
-import instruments.units as u
 
 from instruments.thorlabs.thorlabs_utils import check_cmd
 
 from instruments.abstract_instruments import Instrument
+import instruments.units as u
 from instruments.util_fns import enum_property, bool_property, unitful_property
 
 # CLASSES #####################################################################

--- a/instruments/thorlabs/pm100usb.py
+++ b/instruments/thorlabs/pm100usb.py
@@ -72,7 +72,7 @@ class PM100USB(SCPIInstrument):
 
     # INNER CLASSES #
 
-    class Sensor(object):
+    class Sensor:
         """
         Class representing a sensor on the ThorLabs PM100USB
 

--- a/instruments/thorlabs/sc10.py
+++ b/instruments/thorlabs/sc10.py
@@ -8,16 +8,14 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-from builtins import range
-
 from enum import IntEnum
-import instruments.units as u
 
 from instruments.abstract_instruments import Instrument
+from instruments.thorlabs.thorlabs_utils import check_cmd
+import instruments.units as u
 from instruments.util_fns import (
     bool_property, enum_property, int_property, unitful_property
 )
-from instruments.thorlabs.thorlabs_utils import check_cmd
 
 # CLASSES #####################################################################
 

--- a/instruments/thorlabs/tc200.py
+++ b/instruments/thorlabs/tc200.py
@@ -8,15 +8,13 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-
-from builtins import range, map
 from enum import IntEnum, Enum
 
-import instruments.units as u
-
 from instruments.abstract_instruments import Instrument
-from instruments.util_fns import convert_temperature
-from instruments.util_fns import enum_property, unitful_property, int_property
+import instruments.units as u
+from instruments.util_fns import (
+    convert_temperature, enum_property, unitful_property, int_property
+)
 
 # CLASSES #####################################################################
 

--- a/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/thorlabs/thorlabsapt.py
@@ -13,10 +13,8 @@ import logging
 import codecs
 import warnings
 
-from builtins import range
-import instruments.units as u
-
 from instruments.thorlabs import _abstract, _packets, _cmds
+import instruments.units as u
 from instruments.util_fns import assume_units
 
 # LOGGING #####################################################################

--- a/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/thorlabs/thorlabsapt.py
@@ -33,7 +33,7 @@ class ThorLabsAPT(_abstract.ThorLabsInstrument):
     thorlabs source folder.
     """
 
-    class APTChannel(object):
+    class APTChannel:
 
         """
         Represents a channel within the hardware device. One device can have

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -8,14 +8,12 @@ Class originally contributed by Catherine Holloway.
 
 # IMPORTS #####################################################################
 
-
-from builtins import range, map
 from enum import IntEnum
-import instruments.units as u
 
+from instruments.abstract_instruments import Instrument
 from instruments.toptica.toptica_utils import convert_toptica_boolean as ctbool
 from instruments.toptica.toptica_utils import convert_toptica_datetime as ctdate
-from instruments.abstract_instruments import Instrument
+import instruments.units as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -60,7 +60,7 @@ class TopMode(Instrument):
 
     # INNER CLASSES #
 
-    class Laser(object):
+    class Laser:
 
         """
         Class representing a laser on the Toptica Topmode.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ numpy
 pyserial
 pyvisa>=1.9
 quantities>=0.12.1
-future>=0.15
 python-vxi11>=0.8
 pyusb
 python-usbtmc

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ INSTALL_REQUIRES = [
     "pyserial>=3.3",
     "pyvisa>=1.9",
     "quantities>=0.12.1",
-    "future>=0.15",
     "python-vxi11>=0.8",
     "python-usbtmc",
     "pyusb",


### PR DESCRIPTION
Throws out a lot of the Python 2 & 3 dual compatibility code and removes `future` as a dependency