### PR TITLE
Enhancement: SRS645 delay generator added burst mode support

### DIFF
--- a/instruments/srs/srsdg645.py
+++ b/instruments/srs/srsdg645.py
@@ -332,3 +332,72 @@ class SRSDG645(SCPIInstrument):
     @holdoff.setter
     def holdoff(self, newval):
         self.sendcmd("HOLD {}".format(newval.rescale(u.s).magnitude))
+
+    @property
+    def enable_burst_mode(self):
+        """
+        Gets/sets whether burst mode is enabled.
+
+        :type: `bool`
+        """
+        return bool(int(self.query("BURM?")))
+
+    @enable_burst_mode.setter
+    def enable_burst_mode(self, newval):
+        self.sendcmd("BURM {}".format(1 if newval else 0))
+
+    @property
+    def enable_burst_t0_first(self):
+        """
+        Gets/sets whether T0 output in burst mode is on first. If
+        enabled, the T0 output is enabled for first delay cycle of the
+        burst only. If disabled, the T0 output is enabled for all delay
+        cycles of the burst.
+
+        :type: `bool`
+        """
+        return bool(int(self.query("BURT?")))
+
+    @enable_burst_t0_first.setter
+    def enable_burst_t0_first(self, newval):
+        self.sendcmd("BURT {}".format(1 if newval else 0))
+
+    @property
+    def burst_count(self):
+        """
+        Gets/sets the burst count. When burst mode is enabled, the
+        DG645 outputs burst count delay cycles per trigger.
+        Valid numbers for burst count are between 1 and 2**32 - 1
+        """
+        return int(self.query("BURC?"))
+
+    @burst_count.setter
+    def burst_count(self, newval):
+        self.sendcmd("BURC {}".format(int(newval)))
+
+    @property
+    def burst_period(self):
+        """
+        Gets/sets the burst period. The burst period sets the time
+        between delay cycles during a burst. The burst period may
+        range from 100 ns to 2000 – 10 ns in 10 ns steps.
+        """
+        return u.Quantity(float(self.query("BURP?")), u.s)
+
+    @burst_period.setter
+    def burst_period(self, newval):
+        self.sendcmd("BURP {}".format(newval.rescale(u.s).magnitude))
+
+    @property
+    def burst_delay(self):
+        """
+        Gets/sets the burst delay. When burst mode is enabled the DG645
+        delays the first burst pulse relative to the trigger by the
+        burst delay. The burst delay may range from 0 ps to < 2000 s
+        with a resolution of 5 ps.
+        """
+        return u.Quantity(float(self.query("BURD?")), u.s)
+
+    @burst_delay.setter
+    def burst_delay(self, newval):
+        self.sendcmd("BURD {}".format(newval.rescale(u.s).magnitude))

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -77,3 +77,97 @@ def test_srsdg645_trigger_source():
         assert ref == ddg.Channels.T0
         assert abs((t - u.Quantity(42, "s")).magnitude) < 1e5
         ddg.channel["B"].delay = (ddg.channel["A"], u.Quantity(1, "minute"))
+
+
+def test_srsdg645_enable_burst_mode():
+    """
+    SRSDG645: Checks getting/setting of enabling burst mode.
+    """
+    with expected_protocol(
+            ik.srs.SRSDG645,
+            [
+                "BURM?",
+                "BURM 1"
+            ],
+            [
+                "0"
+            ]
+    ) as ddg:
+        assert ddg.enable_burst_mode == False
+        ddg.enable_burst_mode = True
+
+
+def test_srsdg645_enable_burst_t0_first():
+    """
+        SRSDG645: Checks getting/setting of enabling T0 output on first
+        in burst mode.
+        """
+    with expected_protocol(
+            ik.srs.SRSDG645,
+            [
+                "BURT?",
+                "BURT 1"
+            ],
+            [
+                "0"
+            ]
+    ) as ddg:
+        assert ddg.enable_burst_t0_first == False
+        ddg.enable_burst_t0_first = True
+
+
+def test_srsdg645_burst_count():
+    """
+        SRSDG645: Checks getting/setting of enabling T0 output on first
+        in burst mode.
+        """
+    with expected_protocol(
+            ik.srs.SRSDG645,
+            [
+                "BURC?",
+                "BURC 42"
+            ],
+            [
+                "10"
+            ]
+    ) as ddg:
+        assert ddg.burst_count == 10
+        ddg.burst_count = 42
+
+
+def test_srsdg645_burst_period():
+    """
+        SRSDG645: Checks getting/setting of enabling T0 output on first
+        in burst mode.
+        """
+    with expected_protocol(
+            ik.srs.SRSDG645,
+            [
+                "BURP?",
+                "BURP 13"
+            ],
+            [
+                "100E-9"
+            ]
+    ) as ddg:
+        unit_eq(ddg.burst_period, u.Quantity(100, "ns").rescale(u.s))
+        ddg.burst_period = u.Quantity(13, "s")
+
+
+def test_srsdg645_burst_delay():
+    """
+        SRSDG645: Checks getting/setting of enabling T0 output on first
+        in burst mode.
+        """
+    with expected_protocol(
+            ik.srs.SRSDG645,
+            [
+                "BURD?",
+                "BURD 42"
+            ],
+            [
+                "0"
+            ]
+    ) as ddg:
+        unit_eq(ddg.burst_delay, u.Quantity(0, "s"))
+        ddg.burst_delay = u.Quantity(42, "s")

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -93,7 +93,7 @@ def test_srsdg645_enable_burst_mode():
                 "0"
             ]
     ) as ddg:
-        assert ddg.enable_burst_mode == False
+        assert ddg.enable_burst_mode is False
         ddg.enable_burst_mode = True
 
 
@@ -112,7 +112,7 @@ def test_srsdg645_enable_burst_t0_first():
                 "0"
             ]
     ) as ddg:
-        assert ddg.enable_burst_t0_first == False
+        assert ddg.enable_burst_t0_first is False
         ddg.enable_burst_t0_first = True
 
 


### PR DESCRIPTION
Here now the promised enhancements for the SRS645 delay generator.

Added routines for enabling burst mode and controlling all sub
properties. Set/get implemented for all sub menus of burst mode.

A full test suite for each of the new functions has been implemented
as well.

Every call has been tested with an actual instrument and is functional.

Local test results:
tox testing: all passed
pylint rating: 10/10