### PR TITLE
Added instrument: Newport Agilis

### DIFF
--- a/doc/source/apiref/newport.rst
+++ b/doc/source/apiref/newport.rst
@@ -7,6 +7,17 @@
 Newport
 =======
 
+:class:`Agilis` Piezo Motor Controller
+======================================
+
+.. autoclass:: AGUC2
+    :members:
+    :undoc-members:
+
+.. autoclass:: _Axis
+    :members:
+    :undoc-members:
+
 :class:`NewportESP301` Motor Controller
 =======================================
 

--- a/instruments/newport/__init__.py
+++ b/instruments/newport/__init__.py
@@ -4,6 +4,7 @@
 Module containing Newport instruments
 """
 
+from .agilis import AGUC2
 
 from .errors import NewportError
 from .newportesp301 import (

--- a/instruments/newport/agilis.py
+++ b/instruments/newport/agilis.py
@@ -406,8 +406,24 @@ class AGUC2(Instrument):
 
         :rtype: `_Axis`
         """
-        self.set_remote_mode()
+        self.enable_remote_mode = True
         return ProxyList(self, _Axis, AGUC2.Axes)
+
+    @property
+    def enable_remote_mode(self):
+        """
+        Gets / sets the status of remote mode.
+        """
+        return self._remote_mode
+
+    @enable_remote_mode.setter
+    def enable_remote_mode(self, newval):
+        if newval and not self._remote_mode:
+            self._remote_mode = True
+            self.ag_sendcmd('MR')
+        elif not newval and self._remote_mode:
+            self._remote_mode = False
+            self.ag_sendcmd('ML')
 
     @property
     def error_previous_command(self):
@@ -448,7 +464,7 @@ class AGUC2(Instrument):
 
         If device has no limit switch, this routine always returns PH0
         """
-        self.set_remote_mode()
+        self.enable_remote_mode = True
         resp = self.ag_query("PH")
         return resp
 
@@ -479,24 +495,6 @@ class AGUC2(Instrument):
         """
         self._remote_mode = False
         self.ag_sendcmd("RS")
-
-    def set_local_mode(self):
-        """
-        Puts the controler into local mode if not already and sets the private
-        self._remote_mode bool to false
-        """
-        if self._remote_mode:
-            self._remote_mode = False
-            self.ag_sendcmd('ML')
-
-    def set_remote_mode(self):
-        """
-        Puts the stage into remote mode if not already and sets the private
-        self._remote_mode bool to true
-        """
-        if not self._remote_mode:
-            self._remote_mode = True
-            self.ag_sendcmd('MR')
 
     # SEND COMMAND AND QUERY ROUTINES AGILIS STYLE #
 

--- a/instruments/newport/agilis.py
+++ b/instruments/newport/agilis.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Provides support for the Newport Agilis Controller AG-UC2 only (currently).
+
+Agilis controllers are piezo driven motors that do not have support for units.
+All units used in this document are given as steps.
+
+Currently I only have a AG-PR100 rotation stage available for testing. This
+device does not contain a limit switch and certain routines are therefore
+completely untested! These are labeled in their respective docstring with:
+    `UNTESTED: SEE COMMENT ON TOP`
+
+The governing document for the commands and implementation is:
+
+Agilis Series, Piezo Motor Driven Components, User's Manual, v2.2.x,
+by Newport, especially chapter 4.7: "ASCII Command Set"
+Document number from footer: EDH0224En5022 — 10/12
+
+Routines not implemented at all:
+- Measure current position (MA command):
+  This routine interrupts the communication and
+  restarts it afterwards. It can, according to the documentation, take up to
+  2 minutes to complete. It is furthermore only available on stages with limit
+  switches. I currently do not have the capability to implement this therefore.
+- Absolute Move (PA command):
+  Exactly the same reason as for MA command.
+"""
+
+# IMPORTS #####################################################################
+
+from time import sleep
+
+from enum import IntEnum
+
+from instruments.abstract_instruments import Instrument
+from instruments.util_fns import ProxyList
+
+# CLASSES #####################################################################
+
+
+class _Axis:
+
+    """
+    Class representing one axis attached to a Controller. This will likely
+    work with the AG-UC8 controller as well.
+
+    .. warning:: This class should NOT be manually created by the user. It is
+        designed to be initialized by a Controller class
+    """
+
+    def __init__(self, cont, ax):
+        if not isinstance(cont, AGUC2):
+            raise TypeError("Don't do that.")
+
+        # set axis integer
+        if isinstance(ax, AGUC2.Axes):
+            self._ax = ax.value
+        else:
+            self._ax = ax
+
+        # set controller
+        self._cont = cont
+
+    # PROPERTIES #
+
+    @property
+    def axis_status(self):
+        """
+        Returns the status of the current axis.
+        """
+        resp = self._cont.ag_query("{} TS".format(
+            int(self._ax)
+        ))
+        if resp.find('TS') == -1:
+            return "Status code query failed."
+
+        resp = int(resp.replace(str(int(self._ax)) + 'TS', ''))
+        status_message = agilis_status_message(resp)
+        return status_message
+
+    @property
+    def jog(self):
+        """
+        Start jog motion / get jog mode
+        Defined jog steps are defined with `step_amplitude` function (default
+        16). If a jog mode is supplied, the jog motion is started. Otherwise
+        the current jog mode is queried. Valid jog modes are:
+
+        -4 — Negative direction, 666 steps/s at defined step amplitude.
+        -3 — Negative direction, 1700 steps/s at max. step amplitude.
+        -2 — Negative direction, 100 step/s at max. step amplitude.
+        -1 — Negative direction, 5 steps/s at defined step amplitude.
+         0 — No move, go to READY state.
+         1 — Positive direction, 5 steps/s at defined step amplitude.
+         2 — Positive direction, 100 steps/s at max. step amplitude.
+         3 — Positive direction, 1700 steps/s at max. step amplitude.
+         4 — Positive direction, 666 steps/s at defined step amplitude.
+
+        If the jog mode is queried it is returend as a string.
+        """
+        resp = self._cont.ag_query("{} JA?".format(
+            int(self._ax)
+        ))
+        return resp
+
+    @jog.setter
+    def jog(self, mode):
+        mode = int(mode)
+        if mode < -4 or mode > 4:
+            raise ValueError("Jog mode out of range. Must be between -4 and "
+                             "4.")
+
+        self._cont.ag_sendcmd("{} JA {}".format(
+            int(self._ax),
+            mode
+        ))
+
+    @property
+    def number_of_steps(self):
+        """
+        Returns the number of accumulated steps in forward direction minus
+        the number of steps in backward direction since powering the
+        controller or since the last ZP (zero position) command, whatever
+        was last.
+
+        Note:
+        The step size of the Agilis devices are not 100% repeatable and
+        vary between forward and backward direction. Furthermore, the step
+        size can be modified using the SU command. Consequently, the TP
+        command provides only limited information about the actual position
+        of the device. In particular, an Agilis device can be at very
+        different positions even though a TP command may return the same
+        result.
+
+        Returns xTPnn where x is the axis queried and nn are the steps.
+        """
+        resp = self._cont.ag_query("{} TP".format(
+            int(self._ax)
+        ))
+        return resp
+
+    @property
+    def move_relative(self):
+        """
+        Moves the axis by nn steps / Queries the status of the axis.
+        Steps must be given a number that can be converted to a signed integer
+        between -2,147,483,648 and 2,147,483,647.
+        If queried, command returns the current target position. At least this
+        is the expected behaviour, never worked with the rotation stage.
+        """
+        resp = self._cont.ag_query("{} PR?".format(
+            int(self._ax)
+        ))
+        return resp
+
+    @move_relative.setter
+    def move_relative(self, steps):
+        steps = int(steps)
+        if steps < -2147483648 or steps > 2147483647:
+            raise ValueError("Number of steps are out of range. They must be "
+                             "between -2,147,483,648 and 2,147,483,647")
+
+        self._cont.ag_sendcmd("{} PR {}".format(
+            int(self._ax),
+            steps
+        ))
+
+    @property
+    def move_to_limit(self):
+        """
+        UNTESTED: SEE COMMENT ON TOP
+
+        The  command functions properly only with devices that feature a
+        limit switch like models AG-LS25, AG-M050L and AG-M100L.
+
+        Starts a jog motion at a defined speed to the limit and stops
+        automatically when the limit is activated. See `jog` command for
+        details on available modes.
+
+        Returns the distance of the current position to the limit in
+        1/1000th of the total travel.
+        """
+        resp = self._cont.ag_query("{} MA?".format(
+            int(self._ax)
+        ))
+        return resp
+
+    @move_to_limit.setter
+    def move_to_limit(self, mode):
+        mode = int(mode)
+        if mode < -4 or mode > 4:
+            raise ValueError("Jog mode out of range. Must be between -4 and "
+                             "4.")
+
+        self._cont.ag_sendcmd("{} MA {}".format(
+            int(self._ax),
+            mode
+        ))
+
+    @property
+    def step_amplitude(self):
+        """
+        Sets / Gets the step_amplitude.
+
+        Sets the step amplitude (step size) in positive and / or negative
+        direction. If the parameter is positive, it will set the step
+        amplitude in the forward direction. If the parameter is negative,
+        it will set the step amplitude in the backward direction. You can also
+        provide a tuple or list of two values (one positive, one negative),
+        which will set both values.
+        Valid values are between -50 and 50, except for 0.
+        If queried, returns a tuple of first the negative, then the positive
+        step amplitude response in the format xSUnn where x is the axis and
+        nn the step amplitude
+        """
+        resp_neg = self._cont.ag_query("{} SU-?".format(
+            int(self._ax)
+        ))
+        resp_pos = self._cont.ag_query("{} SU+?".format(
+            int(self._ax)
+        ))
+        return resp_neg, resp_pos
+
+    @step_amplitude.setter
+    def step_amplitude(self, nns):
+        if not isinstance(nns, tuple) and not isinstance(nns, list):
+            nns = [nns]
+
+        # check all values for validity
+        for nn in nns:
+            nn = int(nn)
+            if nn < -50 or nn > 50 or nn == 0:
+                raise ValueError("Step amplitude {} outside the valid range. "
+                                 "It must be between -50 and -1 or between "
+                                 "1 and 50.".format(nn))
+
+        for nn in nns:
+            self._cont.ag_sendcmd("{} SU {}".format(
+                int(self._ax),
+                int(nn)
+            ))
+
+    @property
+    def step_delay(self):
+        """
+        Sets/gets the step delay of stepping mode. The delay applies for both
+        positive and negative directions. The delay is programmed as multiple
+        of 10µs. For example, a delay of 40 is equivalent to
+        40 x 10 µs = 400 µs. The maximum value of the parameter is equal to a
+        delay of 2 seconds between pulses. By default, after reset, the value
+        is 0.
+        Setter: value must be integer between 0 and 200000 included
+        If queried, command returns the currently set step delay as a string
+        in the format xDLnn where x is the axis number and nn the step delay
+        value.
+        """
+        resp = self._cont.ag_query("{} DL?".format(
+            int(self._ax)
+        ))
+        return resp
+
+    @step_delay.setter
+    def step_delay(self, nn):
+        nn = int(nn)
+        if nn < 0 or nn > 200000:
+            raise ValueError("Step delay is out of range. It must be between "
+                             "0 and 200000.")
+
+        self._cont.ag_sendcmd("{} DL {}".format(
+            int(self._ax),
+            nn
+        ))
+
+    # MODES #
+
+    def am_i_still(self, max_retries=5):
+        """
+        Function to test if an axis stands still. It queries the status of
+        the given axis and returns True (if axis is still) or False if it is
+        moving.
+        The reason this routine is implemented is because the status messages
+        can time out. If a timeout occurs, this routine will retry the query
+        until `max_retries` is reached. If query is still not successful, an
+        IOError will be raised.
+
+        :param int max_retries: Maximum number of retries
+
+        :return: True if the axis is still, False if the axis is moving
+        :rtype: bool
+        """
+        retries = 0
+
+        while retries < max_retries:
+            status = self.axis_status
+            if status == agilis_status_message(0):
+                return True
+            elif status == agilis_status_message(1) or \
+                status == agilis_status_message(2) or \
+                status == agilis_status_message(3):
+                return False
+            else:
+                retries += 1
+
+        raise IOError("The function `am_i_still` ran out of maximum retries. "
+                      "Could not query the status of the axis.")
+
+    def stop(self):
+        """
+        Stops the axis. This is useful to interrupt a jogging motion.
+        """
+        self._cont.ag_sendcmd("{} ST".format(
+            int(self._ax)
+        ))
+
+    def zero_position(self):
+        """
+        Resets the step counter to zero. See `number_of_steps` for details.
+        """
+        self._cont.ag_sendcmd("{} ZP".format(
+            int(self._ax)
+        ))
+
+
+class AGUC2(Instrument):
+
+    """
+    Handles the communication with the AGUC2 controller using the serial
+    connection.
+
+    Example usage:
+
+    >>> import instruments as ik
+    >>> agl = ik.newport.AGUC2.open_serial(port='COM5', baud=921600)
+
+    This loads a controller into the instance `agl`. The two axis are
+    called 'X' (axis 1) and 'Y' (axis 2). Controller commands and settings
+    can be executed as following, as examples:
+
+    Reset the controller:
+
+    >>> agl.reset_controller()
+
+    Print the firmware version:
+
+    >>> print(agl.firmware_version)
+
+    Individual axes can be controlled and queried as following:
+
+    Relative move by 1000 steps:
+
+    >>> agl.axis["X"].move_relative(1000)
+
+    Activate jogging in mode 3:
+
+    >>> agl.axis["X"].jog(3)
+
+    Jogging will continue until the axis is stopped
+
+    >>> agl.axis["X"].stop()
+
+    Query the step amplitude, then set the postive one to +10 and the
+    negative one to -20
+
+    >>> print(agl.axis["X"].step_amplitude)
+    >>> agl.axis["X"].step_amplitude = 10
+    >>> agl.axis["X"].step_amplitude = -20
+    """
+
+    def __init__(self, filelike):
+        super(AGUC2, self).__init__(filelike)
+
+        # Instrument requires '\r\n' line termination
+        self.terminator = '\r\n'
+
+        # Some local variables
+        self._remote_mode = False
+        self._sleep_time = 0.25
+
+    # ENUMS #
+
+    class Axes(IntEnum):
+        """
+        Enumeration of valid delay channels for the AG-UC2 controller.
+        """
+        X = 1
+        Y = 2
+
+    # INNER CLASSES #
+
+    # PROPERTIES #
+
+    @property
+    def axis(self):
+        """
+        Gets a specific axis object.
+
+        The desired axis is accessed by passing an EnumValue from
+        `~AGUC2.Channels`. For example, to access the X axis (axis 1):
+
+        >>> import instruments as ik
+        >>> agl = ik.newport.AGUC2.open_serial(port='COM5', baud=921600)
+        >>> agl.axis["X"].move_relative(1000)
+
+        See example in `AGUC2` for a more details
+
+        :rtype: `_Axis`
+        """
+        self.set_remote_mode()
+        return ProxyList(self, _Axis, AGUC2.Axes)
+
+    @property
+    def error_previous_command(self):
+        """
+        Retrieves the error of the previous command and translates it into a
+        string. The string is returned
+        """
+        resp = self.ag_query('TE')
+
+        if resp.find('TE') == -1:
+            return "Error code query failed."
+
+        resp = int(resp.replace('TE', ''))
+        error_message = agilis_error_message(resp)
+        return error_message
+
+    @property
+    def firmware_version(self):
+        """
+        Returns the firmware version of the controller
+        """
+        resp = self.ag_query('VE')
+        return resp
+
+    @property
+    def limit_status(self):
+        """
+        PARTLY UNTESTED: SEE COMMENT ABOVE
+
+        Returns the limit switch status of the controller. Possible returns
+        are:
+        - PH0: No limit switch is active
+        - PH1: Limit switch of axis #1 (X) is active,
+               limit switch of axis #2 (Y)  is not active
+        - PH2: Limit switch of axis #2 (Y) is active,
+               limit switch of axis #1 (X) is not active
+        - PH3: Limit switches of axis #1 (X) and axis #2 (Y) are active
+
+        If device has no limit switch, this routine always returns PH0
+        """
+        self.set_remote_mode()
+        resp = self.ag_query("PH")
+        return resp
+
+    @property
+    def sleep_time(self):
+        """
+        The device often times out. Therefore a sleep time can be set. The
+        routine will wait for this amount (in seconds) every time after a
+        command or a query are sent.
+        Setting the sleep time: Give time in seconds
+        If queried: Returns the sleep time in seconds as a float
+        """
+        return self._sleep_time
+
+    @sleep_time.setter
+    def sleep_time(self, t):
+        if t < 0:
+            raise ValueError("Sleep time must be >= 0.")
+
+        self._sleep_time = float(t)
+
+    # MODES #
+
+    def reset_controller(self):
+        """
+        Resets the controller. All temporary settings are reset to the default
+        value. Controller is put into local model.
+        """
+        self._remote_mode = False
+        self.ag_sendcmd("RS")
+
+    def set_local_mode(self):
+        """
+        Puts the controler into local mode if not already and sets the private
+        self._remote_mode bool to false
+        """
+        if self._remote_mode:
+            self._remote_mode = False
+            self.ag_sendcmd('ML')
+
+    def set_remote_mode(self):
+        """
+        Puts the stage into remote mode if not already and sets the private
+        self._remote_mode bool to true
+        """
+        if not self._remote_mode:
+            self._remote_mode = True
+            self.ag_sendcmd('MR')
+
+    # SEND COMMAND AND QUERY ROUTINES AGILIS STYLE #
+
+    def ag_sendcmd(self, cmd):
+        """
+        Sends the command, then sleeps
+        """
+        self.sendcmd(cmd)
+        sleep(self._sleep_time)
+
+    def ag_query(self, cmd, size=-1):
+        """
+        This runs the query command. However, the query command often times
+        out for this device. The response of all queries are always strings.
+        If timeout occurs, the response will be:
+        "Query timed out."
+        """
+        try:
+            resp = self.query(cmd, size=size)
+        except IOError:
+            resp = "Query timed out."
+
+        # sleep
+        sleep(self._sleep_time)
+
+        return resp
+
+
+def agilis_error_message(error_code):
+    """
+    Returns a string with th error message for a given Agilis error code.
+
+    :param int error_code: error code as an integer
+
+    :return: error message
+    :rtype: string
+    """
+    if not isinstance(error_code, int):
+        return "Error code is not an integer."
+
+    error_dict = {
+        0: "No error",
+        -1: "Unknown command",
+        -2: "Axis out of range (must be 1 or 2, or must not be specified)",
+        -3: "Wrong format for parameter nn (or must not be specified)",
+        -4: "Parameter nn out of range",
+        -5: "Not allowed in local mode",
+        -6: "Not allowed in current state"
+    }
+
+    if error_code in error_dict.keys():
+        return error_dict[error_code]
+    else:
+        return "An unknown error occurred."
+
+
+def agilis_status_message(status_code):
+    """
+        Returns a string with the status message for a given Agilis status
+        code.
+
+        :param int status_code: status code as returned
+
+        :return: status message
+        :rtype: string
+        """
+    if not isinstance(status_code, int):
+        return "Status code is not an integer."
+
+    status_dict = {
+        0: "Ready (not moving).",
+        1: "Stepping (currently executing a `move_relative` command).",
+        2: "Jogging (currently executing a `jog` command with command"
+           "parameter different than 0).",
+        3: "Moving to limit (currently executing `measure_current_position`, "
+           "`move_to_limit`, or `move_absolute` command).",
+    }
+
+    if status_code in status_dict.keys():
+        return status_dict[status_code]
+    else:
+        return "An unknown status occurred."

--- a/instruments/tests/test_newport/test_agilis.py
+++ b/instruments/tests/test_newport/test_agilis.py
@@ -16,6 +16,26 @@ from instruments.tests import expected_protocol
 # CONTROLLER TESTS #
 
 
+def test_aguc2_enable_remote_mode():
+    """
+    Check enabling of remote mode.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "MR",
+                "ML"
+            ],
+            [
+            ],
+            sep="\r\n"
+    ) as agl:
+        agl.enable_remote_mode = True
+        assert agl.enable_remote_mode is True
+        agl.enable_remote_mode = False
+        assert agl.enable_remote_mode is False
+
+
 def test_aguc2_error_previous_command():
     """
     Check the call error of previous command routine. Note that the test will
@@ -57,15 +77,15 @@ def test_aguc2_limit_status():
     Check the limit status routine.
     """
     with expected_protocol(
-        ik.newport.AGUC2,
-        [
-            "MR",   # initialize remote mode
-            "PH"
-        ],
-        [
-            "PH0"
-        ],
-        sep="\r\n"
+            ik.newport.AGUC2,
+            [
+                "MR",   # initialize remote mode
+                "PH"
+            ],
+            [
+                "PH0"
+            ],
+            sep="\r\n"
     ) as agl:
         assert agl.limit_status == "PH0"
 
@@ -75,12 +95,12 @@ def test_aguc2_sleep_time():
     Check setting, getting the sleep time.
     """
     with expected_protocol(
-        ik.newport.AGUC2,
-        [
-        ],
-        [
-        ],
-        sep="\r\n"
+            ik.newport.AGUC2,
+            [
+            ],
+            [
+            ],
+            sep="\r\n"
     ) as agl:
         agl.sleep_time = 3
         assert agl.sleep_time == 3
@@ -102,47 +122,7 @@ def test_aguc2_reset_controller():
             sep="\r\n"
     ) as agl:
         agl.reset_controller()
-        assert agl._remote_mode is False
-
-
-def test_aguc2_set_local_mode():
-    """
-    Check setting local mode.
-    """
-    with expected_protocol(
-            ik.newport.AGUC2,
-            [
-                "ML"
-            ],
-            [
-            ],
-            sep="\r\n"
-    ) as agl:
-        # set remote mode -> otherwise local mode cannot be set
-        agl._remote_mode = True
-        # test
-        agl.set_local_mode()
-        assert agl._remote_mode is False
-
-
-def test_aguc2_set_remote_mode():
-    """
-    Check setting remote mode.
-    """
-    with expected_protocol(
-            ik.newport.AGUC2,
-            [
-                "MR"
-            ],
-            [
-            ],
-            sep="\r\n"
-    ) as agl:
-        # set local mode -> otherwise remote mode cannot be set
-        agl._remote_mode = False
-        # test
-        agl.set_remote_mode()
-        assert agl._remote_mode is True
+        assert agl.enable_remote_mode is False
 
 
 def test_aguc2_ag_sendcmd():
@@ -178,7 +158,7 @@ def test_aguc2_ag_query():
         assert agl.ag_query("VE") == "AG-UC2 v2.2.1"
 
 
-# AXES TESTS #
+# AXIS TESTS #
 
 
 def test_aguc2_axis_am_i_still():
@@ -204,22 +184,21 @@ def test_aguc2_axis_am_i_still():
             agl.axis["Y"].am_i_still(max_retries=3)
 
 
-
 def test_aguc2_axis_axis_status():
     """
     Check the status of the axis. Note that the test will return
     "Status code not valid." since no instrument is connected.
     """
     with expected_protocol(
-        ik.newport.AGUC2,
-        [
-            "MR",   # initialize remote mode
-            "1 TS",
-            "2 TS"
-        ],
-        [
-        ],
-        sep="\r\n"
+            ik.newport.AGUC2,
+            [
+                "MR",   # initialize remote mode
+                "1 TS",
+                "2 TS"
+            ],
+            [
+            ],
+            sep="\r\n"
     ) as agl:
         assert agl.axis["X"].axis_status == "Status code query failed."
         assert agl.axis["Y"].axis_status == "Status code query failed."
@@ -230,15 +209,15 @@ def test_aguc2_axis_jog():
     Check the jog function.
     """
     with expected_protocol(
-        ik.newport.AGUC2,
-        [
-            "MR",   # initialize remote mode
-            "1 JA 3",
-            "2 JA -4",
-        ],
-        [
-        ],
-        sep="\r\n"
+            ik.newport.AGUC2,
+            [
+                "MR",   # initialize remote mode
+                "1 JA 3",
+                "2 JA -4",
+            ],
+            [
+            ],
+            sep="\r\n"
     ) as agl:
         agl.axis["X"].jog = 3
         agl.axis["Y"].jog = -4
@@ -346,17 +325,17 @@ def test_aguc2_axis_step_delay():
     Check the step delay function.
     """
     with expected_protocol(
-        ik.newport.AGUC2,
-        [
-            "MR",   # initialize remote mode
-            "2 DL?",
-            "1 DL 1000",
-            "1 DL 200"
-        ],
-        [
-            "2DL0"
-        ],
-        sep="\r\n"
+            ik.newport.AGUC2,
+            [
+                "MR",   # initialize remote mode
+                "2 DL?",
+                "1 DL 1000",
+                "1 DL 200"
+            ],
+            [
+                "2DL0"
+            ],
+            sep="\r\n"
     ) as agl:
         assert agl.axis["Y"].step_delay == "2DL0"
         agl.axis["X"].step_delay = 1000
@@ -372,15 +351,15 @@ def test_aguc2_axis_stop():
     Check the stop function.
     """
     with expected_protocol(
-        ik.newport.AGUC2,
-        [
-            "MR",   # initialize remote mode
-            "1 ST",
-            "2 ST"
-        ],
-        [
-        ],
-        sep="\r\n"
+            ik.newport.AGUC2,
+            [
+                "MR",   # initialize remote mode
+                "1 ST",
+                "2 ST"
+            ],
+            [
+            ],
+            sep="\r\n"
     ) as agl:
         agl.axis["X"].stop()
         agl.axis["Y"].stop()
@@ -391,15 +370,15 @@ def test_aguc2_axis_zero_position():
     Check the stop function.
     """
     with expected_protocol(
-        ik.newport.AGUC2,
-        [
-            "MR",   # initialize remote mode
-            "1 ZP",
-            "2 ZP"
-        ],
-        [
-        ],
-        sep="\r\n"
+            ik.newport.AGUC2,
+            [
+                "MR",   # initialize remote mode
+                "1 ZP",
+                "2 ZP"
+            ],
+            [
+            ],
+            sep="\r\n"
     ) as agl:
         agl.axis["X"].zero_position()
         agl.axis["Y"].zero_position()

--- a/instruments/tests/test_newport/test_agilis.py
+++ b/instruments/tests/test_newport/test_agilis.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the Agilis Controller
+"""
+
+# IMPORTS #####################################################################
+
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol
+
+# TESTS #######################################################################
+
+# CONTROLLER TESTS #
+
+
+def test_aguc2_error_previous_command():
+    """
+    Check the call error of previous command routine. Note that the test will
+    return "Error code must be given as an integer." will be returned because
+    no actual error code is fed to the error message checker.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "TE"
+            ],
+            [
+            ],
+            sep="\r\n"
+    ) as agl:
+        assert agl.error_previous_command == "Error code query failed."
+
+
+def test_aguc2_firmware_version():
+    """
+    Check firmware version
+    AG-UC2 v2.2.1
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "VE"
+            ],
+            [
+                "AG-UC2 v2.2.1"
+            ],
+            sep="\r\n"
+    ) as agl:
+        assert agl.firmware_version == "AG-UC2 v2.2.1"
+
+
+def test_aguc2_limit_status():
+    """
+    Check the limit status routine.
+    """
+    with expected_protocol(
+        ik.newport.AGUC2,
+        [
+            "MR",   # initialize remote mode
+            "PH"
+        ],
+        [
+            "PH0"
+        ],
+        sep="\r\n"
+    ) as agl:
+        assert agl.limit_status == "PH0"
+
+
+def test_aguc2_sleep_time():
+    """
+    Check setting, getting the sleep time.
+    """
+    with expected_protocol(
+        ik.newport.AGUC2,
+        [
+        ],
+        [
+        ],
+        sep="\r\n"
+    ) as agl:
+        agl.sleep_time = 3
+        assert agl.sleep_time == 3
+        with pytest.raises(ValueError):
+            agl.sleep_time = -3.14
+
+
+def test_aguc2_reset_controller():
+    """
+    Check reset controller function.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "RS"
+            ],
+            [
+            ],
+            sep="\r\n"
+    ) as agl:
+        agl.reset_controller()
+        assert agl._remote_mode is False
+
+
+def test_aguc2_set_local_mode():
+    """
+    Check setting local mode.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "ML"
+            ],
+            [
+            ],
+            sep="\r\n"
+    ) as agl:
+        # set remote mode -> otherwise local mode cannot be set
+        agl._remote_mode = True
+        # test
+        agl.set_local_mode()
+        assert agl._remote_mode is False
+
+
+def test_aguc2_set_remote_mode():
+    """
+    Check setting remote mode.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "MR"
+            ],
+            [
+            ],
+            sep="\r\n"
+    ) as agl:
+        # set local mode -> otherwise remote mode cannot be set
+        agl._remote_mode = False
+        # test
+        agl.set_remote_mode()
+        assert agl._remote_mode is True
+
+
+def test_aguc2_ag_sendcmd():
+    """
+    Check agilis sendcommand wrapper.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "MR"   # some command, here remote mode
+            ],
+            [
+            ],
+            sep="\r\n"
+    ) as agl:
+        agl.ag_sendcmd("MR")
+
+
+def test_aguc2_ag_query():
+    """
+        Check agilis query wrapper.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "VE"
+            ],
+            [
+                "AG-UC2 v2.2.1"
+            ],
+            sep="\r\n"
+    ) as agl:
+        assert agl.ag_query("VE") == "AG-UC2 v2.2.1"
+
+
+# AXES TESTS #
+
+
+def test_aguc2_axis_am_i_still():
+    """
+    Check if a given axis is still or not.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "MR",  # initialize remote mode
+                "1 TS",
+                "2 TS",
+                "2 TS",
+                "2 TS"
+            ],
+            [
+            ],
+            sep="\r\n"
+    ) as agl:
+        with pytest.raises(IOError):
+            agl.axis["X"].am_i_still(max_retries=1)
+        with pytest.raises(IOError):
+            agl.axis["Y"].am_i_still(max_retries=3)
+
+
+
+def test_aguc2_axis_axis_status():
+    """
+    Check the status of the axis. Note that the test will return
+    "Status code not valid." since no instrument is connected.
+    """
+    with expected_protocol(
+        ik.newport.AGUC2,
+        [
+            "MR",   # initialize remote mode
+            "1 TS",
+            "2 TS"
+        ],
+        [
+        ],
+        sep="\r\n"
+    ) as agl:
+        assert agl.axis["X"].axis_status == "Status code query failed."
+        assert agl.axis["Y"].axis_status == "Status code query failed."
+
+
+def test_aguc2_axis_jog():
+    """
+    Check the jog function.
+    """
+    with expected_protocol(
+        ik.newport.AGUC2,
+        [
+            "MR",   # initialize remote mode
+            "1 JA 3",
+            "2 JA -4",
+        ],
+        [
+        ],
+        sep="\r\n"
+    ) as agl:
+        agl.axis["X"].jog = 3
+        agl.axis["Y"].jog = -4
+        with pytest.raises(ValueError):
+            agl.axis["X"].jog = -5
+        with pytest.raises(ValueError):
+            agl.axis["Y"].jog = 5
+
+
+def test_aguc2_axis_number_of_steps():
+    """
+    Check the number of steps function.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "MR",   # initialize remote mode
+                "1 TP",
+            ],
+            [
+                "1TP0"
+            ],
+            sep="\r\n"
+    ) as agl:
+        assert agl.axis["X"].number_of_steps == "1TP0"
+
+
+def test_aguc2_axis_move_relative():
+    """
+    Check the move relative function.
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "MR",   # initialize remote mode
+                "1 PR 1000",
+                "2 PR -340"
+            ],
+            [
+            ],
+            sep="\r\n"
+    ) as agl:
+        agl.axis["X"].move_relative = 1000
+        agl.axis["Y"].move_relative = -340
+        with pytest.raises(ValueError):
+            agl.axis["X"].move_relative = 2147483648
+        with pytest.raises(ValueError):
+            agl.axis["Y"].move_relative = -2147483649
+
+
+def test_aguc2_axis_move_to_limit():
+    """
+    Check for move to limit function.
+    This function is UNTESTED to work, here simply command sending is checked
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "MR",  # initialize remote mode
+                "2 MA 3"
+            ],
+            [
+            ],
+            sep="\r\n"
+    ) as agl:
+        agl.axis["Y"].move_to_limit = 3
+        with pytest.raises(ValueError):
+            agl.axis["Y"].move_to_limit = -5
+        with pytest.raises(ValueError):
+            agl.axis["X"].move_to_limit = 5
+
+
+def test_aguc2_axis_step_amplitude():
+    """
+    Check for step amplitude function
+    """
+    with expected_protocol(
+            ik.newport.AGUC2,
+            [
+                "MR",  # initialize remote mode
+                "1 SU-?",
+                "1 SU+?",
+                "1 SU -35",
+                "1 SU 47"
+
+            ],
+            [
+                "1SU-35", "1SU+35"
+            ],
+            sep="\r\n"
+    ) as agl:
+        assert agl.axis["X"].step_amplitude == ("1SU-35", "1SU+35")
+        agl.axis["X"].step_amplitude = -35
+        agl.axis["X"].step_amplitude = 47
+        with pytest.raises(ValueError):
+            agl.axis["X"].step_amplitude = 0
+        with pytest.raises(ValueError):
+            agl.axis["Y"].step_amplitude = -51
+        with pytest.raises(ValueError):
+            agl.axis["Y"].step_amplitude = 51
+
+
+def test_aguc2_axis_step_delay():
+    """
+    Check the step delay function.
+    """
+    with expected_protocol(
+        ik.newport.AGUC2,
+        [
+            "MR",   # initialize remote mode
+            "2 DL?",
+            "1 DL 1000",
+            "1 DL 200"
+        ],
+        [
+            "2DL0"
+        ],
+        sep="\r\n"
+    ) as agl:
+        assert agl.axis["Y"].step_delay == "2DL0"
+        agl.axis["X"].step_delay = 1000
+        agl.axis["X"].step_delay = 200
+        with pytest.raises(ValueError):
+            agl.axis["X"].step_delay = -1
+        with pytest.raises(ValueError):
+            agl.axis["Y"].step_delay = 2000001
+
+
+def test_aguc2_axis_stop():
+    """
+    Check the stop function.
+    """
+    with expected_protocol(
+        ik.newport.AGUC2,
+        [
+            "MR",   # initialize remote mode
+            "1 ST",
+            "2 ST"
+        ],
+        [
+        ],
+        sep="\r\n"
+    ) as agl:
+        agl.axis["X"].stop()
+        agl.axis["Y"].stop()
+
+
+def test_aguc2_axis_zero_position():
+    """
+    Check the stop function.
+    """
+    with expected_protocol(
+        ik.newport.AGUC2,
+        [
+            "MR",   # initialize remote mode
+            "1 ZP",
+            "2 ZP"
+        ],
+        [
+        ],
+        sep="\r\n"
+    ) as agl:
+        agl.axis["X"].zero_position()
+        agl.axis["Y"].zero_position()
+
+
+# FUNCTION TESTS #
+
+
+def test_agilis_error_message():
+    # regular error messages
+    assert ik.newport.agilis.agilis_error_message(0) == "No error"
+    assert ik.newport.agilis.agilis_error_message(-6) == "Not allowed in " \
+                                                         "current state"
+    # out of range integers
+    assert ik.newport.agilis.agilis_error_message(1) == "An unknown error " \
+                                                        "occurred."
+    assert ik.newport.agilis.agilis_error_message(-7) == "An unknown error " \
+                                                         "occurred."
+    # non-integers
+    assert ik.newport.agilis.agilis_error_message(-7.5) == "Error code is " \
+                                                           "not an integer."
+    assert ik.newport.agilis.agilis_error_message("TE0") == "Error code is " \
+                                                            "not an integer."
+
+
+def test_agilis_status_message():
+    # regular status messages
+    assert ik.newport.agilis.agilis_status_message(0) == "Ready (not moving)."
+    assert ik.newport.agilis.agilis_status_message(3) == \
+           "Moving to limit (currently executing " \
+           "`measure_current_position`, `move_to_limit`, or " \
+           "`move_absolute` command)."
+    # out of range integers
+    assert ik.newport.agilis.agilis_status_message(4) == "An unknown " \
+                                                         "status occurred."
+    assert ik.newport.agilis.agilis_status_message(-1) == "An unknown " \
+                                                          "status occurred."
+    # non integers
+    assert ik.newport.agilis.agilis_status_message(3.14) == "Status code is " \
+                                                            "not an integer."
+    assert ik.newport.agilis.agilis_status_message("1TS0") == "Status code " \
+                                                              "is not an " \
+                                                              "integer."


### PR DESCRIPTION
Added a new instrument for Newport Agilis devices. Currently, only the
AG-UC2 Controller is supported. Added the controller to the respective
ini file in the newport folder.

Axis class implemented to send device specific commands. This can be
used from other controllers, once implemented, as well.

Some caveats / non-implemented and only partially tested routines are
noted on top of the `agilis.py` file. I don't have a device with a limit
switch available for testing, therefore, some routines that only work
on such devices are not implemented and some routines are untested. The
doc strings for every routine states this clearly as well.

A full test suite for all functions is also provided.

Everything tested with tox for py36, py37, and py38. All tests succeeded.