### PR TITLE
[WIP] Replace quantities with pint

### DIFF
--- a/doc/examples/ex_hp3456.py
+++ b/doc/examples/ex_hp3456.py
@@ -4,7 +4,7 @@
 import logging
 import time
 import instruments as ik
-import instruments.units as u
+from instruments.units import ureg as u
 
 dmm = ik.hp.HP3456a.open_gpibusb('/dev/ttyUSB0', 22)
 logging.basicConfig(level=logging.DEBUG)

--- a/doc/examples/ex_tekdpo70000.ipynb
+++ b/doc/examples/ex_tekdpo70000.ipynb
@@ -152,7 +152,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "_.rescale('GHz')"
+      "_.to('GHz')"
      ],
      "language": "python",
      "metadata": {},

--- a/doc/examples/ex_topticatopmode.py
+++ b/doc/examples/ex_topticatopmode.py
@@ -5,7 +5,7 @@ Toptica Topmode example
 """
 
 import instruments as ik
-import instruments.units as u
+from instruments.units import ureg as u
 from platform import system
 if system() == 'Windows':
       tm = ik.toptica.TopMode.open_serial('COM17', 115200)

--- a/doc/examples/minghe/ex_minghe_mhs5200.py
+++ b/doc/examples/minghe/ex_minghe_mhs5200.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 from instruments.minghe import MHS5200
-import instruments.units as u
+from instruments.units import ureg as u
 
 mhs = MHS5200.open_serial(vid=6790, pid=29987, baud=57600)
 print(mhs.serial_number)

--- a/doc/examples/qubitekk/ex_qubitekk_mc1.py
+++ b/doc/examples/qubitekk/ex_qubitekk_mc1.py
@@ -3,7 +3,7 @@
 from time import sleep
 
 from instruments.qubitekk import MC1
-import instruments.units as u
+from instruments.units import ureg as u
 
 
 if __name__ == "__main__":

--- a/doc/examples/srs_DG645.ipynb
+++ b/doc/examples/srs_DG645.ipynb
@@ -43,7 +43,7 @@
      "collapsed": false,
      "input": [
       "from instruments.srs import SRSDG645\n",
-      "import instruments.units as u"
+      "from instruments.units import ureg as u"
      ],
      "language": "python",
      "metadata": {},

--- a/doc/examples/srs_DG645.py
+++ b/doc/examples/srs_DG645.py
@@ -21,7 +21,7 @@
 # <codecell>
 
 from instruments.srs import SRSDG645
-import instruments.units as u
+from instruments.units import ureg as u
 
 # <markdowncell>
 

--- a/instruments/abstract_instruments/comm/gpib_communicator.py
+++ b/instruments/abstract_instruments/comm/gpib_communicator.py
@@ -12,7 +12,7 @@ from enum import Enum
 import io
 import time
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
@@ -107,13 +107,13 @@ class GPIBCommunicator(io.IOBase, AbstractCommunicator):
     def timeout(self, newval):
         newval = assume_units(newval, u.second)
         if self._model == GPIBCommunicator.Model.gi and self._version <= 4:
-            newval = newval.rescale(u.second)
+            newval = newval.to(u.second)
             self._file.sendcmd('+t:{}'.format(int(newval.magnitude)))
         else:
-            newval = newval.rescale(u.millisecond)
+            newval = newval.to(u.millisecond)
             self._file.sendcmd("++read_tmo_ms {}".format(int(newval.magnitude)))
-        self._file.timeout = newval.rescale(u.second)
-        self._timeout = newval.rescale(u.second)
+        self._file.timeout = newval.to(u.second)
+        self._timeout = newval.to(u.second)
 
     @property
     def terminator(self):

--- a/instruments/abstract_instruments/comm/serial_communicator.py
+++ b/instruments/abstract_instruments/comm/serial_communicator.py
@@ -11,7 +11,7 @@ connections.
 import io
 import serial
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
@@ -87,7 +87,7 @@ class SerialCommunicator(io.IOBase, AbstractCommunicator):
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, u.second).rescale(u.second).magnitude
+        newval = assume_units(newval, u.second).to(u.second).magnitude
         self._conn.timeout = newval
 
     # FILE-LIKE METHODS #

--- a/instruments/abstract_instruments/comm/socket_communicator.py
+++ b/instruments/abstract_instruments/comm/socket_communicator.py
@@ -11,7 +11,7 @@ raw ethernet connections.
 import io
 import socket
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
@@ -77,7 +77,7 @@ class SocketCommunicator(io.IOBase, AbstractCommunicator):
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, u.second).rescale(u.second).magnitude
+        newval = assume_units(newval, u.second).to(u.second).magnitude
         self._conn.settimeout(newval)
 
     # FILE-LIKE METHODS #

--- a/instruments/abstract_instruments/comm/usbtmc_communicator.py
+++ b/instruments/abstract_instruments/comm/usbtmc_communicator.py
@@ -14,7 +14,7 @@ import usbtmc
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
-import instruments.units as u
+from instruments.units import ureg as u
 
 # CLASSES #####################################################################
 
@@ -74,7 +74,7 @@ class USBTMCCommunicator(io.IOBase, AbstractCommunicator):
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, u.second).rescale(u.s).magnitude
+        newval = assume_units(newval, u.second).to(u.s).magnitude
         self._filelike.timeout = newval
 
     # FILE-LIKE METHODS #

--- a/instruments/abstract_instruments/comm/visa_communicator.py
+++ b/instruments/abstract_instruments/comm/visa_communicator.py
@@ -14,7 +14,7 @@ import visa
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
-import instruments.units as u
+from instruments.units import ureg as u
 
 # CLASSES #####################################################################
 
@@ -86,7 +86,7 @@ class VisaCommunicator(io.IOBase, AbstractCommunicator):
 
     @timeout.setter
     def timeout(self, newval):
-        newval = assume_units(newval, u.second).rescale(u.second).magnitude
+        newval = assume_units(newval, u.second).to(u.second).magnitude
         self._conn.timeout = newval
 
     # FILE-LIKE METHODS #

--- a/instruments/abstract_instruments/function_generator.py
+++ b/instruments/abstract_instruments/function_generator.py
@@ -11,7 +11,7 @@ import abc
 from enum import Enum
 
 from instruments.abstract_instruments import Instrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import assume_units, ProxyList
 
 # CLASSES #####################################################################
@@ -173,7 +173,7 @@ class FunctionGenerator(Instrument, metaclass=abc.ABCMeta):
             # Try and rescale to dBm... if it succeeds, set the magnitude
             # and units accordingly, otherwise handle as a voltage.
             try:
-                newval_dbm = newval.rescale(u.dBm)
+                newval_dbm = newval.to(u.dBm)
                 mag = float(newval_dbm.magnitude)
                 units = self._parent.VoltageMode.dBm
             except (AttributeError, ValueError):
@@ -185,7 +185,7 @@ class FunctionGenerator(Instrument, metaclass=abc.ABCMeta):
                     mag, units = newval
 
                 # Finally, convert the magnitude out to a float.
-                mag = float(assume_units(mag, u.V).rescale(u.V).magnitude)
+                mag = float(assume_units(mag, u.V).to(u.V).magnitude)
 
             self._set_amplitude_(mag, units)
 

--- a/instruments/agilent/agilent33220a.py
+++ b/instruments/agilent/agilent33220a.py
@@ -10,7 +10,7 @@ from enum import Enum
 
 
 from instruments.generic_scpi import SCPIFunctionGenerator
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (
     enum_property, int_property, bool_property, assume_units
 )
@@ -29,7 +29,7 @@ class Agilent33220a(SCPIFunctionGenerator):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> inst = ik.agilent.Agilent33220a.open_gpibusb('/dev/ttyUSB0', 1)
     >>> inst.function = inst.Function.sinusoid
     >>> inst.frequency = 1 * u.kHz
@@ -171,7 +171,7 @@ class Agilent33220a(SCPIFunctionGenerator):
         if isinstance(newval, self.LoadResistance):
             newval = newval.value
         else:
-            newval = assume_units(newval, u.ohm).rescale(u.ohm).magnitude
+            newval = assume_units(newval, u.ohm).to(u.ohm).magnitude
             if (newval < 0) or (newval > 10000):
                 raise ValueError(
                     "Load resistance must be between 0 and 10,000")

--- a/instruments/agilent/agilent34410a.py
+++ b/instruments/agilent/agilent34410a.py
@@ -7,7 +7,7 @@ Provides support for the Agilent 34410a digital multimeter.
 # IMPORTS #####################################################################
 
 from instruments.generic_scpi import SCPIMultimeter
-import instruments.units as u
+from instruments.units import ureg as u
 
 # CLASSES #####################################################################
 
@@ -23,7 +23,7 @@ class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> dmm = ik.agilent.Agilent34410a.open_gpibusb('/dev/ttyUSB0', 1)
     >>> print(dmm.measure(dmm.Mode.resistance))
 

--- a/instruments/config.py
+++ b/instruments/config.py
@@ -21,7 +21,7 @@ except ImportError:
     # the import-error check should be re-enabled.
     import ruamel_yaml as yaml  # pylint: disable=import-error
 
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import setattr_expression, split_unit_str
 
 # FUNCTIONS ###################################################################

--- a/instruments/fluke/fluke3000.py
+++ b/instruments/fluke/fluke3000.py
@@ -37,7 +37,7 @@ import time
 from enum import Enum
 
 from instruments.abstract_instruments import Multimeter
-import instruments.units as u
+from instruments.units import ureg as u
 
 # CLASSES #####################################################################
 
@@ -349,7 +349,7 @@ class Fluke3000(Multimeter):
 
         # Return with the appropriate units
         units = UNITS[mode]
-        return value * units
+        return u.Quantity(value, units)
 
     def _get_module(self, mode):
         """Gets the module associated with this measurement mode.
@@ -472,7 +472,7 @@ UNITS = {
     Fluke3000.Mode.current_ac:  u.amp,
     Fluke3000.Mode.current_dc:  u.amp,
     Fluke3000.Mode.frequency:   u.hertz,
-    Fluke3000.Mode.temperature: u.celsius,
+    Fluke3000.Mode.temperature: u.degC,
     Fluke3000.Mode.resistance:  u.ohm,
     Fluke3000.Mode.capacitance: u.farad
 }

--- a/instruments/generic_scpi/scpi_function_generator.py
+++ b/instruments/generic_scpi/scpi_function_generator.py
@@ -7,7 +7,7 @@ Provides support for SCPI compliant function generators
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import FunctionGenerator
 from instruments.generic_scpi import SCPIInstrument
@@ -25,7 +25,7 @@ class SCPIFunctionGenerator(FunctionGenerator, SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> inst = ik.generic_scpi.SCPIFunctionGenerator.open_tcpip("192.168.1.1")
     >>> inst.frequency = 1 * u.kHz
     """

--- a/instruments/generic_scpi/scpi_instrument.py
+++ b/instruments/generic_scpi/scpi_instrument.py
@@ -9,7 +9,7 @@ Provides support for SCPI compliant instruments
 from enum import IntEnum
 
 from instruments.abstract_instruments import Instrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import assume_units
 
 # CLASSES #####################################################################
@@ -154,7 +154,7 @@ class SCPIInstrument(Instrument):
     @line_frequency.setter
     def line_frequency(self, newval):
         self.sendcmd("SYST:LFR {}".format(
-            assume_units(newval, "Hz").rescale("Hz").magnitude
+            assume_units(newval, "Hz").to("Hz").magnitude
         ))
 
     # ERROR QUEUE HANDLING ##

--- a/instruments/generic_scpi/scpi_multimeter.py
+++ b/instruments/generic_scpi/scpi_multimeter.py
@@ -9,7 +9,7 @@ Provides support for SCPI compliant multimeters
 
 from enum import Enum
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import Multimeter
 from instruments.generic_scpi import SCPIInstrument
@@ -197,7 +197,7 @@ class SCPIMultimeter(SCPIInstrument, Multimeter):
         if isinstance(newval, self.InputRange):
             newval = newval.value
         else:
-            newval = assume_units(newval, units).rescale(units).magnitude
+            newval = assume_units(newval, units).to(units).magnitude
         self.sendcmd("CONF:{} {}".format(mode.value, newval))
 
     @property

--- a/instruments/glassman/glassmanfr.py
+++ b/instruments/glassman/glassmanfr.py
@@ -39,7 +39,7 @@ from instruments.abstract_instruments import (
     PowerSupply,
     PowerSupplyChannel
 )
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import assume_units
 
 # CLASSES #####################################################################
@@ -76,7 +76,7 @@ class GlassmanFR(PowerSupply, PowerSupplyChannel):
     `polarity` that are only valid of the FR50R6 in its positive setting.
     If your power supply differs, reset those values by calling:
 
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> psu.voltage_max = 40.0 * u.kilovolt
     >>> psu.current_max = 7.5 * u.milliamp
     >>> psu.polarity = -1
@@ -339,7 +339,7 @@ class GlassmanFR(PowerSupply, PowerSupplyChannel):
 
             # If the voltage is not specified, keep it as is
             voltage = assume_units(voltage, u.volt) if voltage is not None else self.voltage
-            ratio = float(voltage.rescale(u.volt)/self.voltage_max.rescale(u.volt))
+            ratio = float(voltage.to(u.volt)/self.voltage_max.to(u.volt))
             voltage_int = int(round(value_max*ratio))
             self._voltage = self.voltage_max*float(voltage_int)/value_max
             assert 0. * u.volt <= self._voltage <= self.voltage_max
@@ -347,7 +347,7 @@ class GlassmanFR(PowerSupply, PowerSupplyChannel):
 
             # If the current is not specified, keep it as is
             current = assume_units(current, u.amp) if current is not None else self.current
-            ratio = float(current.rescale(u.amp)/self.current_max.rescale(u.amp))
+            ratio = float(current.to(u.amp)/self.current_max.to(u.amp))
             current_int = int(round(value_max*ratio))
             self._current = self.current_max*float(current_int)/value_max
             assert 0. * u.amp <= self._current <= self.current_max

--- a/instruments/holzworth/holzworth_hs9000.py
+++ b/instruments/holzworth/holzworth_hs9000.py
@@ -7,7 +7,7 @@ Provides support for the Holzworth HS9000
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments.signal_generator import (
     SignalGenerator,

--- a/instruments/hp/hp3456a.py
+++ b/instruments/hp/hp3456a.py
@@ -36,7 +36,7 @@ import time
 from enum import Enum, IntEnum
 
 from instruments.abstract_instruments import Multimeter
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import assume_units, bool_property, enum_property
 
 # CLASSES #####################################################################
@@ -297,7 +297,7 @@ class HP3456a(Multimeter):
 
     @delay.setter
     def delay(self, value):
-        delay = assume_units(value, u.s).rescale(u.s).magnitude
+        delay = assume_units(value, u.s).to(u.s).magnitude
         self._register_write(HP3456a.Register.delay, delay)
 
     @property
@@ -429,18 +429,18 @@ class HP3456a(Multimeter):
                 raise ValueError("Only 'auto' is acceptable when specifying "
                                  "the input range as a string.")
 
-        elif isinstance(value, u.quantity.Quantity):
+        elif isinstance(value, u.Quantity):
             if value.units == u.volt:
                 valid = HP3456a.ValidRange.voltage.value
-                value = value.rescale(u.volt)
+                value = value.to(u.volt)
             elif value.units == u.ohm:
                 valid = HP3456a.ValidRange.resistance.value
-                value = value.rescale(u.ohm)
+                value = value.to(u.ohm)
             else:
                 raise ValueError("Value {} not quantity.volt or quantity.ohm"
                                  "".format(value))
 
-            value = float(value)
+            value = float(value.magnitude)
             if value not in valid:
                 raise ValueError("Value {} outside valid ranges "
                                  "{}".format(value, valid))

--- a/instruments/hp/hp6624a.py
+++ b/instruments/hp/hp6624a.py
@@ -12,7 +12,7 @@ from instruments.abstract_instruments import (
     PowerSupply,
     PowerSupplyChannel
 )
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import ProxyList, unitful_property, bool_property
 
 # CLASSES #####################################################################

--- a/instruments/hp/hp6632b.py
+++ b/instruments/hp/hp6632b.py
@@ -36,7 +36,7 @@ from enum import Enum, IntEnum
 
 from instruments.generic_scpi.scpi_instrument import SCPIInstrument
 from instruments.hp.hp6652a import HP6652a
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (unitful_property, unitless_property,
                                   bool_property, enum_property, int_property)
 

--- a/instruments/hp/hp6652a.py
+++ b/instruments/hp/hp6652a.py
@@ -9,7 +9,7 @@ Originally contributed by Wil Langford (wil.langford+instrumentkit@gmail.com)
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import (PowerSupply, PowerSupplyChannel)
 from instruments.util_fns import unitful_property, bool_property

--- a/instruments/hp/hpe3631a.py
+++ b/instruments/hp/hpe3631a.py
@@ -35,7 +35,7 @@ Kit project.
 
 import time
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import (
     PowerSupply,
@@ -162,7 +162,7 @@ class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
         :type: `float` or `~quantities.Quantity`
         """
         raw = self.query("SOUR:VOLT?")
-        return u.Quantity(*split_unit_str(raw, u.volt)).rescale(u.volt)
+        return u.Quantity(*split_unit_str(raw, u.volt)).to(u.volt)
 
     @voltage.setter
     def voltage(self, newval):
@@ -183,7 +183,7 @@ class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
 
         # Rescale to the correct unit before printing. This will also
         # catch bad units.
-        strval = "{:e}".format(assume_units(newval, u.volt).rescale(u.volt).item())
+        strval = "{:e}".format(assume_units(newval, u.volt).to(u.volt).magnitude)
         self.sendcmd('SOUR:VOLT {}'.format(strval))
 
     @property

--- a/instruments/keithley/keithley195.py
+++ b/instruments/keithley/keithley195.py
@@ -11,7 +11,7 @@ import time
 import struct
 from enum import Enum, IntEnum
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import Multimeter
 
@@ -27,7 +27,7 @@ class Keithley195(Multimeter):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> dmm = ik.keithley.Keithley195.open_gpibusb('/dev/ttyUSB0', 12)
     >>> print dmm.measure(dmm.Mode.resistance)
 
@@ -244,7 +244,7 @@ class Keithley195(Multimeter):
         Example usage:
 
         >>> import instruments as ik
-        >>> import instruments.units as u
+        >>> from instruments.units import ureg as u
         >>> dmm = ik.keithley.Keithley195.open_gpibusb('/dev/ttyUSB0', 12)
         >>> print(dmm.measure(dmm.Mode.resistance))
 

--- a/instruments/keithley/keithley2182.py
+++ b/instruments/keithley/keithley2182.py
@@ -7,7 +7,7 @@ Driver for the Keithley 2182 nano-voltmeter
 # IMPORTS #####################################################################
 
 from enum import Enum
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.generic_scpi import SCPIMultimeter
 from instruments.abstract_instruments import Multimeter
@@ -98,7 +98,7 @@ class Keithley2182(SCPIMultimeter):
             self._parent.sendcmd('SENS:CHAN {}'.format(self._idx))
             value = float(self._parent.query('SENS:DATA:FRES?'))
             unit = self._parent.units
-            return value * unit
+            return u.Quantity(value, unit)
 
     # ENUMS #
 

--- a/instruments/keithley/keithley485.py
+++ b/instruments/keithley/keithley485.py
@@ -37,7 +37,7 @@ from struct import unpack
 from enum import Enum
 
 from instruments.abstract_instruments import Instrument
-import instruments.units as u
+from instruments.units import ureg as u
 
 # CLASSES #####################################################################
 
@@ -200,7 +200,7 @@ class Keithley485(Instrument):
             else:
                 raise ValueError("Only `auto` is acceptable when specifying "
                                  "the range as a string.")
-        if isinstance(newval, u.quantity.Quantity):
+        if isinstance(newval, u.Quantity):
             newval = float(newval)
 
         if isinstance(newval, (float, int)):

--- a/instruments/keithley/keithley580.py
+++ b/instruments/keithley/keithley580.py
@@ -38,7 +38,7 @@ import struct
 
 from enum import IntEnum
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import Instrument
 

--- a/instruments/keithley/keithley6220.py
+++ b/instruments/keithley/keithley6220.py
@@ -7,7 +7,7 @@ Provides support for the Keithley 6220 constant current supply
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import PowerSupply
 from instruments.generic_scpi import SCPIInstrument
@@ -26,7 +26,7 @@ class Keithley6220(SCPIInstrument, PowerSupply):
 
     Example usage:
 
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> import instruments as ik
     >>> ccs = ik.keithley.Keithley6220.open_gpibusb("/dev/ttyUSB0", 10)
     >>> ccs.current = 10 * u.milliamp # Sets current to 10mA

--- a/instruments/keithley/keithley6514.py
+++ b/instruments/keithley/keithley6514.py
@@ -10,7 +10,7 @@ from enum import Enum
 
 from instruments.abstract_instruments import Electrometer
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import bool_property, enum_property
 
 # CLASSES #####################################################################
@@ -25,7 +25,7 @@ class Keithley6514(SCPIInstrument, Electrometer):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> dmm = ik.keithley.Keithley6514.open_gpibusb('/dev/ttyUSB0', 12)
     """
 
@@ -186,7 +186,7 @@ class Keithley6514(SCPIInstrument, Electrometer):
     def input_range(self, newval):
         # pylint: disable=no-member
         mode = self.mode
-        val = newval.rescale(self._MODE_UNITS[mode]).item()
+        val = newval.to(self._MODE_UNITS[mode]).magnitude
         if val not in self._valid_range(mode).value:
             raise ValueError(
                 'Unexpected range limit for currently selected mode.')

--- a/instruments/lakeshore/lakeshore340.py
+++ b/instruments/lakeshore/lakeshore340.py
@@ -7,7 +7,7 @@ Provides support for the Lakeshore 340 cryogenic temperature controller.
 # IMPORTS #####################################################################
 
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################
@@ -21,7 +21,7 @@ class Lakeshore340(SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> inst = ik.lakeshore.Lakeshore340.open_gpibusb('/dev/ttyUSB0', 1)
     >>> print(inst.sensor[0].temperature)
     >>> print(inst.sensor[1].temperature)

--- a/instruments/lakeshore/lakeshore370.py
+++ b/instruments/lakeshore/lakeshore370.py
@@ -7,7 +7,7 @@ Provides support for the Lakeshore 370 AC resistance bridge.
 # IMPORTS #####################################################################
 
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################

--- a/instruments/lakeshore/lakeshore475.py
+++ b/instruments/lakeshore/lakeshore475.py
@@ -9,7 +9,7 @@ Provides support for the Lakeshore 475 Gaussmeter.
 from enum import IntEnum
 
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import assume_units, bool_property
 
 # CONSTANTS ###################################################################
@@ -18,7 +18,7 @@ LAKESHORE_FIELD_UNITS = {
     1: u.gauss,
     2: u.tesla,
     3: u.oersted,
-    4: u.CompoundUnit('A/m')
+    4: u.amp / u.meter
 }
 
 LAKESHORE_TEMP_UNITS = {
@@ -42,7 +42,7 @@ class Lakeshore475(SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> gm = ik.lakeshore.Lakeshore475.open_gpibusb('/dev/ttyUSB0', 1)
     >>> print(gm.field)
     >>> gm.field_units = u.tesla
@@ -153,7 +153,7 @@ class Lakeshore475(SCPIInstrument):
     @field_setpoint.setter
     def field_setpoint(self, newval):
         units = self.field_units
-        newval = float(assume_units(newval, u.gauss).rescale(units).magnitude)
+        newval = float(assume_units(newval, u.gauss).to(units).magnitude)
         self.sendcmd('CSETP {}'.format(newval))
 
     @property
@@ -181,10 +181,10 @@ class Lakeshore475(SCPIInstrument):
 
         unit = self.field_units / u.minute
         newval[2] = float(
-            assume_units(newval[2], unit).rescale(unit).magnitude)
+            assume_units(newval[2], unit).to(unit).magnitude)
         unit = u.volt / u.minute
         newval[3] = float(
-            assume_units(newval[3], unit).rescale(unit).magnitude)
+            assume_units(newval[3], unit).to(unit).magnitude)
 
         self.sendcmd('CPARAM {},{},{},{}'.format(
             newval[0],
@@ -239,7 +239,7 @@ class Lakeshore475(SCPIInstrument):
     @ramp_rate.setter
     def ramp_rate(self, newval):
         unit = self.field_units / u.minute
-        newval = float(assume_units(newval, unit).rescale(unit).magnitude)
+        newval = float(assume_units(newval, unit).to(unit).magnitude)
         values = list(self.field_control_params)
         values[2] = newval
         self.field_control_params = tuple(values)
@@ -258,7 +258,7 @@ class Lakeshore475(SCPIInstrument):
     @control_slope_limit.setter
     def control_slope_limit(self, newval):
         unit = u.volt / u.minute
-        newval = float(assume_units(newval, unit).rescale(unit).magnitude)
+        newval = float(assume_units(newval, unit).to(unit).magnitude)
         values = list(self.field_control_params)
         values[3] = newval
         self.field_control_params = tuple(values)

--- a/instruments/minghe/mhs5200a.py
+++ b/instruments/minghe/mhs5200a.py
@@ -11,7 +11,7 @@ Class originally contributed by Catherine Holloway.
 from enum import Enum
 
 from instruments.abstract_instruments import FunctionGenerator
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import ProxyList, assume_units
 
 # CLASSES #####################################################################
@@ -66,7 +66,7 @@ class MHS5200(FunctionGenerator):
         def _set_amplitude_(self, magnitude, units):
             if units == self._mhs.VoltageMode.peak_to_peak or \
                             units == self._mhs.VoltageMode.rms:
-                magnitude = assume_units(magnitude, "V").rescale(u.V).magnitude
+                magnitude = assume_units(magnitude, "V").to(u.V).magnitude
             elif units == self._mhs.VoltageMode.dBm:
                 raise NotImplementedError("Decibel units are not supported.")
             magnitude *= 100
@@ -123,7 +123,7 @@ class MHS5200(FunctionGenerator):
 
         @frequency.setter
         def frequency(self, new_val):
-            new_val = assume_units(new_val, u.Hz).rescale(u.Hz).\
+            new_val = assume_units(new_val, u.Hz).to(u.Hz).\
                           magnitude*100.0
             query = ":s{0}f{1}".format(self._chan, int(new_val))
             self._mhs.sendcmd(query)
@@ -164,7 +164,7 @@ class MHS5200(FunctionGenerator):
 
         @phase.setter
         def phase(self, new_val):
-            new_val = assume_units(new_val, u.deg).rescale("deg").magnitude
+            new_val = assume_units(new_val, u.deg).to("deg").magnitude
             query = ":s{0}p{1}".format(self._chan, int(new_val))
             self._mhs.sendcmd(query)
 

--- a/instruments/newport/newportesp301.py
+++ b/instruments/newport/newportesp301.py
@@ -17,7 +17,7 @@ from time import time, sleep
 
 from instruments.abstract_instruments import Instrument
 from instruments.newport.errors import NewportError
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import assume_units, ProxyList
 
 # ENUMS #######################################################################
@@ -299,7 +299,8 @@ class NewportESP301Axis:
     returned by `NewportESP301.axis`.
     """
     # quantities micro inch
-    micro_inch = u.UnitQuantity('micro-inch', u.inch / 1e6, symbol='uin')
+    # micro_inch = u.UnitQuantity('micro-inch', u.inch / 1e6, symbol='uin')
+    micro_inch = u.uinch
 
     # Some more work might need to be done here to make
     # the encoder_step and motor_step functional
@@ -407,7 +408,7 @@ class NewportESP301Axis:
     def acceleration(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / (u.s**2)).rescale(
+        newval = float(assume_units(newval, self._units / (u.s**2)).to(
             self._units / (u.s**2)).magnitude)
         self._newport_cmd("AC", target=self.axis_id, params=[newval])
 
@@ -429,7 +430,7 @@ class NewportESP301Axis:
     def deceleration(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / (u.s**2)).rescale(
+        newval = float(assume_units(newval, self._units / (u.s**2)).to(
             self._units / (u.s**2)).magnitude)
         self._newport_cmd("AG", target=self.axis_id, params=[newval])
 
@@ -449,7 +450,7 @@ class NewportESP301Axis:
 
     @estop_deceleration.setter
     def estop_deceleration(self, decel):
-        decel = float(assume_units(decel, self._units / (u.s**2)).rescale(
+        decel = float(assume_units(decel, self._units / (u.s**2)).to(
             self._units / (u.s**2)).magnitude)
         self._newport_cmd("AE", target=self.axis_id, params=[decel])
 
@@ -470,7 +471,7 @@ class NewportESP301Axis:
 
     @jerk.setter
     def jerk(self, jerk):
-        jerk = float(assume_units(jerk, self._units / (u.s**3)).rescale(
+        jerk = float(assume_units(jerk, self._units / (u.s**3)).to(
             self._units / (u.s**3)).magnitude)
         self._newport_cmd("JK", target=self.axis_id, params=[jerk])
 
@@ -490,7 +491,7 @@ class NewportESP301Axis:
 
     @velocity.setter
     def velocity(self, velocity):
-        velocity = float(assume_units(velocity, self._units / (u.s)).rescale(
+        velocity = float(assume_units(velocity, self._units / (u.s)).to(
             self._units / u.s).magnitude)
         self._newport_cmd("VA", target=self.axis_id, params=[velocity])
 
@@ -512,7 +513,7 @@ class NewportESP301Axis:
     def max_velocity(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / u.s).rescale(
+        newval = float(assume_units(newval, self._units / u.s).to(
             self._units / u.s).magnitude)
         self._newport_cmd("VU", target=self.axis_id, params=[newval])
 
@@ -534,7 +535,7 @@ class NewportESP301Axis:
     def max_base_velocity(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / u.s).rescale(
+        newval = float(assume_units(newval, self._units / u.s).to(
             self._units / u.s).magnitude)
         self._newport_cmd("VB", target=self.axis_id, params=[newval])
 
@@ -559,7 +560,7 @@ class NewportESP301Axis:
         newval = float(assume_units(
             newval,
             self._units / u.s
-        ).rescale(self._units / u.s).magnitude)
+        ).to(self._units / u.s).magnitude)
         self._newport_cmd("JH", target=self.axis_id, params=[newval])
 
     @property
@@ -583,7 +584,7 @@ class NewportESP301Axis:
         newval = float(assume_units(
             newval,
             self._units / u.s
-        ).rescale(self._units / u.s).magnitude)
+        ).to(self._units / u.s).magnitude)
         self._newport_cmd("JW", target=self.axis_id, params=[newval])
 
     @property
@@ -607,7 +608,7 @@ class NewportESP301Axis:
         newval = float(assume_units(
             newval,
             self._units / u.s
-        ).rescale(self._units / u.s).magnitude)
+        ).to(self._units / u.s).magnitude)
         self._newport_cmd("OH", target=self.axis_id, params=[newval])
 
     @property
@@ -628,7 +629,7 @@ class NewportESP301Axis:
     def max_acceleration(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units / (u.s**2)).rescale(
+        newval = float(assume_units(newval, self._units / (u.s**2)).to(
             self._units / (u.s**2)).magnitude)
         self._newport_cmd("AU", target=self.axis_id, params=[newval])
 
@@ -646,7 +647,7 @@ class NewportESP301Axis:
 
     @max_deceleration.setter
     def max_deceleration(self, decel):
-        decel = float(assume_units(decel, self._units / (u.s**2)).rescale(
+        decel = float(assume_units(decel, self._units / (u.s**2)).to(
             self._units / (u.s**2)).magnitude)
         self.max_acceleration = decel
 
@@ -711,7 +712,7 @@ class NewportESP301Axis:
     def home(self, newval=0):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units).rescale(
+        newval = float(assume_units(newval, self._units).to(
             self._units).magnitude)
         self._newport_cmd("DH", target=self.axis_id, params=[newval])
 
@@ -757,7 +758,7 @@ class NewportESP301Axis:
     def encoder_resolution(self, newval):
         if newval is None:
             return
-        newval = float(assume_units(newval, self._units).rescale(
+        newval = float(assume_units(newval, self._units).to(
             self._units).magnitude)
         self._newport_cmd("SU", target=self.axis_id, params=[newval])
 
@@ -783,7 +784,7 @@ class NewportESP301Axis:
         newval = float(assume_units(
             newval,
             self._units
-        ).rescale(self._units).magnitude)
+        ).to(self._units).magnitude)
         self._newport_cmd("FR", target=self.axis_id, params=[newval])
 
     @property
@@ -801,7 +802,7 @@ class NewportESP301Axis:
 
     @left_limit.setter
     def left_limit(self, limit):
-        limit = float(assume_units(limit, self._units).rescale(
+        limit = float(assume_units(limit, self._units).to(
             self._units).magnitude)
         self._newport_cmd("SL", target=self.axis_id, params=[limit])
 
@@ -820,7 +821,7 @@ class NewportESP301Axis:
 
     @right_limit.setter
     def right_limit(self, limit):
-        limit = float(assume_units(limit, self._units).rescale(
+        limit = float(assume_units(limit, self._units).to(
             self._units).magnitude)
         self._newport_cmd("SR", target=self.axis_id, params=[limit])
 
@@ -844,7 +845,7 @@ class NewportESP301Axis:
         newval = float(assume_units(
             newval,
             self._units
-        ).rescale(self._units).magnitude)
+        ).to(self._units).magnitude)
         self._newport_cmd("FE", target=self.axis_id, params=[newval])
 
     @property
@@ -865,7 +866,7 @@ class NewportESP301Axis:
     def current(self, newval):
         if newval is None:
             return
-        current = float(assume_units(newval, u.A).rescale(
+        current = float(assume_units(newval, u.A).to(
             u.A).magnitude)
         self._newport_cmd("QI", target=self.axis_id, params=[current])
 
@@ -887,7 +888,7 @@ class NewportESP301Axis:
     def voltage(self, newval):
         if newval is None:
             return
-        voltage = float(assume_units(newval, u.V).rescale(
+        voltage = float(assume_units(newval, u.V).to(
             u.V).magnitude)
         self._newport_cmd("QV", target=self.axis_id, params=[voltage])
 
@@ -1110,7 +1111,7 @@ class NewportESP301Axis:
             commands until movement is finished
         :param bool block: If True, will block code until movement is finished
         """
-        position = float(assume_units(position, self._units).rescale(
+        position = float(assume_units(position, self._units).to(
             self._units).magnitude)
         if absolute:
             self._newport_cmd("PA", params=[position], target=self.axis_id)
@@ -1166,7 +1167,7 @@ class NewportESP301Axis:
 
         :type position: float or :class:`~quantities.Quantity`
         """
-        position = float(assume_units(position, self._units).rescale(
+        position = float(assume_units(position, self._units).to(
             self._units).magnitude)
         self._newport_cmd(
             "WP", target=self.axis_id, params=[position])
@@ -1187,9 +1188,9 @@ class NewportESP301Axis:
         #        In programming mode, the "WS" command should be
         #        sent instead, and the two parameters to this method should
         #        be ignored.
-        poll_interval = float(assume_units(poll_interval, u.s).rescale(
+        poll_interval = float(assume_units(poll_interval, u.s).to(
             u.s).magnitude)
-        max_wait = float(assume_units(max_wait, u.s).rescale(
+        max_wait = float(assume_units(max_wait, u.s).to(
             u.s).magnitude)
         tic = time()
         while True:
@@ -1277,11 +1278,11 @@ class NewportESP301Axis:
                                                        'configuration')
         if 'reduce_motor_torque_time' in kwargs and 'reduce_motor_torque_percentage' in kwargs:
             motor_time = kwargs['reduce_motor_torque_time']
-            motor_time = int(assume_units(motor_time, u.ms).rescale(u.ms).magnitude)
+            motor_time = int(assume_units(motor_time, u.ms).to(u.ms).magnitude)
             if motor_time < 0 or motor_time > 60000:
                 raise ValueError("Time must be between 0 and 60000 ms")
             percentage = kwargs['reduce_motor_torque_percentage']
-            percentage = int(assume_units(percentage, u.percent).rescale(
+            percentage = int(assume_units(percentage, u.percent).to(
                 u.percent).magnitude)
             if percentage < 0 or percentage > 100:
                 raise ValueError("Time must be between 0 and 60000 ms")

--- a/instruments/ondax/lm.py
+++ b/instruments/ondax/lm.py
@@ -11,7 +11,7 @@ Class originally contributed by Catherine Holloway.
 
 from enum import IntEnum
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import convert_temperature, assume_units
@@ -252,7 +252,7 @@ class LM(Instrument):
             Example usage:
 
             >>> import instruments as ik
-            >>> import instruments.units as u
+            >>> from instruments.units import ureg as u
             >>> laser = ik.ondax.LM.open_serial('/dev/ttyUSB0', baud=1234)
             >>> print(laser.modulation.on_time)
             >>> laser.modulation.on_time = 1 * u.ms
@@ -267,7 +267,7 @@ class LM(Instrument):
 
         @on_time.setter
         def on_time(self, newval):
-            newval = assume_units(newval, u.ms).rescale(u.ms).magnitude
+            newval = assume_units(newval, u.ms).to(u.ms).magnitude
             self._parent.sendcmd("stsont:"+str(newval))
 
         @property
@@ -280,7 +280,7 @@ class LM(Instrument):
             Example usage:
 
             >>> import instruments as ik
-            >>> import instruments.units as u
+            >>> from instruments.units import ureg as u
             >>> laser = ik.ondax.LM.open_serial('/dev/ttyUSB0', baud=1234)
             >>> print(laser.modulation.on_time)
             >>> laser.modulation.on_time = 1 * u.ms
@@ -295,7 +295,7 @@ class LM(Instrument):
 
         @off_time.setter
         def off_time(self, newval):
-            newval = assume_units(newval, u.ms).rescale(u.ms).magnitude
+            newval = assume_units(newval, u.ms).to(u.ms).magnitude
             self._parent.sendcmd("stsofft:"+str(newval))
 
         @property
@@ -375,7 +375,7 @@ class LM(Instrument):
             :type: `~quantities.Quantity`
             """
             response = self._parent.query("rstt?")
-            return float(response)*u.degC
+            return u.Quantity(float(response), u.degC)
 
         @property
         def enabled(self):
@@ -436,7 +436,7 @@ class LM(Instrument):
 
     @current.setter
     def current(self, newval):
-        newval = assume_units(newval, u.mA).rescale(u.mA).magnitude
+        newval = assume_units(newval, u.mA).to(u.mA).magnitude
         self.sendcmd("slc:"+str(newval))
 
     @property
@@ -454,7 +454,7 @@ class LM(Instrument):
 
     @maximum_current.setter
     def maximum_current(self, newval):
-        newval = assume_units(newval, u.mA).rescale('mA').magnitude
+        newval = assume_units(newval, u.mA).to('mA').magnitude
         self.sendcmd("smlc:" + str(newval))
 
     @property
@@ -471,7 +471,7 @@ class LM(Instrument):
 
     @power.setter
     def power(self, newval):
-        newval = assume_units(newval, u.mW).rescale(u.mW).magnitude
+        newval = assume_units(newval, u.mW).to(u.mW).magnitude
         self.sendcmd("slp:"+str(newval))
 
     @property
@@ -504,7 +504,7 @@ class LM(Instrument):
         :type: `~quantities.Quantity`
         """
         response = self.query("rtt?")
-        return float(response)*u.degC
+        return u.Quantity(float(response), u.degC)
 
     @temperature.setter
     def temperature(self, newval):

--- a/instruments/oxford/oxforditc503.py
+++ b/instruments/oxford/oxforditc503.py
@@ -7,7 +7,7 @@ Provides support for the Oxford ITC 503 temperature controller.
 # IMPORTS #####################################################################
 
 from instruments.abstract_instruments import Instrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################
@@ -57,7 +57,7 @@ class OxfordITC503(Instrument):
             :type: `~quantities.quantity.Quantity`
             """
             value = float(self._parent.query('R{}'.format(self._idx))[1:])
-            return u.Quantity(value, u.Kelvin)
+            return u.Quantity(value, u.kelvin)
 
     # PROPERTIES #
 

--- a/instruments/phasematrix/phasematrix_fsw0020.py
+++ b/instruments/phasematrix/phasematrix_fsw0020.py
@@ -10,8 +10,9 @@ Provides support for the Phase Matrix FSW0020 signal generator.
 from quantities import GHz
 
 from instruments.abstract_instruments.signal_generator import SingleChannelSG
+from instruments.units import ureg as u
+from instruments.units import cBm, dBm
 from instruments.util_fns import assume_units
-from instruments.units import dBm, cBm, mHz
 
 # CLASSES #####################################################################
 
@@ -25,7 +26,7 @@ class PhaseMatrixFSW0020(SingleChannelSG):
     Example::
 
         >>> import instruments as ik
-        >>> import instruments.units as u
+        >>> from instruments.units import ureg as u
         >>> inst = ik.phasematrix.PhaseMatrixFSW0020.open_serial("/dev/ttyUSB0", baud=115200)
         >>> inst.frequency = 1 * u.GHz
         >>> inst.power = 0 * ik.units.dBm  # Can omit units and will assume dBm
@@ -50,13 +51,13 @@ class PhaseMatrixFSW0020(SingleChannelSG):
         :type: `~quantities.Quantity`
         :units: frequency, assumed to be GHz
         """
-        return (int(self.query('04.'), 16) * mHz).rescale(GHz)
+        return (int(self.query('04.'), 16) * u.mHz).to(u.GHz)
 
     @frequency.setter
     def frequency(self, newval):
         # Rescale the input to millihertz as demanded by the signal
         # generator, then convert to an integer.
-        newval = int(assume_units(newval, GHz).rescale(mHz).magnitude)
+        newval = int(assume_units(newval, u.GHz).to(u.mHz).magnitude)
 
         # Write the integer to the serial port in ASCII-encoded
         # uppercase-hexadecimal format, with padding to 12 nybbles.
@@ -74,7 +75,7 @@ class PhaseMatrixFSW0020(SingleChannelSG):
         :type: `~quantities.Quantity`
         :units: log-power, assumed to be dBm
         """
-        return (int(self.query('0D.'), 16) * cBm).rescale(dBm)
+        return (int(self.query('0D.'), 16) * cBm).to(dBm)
 
     @power.setter
     def power(self, newval):
@@ -83,7 +84,7 @@ class PhaseMatrixFSW0020(SingleChannelSG):
 
         # The Phase Matrix unit speaks in units of centibel-milliwats,
         # so convert and take the integer part.
-        newval = int(assume_units(newval, dBm).rescale(cBm).magnitude)
+        newval = int(assume_units(newval, dBm).to(cBm).magnitude)
 
         # Command code 0x03, parameter length 2 bytes (4 nybbles)
         self.sendcmd('03{:04X}.'.format(newval))

--- a/instruments/picowatt/picowattavs47.py
+++ b/instruments/picowatt/picowattavs47.py
@@ -9,7 +9,7 @@ Provides support for the Picowatt AVS 47 resistance bridge
 from enum import IntEnum
 
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (enum_property, bool_property, int_property,
                                   ProxyList)
 

--- a/instruments/qubitekk/cc1.py
+++ b/instruments/qubitekk/cc1.py
@@ -11,7 +11,7 @@ CC1 Class originally contributed by Catherine Holloway.
 from enum import Enum
 
 from instruments.generic_scpi.scpi_instrument import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (
     ProxyList, assume_units, split_unit_str
 )
@@ -229,7 +229,7 @@ class CC1(SCPIInstrument):
 
     @window.setter
     def window(self, new_val):
-        new_val_mag = int(assume_units(new_val, u.ns).rescale(u.ns).magnitude)
+        new_val_mag = int(assume_units(new_val, u.ns).to(u.ns).magnitude)
         if new_val_mag < 0 or new_val_mag > 7:
             raise ValueError("Window is out of range.")
         # window must be an integer!
@@ -249,7 +249,7 @@ class CC1(SCPIInstrument):
 
     @delay.setter
     def delay(self, new_val):
-        new_val = assume_units(new_val, u.ns).rescale(u.ns)
+        new_val = assume_units(new_val, u.ns).to(u.ns)
         if new_val < 0*u.ns or new_val > 14*u.ns:
             raise ValueError("New delay value is out of bounds.")
         if new_val.magnitude % 2 != 0:
@@ -276,7 +276,7 @@ class CC1(SCPIInstrument):
 
     @dwell_time.setter
     def dwell_time(self, new_val):
-        new_val_mag = assume_units(new_val, u.s).rescale(u.s).magnitude
+        new_val_mag = assume_units(new_val, u.s).to(u.s).magnitude
         if new_val_mag < 0:
             raise ValueError("Dwell time cannot be negative.")
         self.sendcmd(":DWEL {}".format(new_val_mag))

--- a/instruments/qubitekk/mc1.py
+++ b/instruments/qubitekk/mc1.py
@@ -11,7 +11,7 @@ MC1 Class originally contributed by Catherine Holloway.
 from enum import Enum
 
 from instruments.abstract_instruments import Instrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (
     int_property, enum_property, unitful_property, assume_units
 )
@@ -56,7 +56,7 @@ class MC1(Instrument):
 
     @increment.setter
     def increment(self, newval):
-        self._increment = assume_units(newval, u.ms).rescale(u.ms)
+        self._increment = assume_units(newval, u.ms).to(u.ms)
 
     @property
     def lower_limit(self):
@@ -70,7 +70,7 @@ class MC1(Instrument):
 
     @lower_limit.setter
     def lower_limit(self, newval):
-        self._lower_limit = assume_units(newval, u.ms).rescale(u.ms)
+        self._lower_limit = assume_units(newval, u.ms).to(u.ms)
 
     @property
     def upper_limit(self):
@@ -84,7 +84,7 @@ class MC1(Instrument):
 
     @upper_limit.setter
     def upper_limit(self, newval):
-        self._upper_limit = assume_units(newval, u.ms).rescale(u.ms)
+        self._upper_limit = assume_units(newval, u.ms).to(u.ms)
 
     direction = unitful_property(
         command="DIRE",
@@ -243,7 +243,7 @@ class MC1(Instrument):
         :type new_position: `~quantities.Quantity`
         """
         if self.lower_limit <= new_position <= self.upper_limit:
-            new_position = assume_units(new_position, u.ms).rescale(u.ms)
+            new_position = assume_units(new_position, u.ms).to(u.ms)
             clock_cycles = new_position/self.step_size
             cmd = ":MOVE "+str(int(clock_cycles))
             self.sendcmd(cmd)

--- a/instruments/srs/srs345.py
+++ b/instruments/srs/srs345.py
@@ -9,7 +9,7 @@ Provides support for the SRS 345 function generator.
 
 from enum import IntEnum
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import FunctionGenerator
 from instruments.generic_scpi import SCPIInstrument
@@ -26,7 +26,7 @@ class SRS345(SCPIInstrument, FunctionGenerator):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> srs = ik.srs.SRS345.open_gpib('/dev/ttyUSB0', 1)
     >>> srs.frequency = 1 * u.MHz
     >>> print(srs.offset)

--- a/instruments/srs/srs830.py
+++ b/instruments/srs/srs830.py
@@ -20,7 +20,7 @@ from instruments.abstract_instruments.comm import (
     LoopbackCommunicator
 )
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (
     bool_property, bounded_unitful_property, enum_property, unitful_property
 )
@@ -41,7 +41,7 @@ class SRS830(SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> srs = ik.srs.SRS830.open_gpibusb('/dev/ttyUSB0', 1)
     >>> srs.frequency = 1000 * u.hertz # Lock-In frequency
     >>> data = srs.take_measurement(1, 10) # 1Hz sample rate, 10 samples total

--- a/instruments/srs/srsctc100.py
+++ b/instruments/srs/srsctc100.py
@@ -12,7 +12,7 @@ from enum import Enum
 import numpy as np
 
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################

--- a/instruments/srs/srsdg645.py
+++ b/instruments/srs/srsdg645.py
@@ -10,7 +10,7 @@ from enum import IntEnum
 
 from instruments.abstract_instruments.comm import GPIBCommunicator
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import assume_units, ProxyList
 
 # CLASSES #####################################################################
@@ -65,7 +65,7 @@ class _SRSDG645Channel:
         self._ddg.sendcmd("DLAY {},{},{}".format(
             int(self._chan),
             int(newval[0].idx),
-            newval[1].rescale("s").magnitude
+            newval[1].to("s").magnitude
         ))
 
 
@@ -78,7 +78,7 @@ class SRSDG645(SCPIInstrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> srs = ik.srs.SRSDG645.open_gpibusb('/dev/ttyUSB0', 1)
     >>> srs.channel["B"].delay = (srs.channel["A"], u.Quantity(10, 'ns'))
     >>> srs.output["AB"].level_amplitude = u.Quantity(4.0, "V")
@@ -304,7 +304,7 @@ class SRSDG645(SCPIInstrument):
     @trigger_rate.setter
     def trigger_rate(self, newval):
         newval = assume_units(newval, u.Hz)
-        self.sendcmd("TRAT {}".format(newval.rescale(u.Hz).magnitude))
+        self.sendcmd("TRAT {}".format(newval.to(u.Hz).magnitude))
 
     @property
     def trigger_source(self):
@@ -331,7 +331,7 @@ class SRSDG645(SCPIInstrument):
 
     @holdoff.setter
     def holdoff(self, newval):
-        self.sendcmd("HOLD {}".format(newval.rescale(u.s).magnitude))
+        self.sendcmd("HOLD {}".format(newval.to(u.s).magnitude))
 
     @property
     def enable_burst_mode(self):
@@ -386,7 +386,7 @@ class SRSDG645(SCPIInstrument):
 
     @burst_period.setter
     def burst_period(self, newval):
-        self.sendcmd("BURP {}".format(newval.rescale(u.s).magnitude))
+        self.sendcmd("BURP {}".format(newval.to(u.sec).magnitude))
 
     @property
     def burst_delay(self):
@@ -400,4 +400,4 @@ class SRSDG645(SCPIInstrument):
 
     @burst_delay.setter
     def burst_delay(self, newval):
-        self.sendcmd("BURD {}".format(newval.rescale(u.s).magnitude))
+        self.sendcmd("BURD {}".format(newval.to(u.s).magnitude))

--- a/instruments/tektronix/tekawg2000.py
+++ b/instruments/tektronix/tekawg2000.py
@@ -11,7 +11,7 @@ from enum import Enum
 import numpy as np
 
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import assume_units, ProxyList
 
 # CLASSES #####################################################################
@@ -73,7 +73,7 @@ class TekAWG2000(SCPIInstrument):
         def amplitude(self, newval):
             self._tek.sendcmd("FG:{}:AMPL {}".format(
                 self._name,
-                assume_units(newval, u.V).rescale(u.V).magnitude
+                assume_units(newval, u.V).to(u.V).magnitude
             ))
 
         @property
@@ -94,7 +94,7 @@ class TekAWG2000(SCPIInstrument):
         def offset(self, newval):
             self._tek.sendcmd("FG:{}:OFFS {}".format(
                 self._name,
-                assume_units(newval, u.V).rescale(u.V).magnitude
+                assume_units(newval, u.V).to(u.V).magnitude
             ))
 
         @property
@@ -115,7 +115,7 @@ class TekAWG2000(SCPIInstrument):
         @frequency.setter
         def frequency(self, newval):
             self._tek.sendcmd("FG:FREQ {}HZ".format(
-                assume_units(newval, u.Hz).rescale(u.Hz).magnitude
+                assume_units(newval, u.Hz).to(u.Hz).magnitude
             ))
 
         @property

--- a/instruments/tektronix/tekdpo70000.py
+++ b/instruments/tektronix/tekdpo70000.py
@@ -14,7 +14,7 @@ from instruments.abstract_instruments import (
     Oscilloscope, OscilloscopeChannel, OscilloscopeDataSource
 )
 from instruments.generic_scpi import SCPIInstrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (
     enum_property, string_property, int_property, unitful_property,
     unitless_property, bool_property, ProxyList

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -19,7 +19,7 @@ from instruments.abstract_instruments import (
 )
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import ProxyList
-import instruments.units as u
+from instruments.units import ureg as u
 
 
 # CLASSES #####################################################################

--- a/instruments/tests/test_abstract_inst/test_function_generator.py
+++ b/instruments/tests/test_abstract_inst/test_function_generator.py
@@ -8,7 +8,7 @@ Module containing tests for the abstract function generator class
 
 
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 

--- a/instruments/tests/test_agilent/test_agilent_33220a.py
+++ b/instruments/tests/test_agilent/test_agilent_33220a.py
@@ -7,7 +7,7 @@ Module containing tests for generic SCPI function generator instruments
 # IMPORTS ####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test
@@ -155,14 +155,14 @@ def test_agilent33220a_load_resistance():
             [
                 "OUTP:LOAD?",
                 "OUTP:LOAD?",
-                "OUTP:LOAD 100.0",
+                "OUTP:LOAD 100",
                 "OUTP:LOAD MAX"
             ], [
                 "50",
                 "INF"
             ]
     ) as fg:
-        assert fg.load_resistance == 50 * u.Ohm
+        assert fg.load_resistance == 50 * u.ohm
         assert fg.load_resistance == fg.LoadResistance.high_impedance
-        fg.load_resistance = 100 * u.Ohm
+        fg.load_resistance = 100 * u.ohm
         fg.load_resistance = fg.LoadResistance.maximum

--- a/instruments/tests/test_agilent/test_agilent_34410a.py
+++ b/instruments/tests/test_agilent/test_agilent_34410a.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq
-import instruments.units as u
+from instruments.units import ureg as u
 
 # TESTS ######################################################################
 

--- a/instruments/tests/test_comm/test_gpibusb.py
+++ b/instruments/tests/test_comm/test_gpibusb.py
@@ -9,7 +9,7 @@ Unit tests for the GPIBUSB communication layer
 
 import pytest
 import serial
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments.comm import GPIBCommunicator, SerialCommunicator
 from instruments.tests import unit_eq

--- a/instruments/tests/test_comm/test_serial.py
+++ b/instruments/tests/test_comm/test_serial.py
@@ -9,7 +9,7 @@ Unit tests for the serial communication layer
 
 import pytest
 import serial
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments.comm import SerialCommunicator
 from instruments.tests import unit_eq

--- a/instruments/tests/test_comm/test_socket.py
+++ b/instruments/tests/test_comm/test_socket.py
@@ -10,7 +10,7 @@ Unit tests for the socket communication layer
 import socket
 
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments.comm import SocketCommunicator
 from instruments.tests import unit_eq

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -13,7 +13,7 @@ from numpy import array
 
 from instruments.abstract_instruments.comm import USBTMCCommunicator
 from instruments.tests import unit_eq
-import instruments.units as u
+from instruments.units import ureg as u
 from .. import mock
 
 # TEST CASES #################################################################

--- a/instruments/tests/test_config.py
+++ b/instruments/tests/test_config.py
@@ -9,7 +9,7 @@ Module containing tests for util_fns.py
 
 from io import StringIO
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments import Instrument
 from instruments.config import (

--- a/instruments/tests/test_fluke/test_fluke3000.py
+++ b/instruments/tests/test_fluke/test_fluke3000.py
@@ -7,7 +7,7 @@ Module containing tests for the Fluke 3000 FC multimeter
 # IMPORTS ####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -160,4 +160,4 @@ def test_measure():
             "\r"
     ) as inst:
         assert inst.measure(inst.Mode.voltage_dc) == 0.509 * u.volt
-        assert inst.measure(inst.Mode.temperature) == -25.3 * u.celsius
+        assert inst.measure(inst.Mode.temperature) == u.Quantity(-25.3, u.degC)

--- a/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
@@ -7,7 +7,7 @@ Module containing tests for generic SCPI function generator instruments
 # IMPORTS ####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test

--- a/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
@@ -7,7 +7,7 @@ Module containing tests for generic SCPI multimeter instruments
 # IMPORTS ####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq
@@ -54,7 +54,7 @@ def test_scpi_multimeter_input_range():
                 "CONF?",  # 3.1
                 "CONF:FRES MIN",  # 3.2
                 "CONF?",  # 4.1
-                "CONF:CURR:DC 1.0"  # 4.2
+                "CONF:CURR:DC 1"  # 4.2
             ], [
                 "CURR:AC +1.000000E+01,+3.000000E-06",  # 1
                 "CURR:AC AUTO,+3.000000E-06",  # 2

--- a/instruments/tests/test_glassman/test_glassmanfr.py
+++ b/instruments/tests/test_glassman/test_glassmanfr.py
@@ -8,7 +8,7 @@ Module containing tests for the Glassman FR power supply
 
 import instruments as ik
 from instruments.tests import expected_protocol
-import instruments.units as u
+from instruments.units import ureg as u
 
 
 # TESTS ######################################################################

--- a/instruments/tests/test_holzworth/test_holzworth_hs9000.py
+++ b/instruments/tests/test_holzworth/test_holzworth_hs9000.py
@@ -7,7 +7,7 @@ Unit tests for the Holzworth HS9000
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -118,7 +118,7 @@ def test_channel_temperature():
             sep="\n"
     ) as hs:
         channel = hs.channel[0]
-        assert channel.temperature == 10 * u.degC
+        assert channel.temperature == u.Quantity(10, u.degC)
 
 
 def test_channel_frequency_getter():

--- a/instruments/tests/test_hp/test_hp3456a.py
+++ b/instruments/tests/test_hp/test_hp3456a.py
@@ -12,7 +12,7 @@ import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
-import instruments.units as u
+from instruments.units import ureg as u
 
 # TESTS #######################################################################
 
@@ -180,15 +180,9 @@ def test_hp3456a_fetch():
             sep="\r"
     ) as dmm:
         v = dmm.fetch(dmm.Mode.resistance_2wire)
-        np.testing.assert_array_equal(
-            v, [0.1055, 0.1043, 0.1005, 0.1014] * u.ohm
-        )
-        assert v[0].units == u.ohm
+        assert v == [0.1055 * u.ohm, 0.1043 * u.ohm, 0.1005 * u.ohm, 0.1014 * u.ohm]
         v = dmm.fetch()
-        np.testing.assert_array_equal(
-            v, [0.1055, 0.1043, 0.1005, 0.1014] * u.ohm
-        )
-        assert isinstance(v[0], float)
+        assert v == [0.1055, 0.1043, 0.1005, 0.1014]
 
 
 def test_hp3456a_variance():
@@ -239,7 +233,7 @@ def test_hp3456a_delay():
             [
                 "HO0T4SO1",
                 "RED",
-                "W1.0STD"
+                "W1STD"
             ], [
                 "-000.0000E+0"
             ],

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -11,7 +11,7 @@ import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
-import instruments.units as u
+from instruments.units import ureg as u
 from .. import mock
 
 # TESTS #######################################################################

--- a/instruments/tests/test_hp/test_hp6632b.py
+++ b/instruments/tests/test_hp/test_hp6632b.py
@@ -7,7 +7,7 @@ Unit tests for the HP 6632b power supply
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq

--- a/instruments/tests/test_hp/test_hpe3631a.py
+++ b/instruments/tests/test_hp/test_hpe3631a.py
@@ -7,7 +7,7 @@ Module containing tests for the HP E3631A power supply
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol

--- a/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/tests/test_keithley/test_keithley2182.py
@@ -12,7 +12,7 @@ import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
-import instruments.units as u
+from instruments.units import ureg as u
 
 # TESTS #######################################################################
 
@@ -69,7 +69,7 @@ def test_channel_measure_temperature():
             ]
     ) as inst:
         channel = inst.channel[0]
-        assert channel.measure() == 1.234 * u.celsius
+        assert channel.measure() == u.Quantity(1.234, u.degC)
 
 
 def test_channel_measure_unknown_temperature_units():
@@ -118,15 +118,9 @@ def test_units():
                 "VOLT"
             ]
     ) as inst:
-        units = str(inst.units.units).split()[1]
-        assert units == "degC"
-
-        units = str(inst.units.units).split()[1]
-        assert units == "degF"
-
-        units = str(inst.units.units).split()[1]
-        assert units == "K"
-
+        assert inst.units == u.degC
+        assert inst.units == u.degF
+        assert inst.units == u.kelvin
         assert inst.units == u.volt
 
 

--- a/instruments/tests/test_keithley/test_keithley485.py
+++ b/instruments/tests/test_keithley/test_keithley485.py
@@ -7,7 +7,7 @@ Module containing tests for the Keithley 485 picoammeter
 # IMPORTS ####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -148,5 +148,5 @@ def test_measure():
                 "NDCL-9.0000E+0"
             ]
     ) as inst:
-        assert inst.measure() == 1.2345 * u.nanoamp
-        assert inst.measure() == 1. * u.nanoamp
+        assert 1.2345 * u.nanoamp == inst.measure()
+        assert 1 * u.nanoamp == inst.measure()

--- a/instruments/tests/test_keithley/test_keithley6220.py
+++ b/instruments/tests/test_keithley/test_keithley6220.py
@@ -7,7 +7,7 @@ Unit tests for the Keithley 6220 constant current supply
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol

--- a/instruments/tests/test_keithley/test_keithley6514.py
+++ b/instruments/tests/test_keithley/test_keithley6514.py
@@ -11,7 +11,7 @@ import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
-import instruments.units as u
+from instruments.units import ureg as u
 
 # TESTS #######################################################################
 

--- a/instruments/tests/test_minghe/test_minghe_mhs5200a.py
+++ b/instruments/tests/test_minghe/test_minghe_mhs5200a.py
@@ -8,7 +8,7 @@ Module containing tests for the MingHe MHS52000a
 
 
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -164,8 +164,8 @@ def test_mhs_phase():
             ],
             sep="\r\n"
     ) as mhs:
-        assert mhs.channel[0].phase == 120
-        assert mhs.channel[1].phase == 0
+        assert mhs.channel[0].phase == 120 * u.degree
+        assert mhs.channel[1].phase == 0 * u.degree
         mhs.channel[0].phase = 60
         mhs.channel[1].phase = 180
 

--- a/instruments/tests/test_ondax/test_lm.py
+++ b/instruments/tests/test_ondax/test_lm.py
@@ -13,6 +13,7 @@ import quantities
 
 from instruments import ondax
 from instruments.tests import expected_protocol
+from instruments.units import ureg as u
 
 # TESTS #######################################################################
 
@@ -28,7 +29,7 @@ def test_acc_target():
             ],
             sep="\r"
     ) as lm:
-        assert lm.acc.target == 100 * quantities.mA
+        assert lm.acc.target == 100 * u.mA
 
 
 def test_acc_enable():
@@ -111,7 +112,7 @@ def test_apc_target():
             ],
             sep="\r"
     ) as lm:
-        assert lm.apc.target == 100 * quantities.mW
+        assert lm.apc.target == 100 * u.mW
 
 
 def test_apc_enable():
@@ -188,7 +189,7 @@ def test_modulation_on_time():
             ondax.LM,
             [
                 "stsont?",
-                "stsont:20.0"
+                "stsont:20"
             ],
             [
                 "10",
@@ -196,8 +197,8 @@ def test_modulation_on_time():
             ],
             sep="\r"
     ) as lm:
-        assert lm.modulation.on_time == 10 * quantities.ms
-        lm.modulation.on_time = 20 * quantities.ms
+        assert lm.modulation.on_time == 10 * u.ms
+        lm.modulation.on_time = 20 * u.ms
 
 
 def test_modulation_off_time():
@@ -205,7 +206,7 @@ def test_modulation_off_time():
             ondax.LM,
             [
                 "stsofft?",
-                "stsofft:20.0"
+                "stsofft:20"
             ],
             [
                 "10",
@@ -213,8 +214,8 @@ def test_modulation_off_time():
             ],
             sep="\r"
     ) as lm:
-        assert lm.modulation.off_time == 10 * quantities.ms
-        lm.modulation.off_time = 20 * quantities.ms
+        assert lm.modulation.off_time == 10 * u.ms
+        lm.modulation.off_time = 20 * u.ms
 
 
 def test_modulation_enabled():
@@ -269,7 +270,7 @@ def test_tec_current():
             ],
             sep="\r"
     ) as lm:
-        assert lm.tec.current == 100 * quantities.mA
+        assert lm.tec.current == 100 * u.mA
 
 
 def test_tec_target():
@@ -283,7 +284,7 @@ def test_tec_target():
             ],
             sep="\r"
     ) as lm:
-        assert lm.tec.target == 22 * quantities.degC
+        assert lm.tec.target == u.Quantity(22, u.degC)
 
 
 def test_tec_enable():
@@ -346,7 +347,7 @@ def test_current():
             ondax.LM,
             [
                 "rli?",
-                "slc:100.0"
+                "slc:100"
             ],
             [
                 "120",
@@ -354,8 +355,8 @@ def test_current():
             ],
             sep="\r"
     ) as lm:
-        assert lm.current == 120 * quantities.mA
-        lm.current = 100 * quantities.mA
+        assert lm.current == 120 * u.mA
+        lm.current = 100 * u.mA
 
 
 def test_maximum_current():
@@ -363,7 +364,7 @@ def test_maximum_current():
             ondax.LM,
             [
                 "rlcm?",
-                "smlc:100.0"
+                "smlc:100"
             ],
             [
                 "120",
@@ -371,8 +372,8 @@ def test_maximum_current():
             ],
             sep="\r"
     ) as lm:
-        assert lm.maximum_current == 120 * quantities.mA
-        lm.maximum_current = 100 * quantities.mA
+        assert lm.maximum_current == 120 * u.mA
+        lm.maximum_current = 100 * u.mA
 
 
 def test_power():
@@ -380,7 +381,7 @@ def test_power():
             ondax.LM,
             [
                 "rlp?",
-                "slp:100.0"
+                "slp:100"
             ],
             [
                 "120",
@@ -388,8 +389,8 @@ def test_power():
             ],
             sep="\r"
     ) as lm:
-        assert lm.power == 120 * quantities.mW
-        lm.power = 100 * quantities.mW
+        assert lm.power == 120 * u.mW
+        lm.power = 100 * u.mW
 
 
 def test_serial_number():
@@ -425,7 +426,7 @@ def test_temperature():
             ondax.LM,
             [
                 "rtt?",
-                "stt:40.0"
+                "stt:40"
             ],
             [
                 "35",
@@ -433,8 +434,8 @@ def test_temperature():
             ],
             sep="\r"
     ) as lm:
-        assert lm.temperature == 35 * quantities.degC
-        lm.temperature = 40 * quantities.degC
+        assert lm.temperature == u.Quantity(35, u.degC)
+        lm.temperature = u.Quantity(40, u.degC)
 
 
 def test_enable():

--- a/instruments/tests/test_oxford/test_oxforditc503.py
+++ b/instruments/tests/test_oxford/test_oxforditc503.py
@@ -7,10 +7,9 @@ Unit tests for the Oxford ITC 503 temperature controller
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
-
 import instruments as ik
 from instruments.tests import expected_protocol
+from instruments.units import ureg as u
 
 # TESTS #######################################################################
 
@@ -41,4 +40,4 @@ def test_sensor_temperature():
             sep="\r"
     ) as inst:
         sensor = inst.sensor[0]
-        assert sensor.temperature == 123 * u.kelvin
+        assert sensor.temperature == u.Quantity(123, u.kelvin)

--- a/instruments/tests/test_phasematrix/test_phasematrix_fsw0020.py
+++ b/instruments/tests/test_phasematrix/test_phasematrix_fsw0020.py
@@ -7,11 +7,11 @@ Unit tests for the Phasematrix FSW0020
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
-from instruments.units import mHz, dBm, cBm
+from instruments.units import dBm, cBm
 
 # TESTS #######################################################################
 
@@ -32,13 +32,13 @@ def test_frequency():
             ik.phasematrix.PhaseMatrixFSW0020,
             [
                 "04.",
-                "0C{:012X}.".format(int((10 * u.GHz).rescale(mHz).magnitude))
+                "0C{:012X}.".format(int((10 * u.GHz).to(u.mHz).magnitude))
             ],
             [
                 "00E8D4A51000"
             ]
     ) as inst:
-        assert inst.frequency == 1 * u.GHz
+        assert inst.frequency == 1.0000000000000002 * u.GHz
         inst.frequency = 10 * u.GHz
 
 
@@ -47,7 +47,7 @@ def test_power():
             ik.phasematrix.PhaseMatrixFSW0020,
             [
                 "0D.",
-                "03{:04X}.".format(int((10 * dBm).rescale(cBm).magnitude))
+                "03{:04X}.".format(int((10 * dBm).to(cBm).magnitude))
             ],
             [
                 "-064"

--- a/instruments/tests/test_picowatt/test_picowatt_avs47.py
+++ b/instruments/tests/test_picowatt/test_picowatt_avs47.py
@@ -7,7 +7,7 @@ Unit tests for the Picowatt AVS47
 # IMPORTS #####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol

--- a/instruments/tests/test_property_factories/test_bounded_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_bounded_unitful_property.py
@@ -8,7 +8,7 @@ Module containing tests for the bounded unitful property factories
 
 
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.util_fns import bounded_unitful_property
 from . import MockInstrument

--- a/instruments/tests/test_property_factories/test_unitful_property.py
+++ b/instruments/tests/test_property_factories/test_unitful_property.py
@@ -8,9 +8,10 @@ Module containing tests for the unitful property factories
 
 
 import pytest
-import instruments.units as u
+import pint
 
 from instruments.util_fns import unitful_property
+from instruments.units import ureg as u
 from . import MockInstrument
 
 # TEST CASES #################################################################
@@ -62,7 +63,7 @@ def test_unitful_property_no_units_on_set():
 
 
 def test_unitful_property_wrong_units():
-    with pytest.raises(ValueError):
+    with pytest.raises(pint.errors.DimensionalityError):
         class UnitfulMock(MockInstrument):
             unitful_property = unitful_property('MOCK', u.hertz)
 

--- a/instruments/tests/test_property_factories/test_unitless_property.py
+++ b/instruments/tests/test_property_factories/test_unitless_property.py
@@ -8,7 +8,7 @@ Module containing tests for the unitless property factory
 
 
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.util_fns import unitless_property
 from . import MockInstrument

--- a/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_cc1.py
@@ -8,7 +8,7 @@ Module containing tests for the Qubitekk CC1
 
 
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, unit_eq

--- a/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
+++ b/instruments/tests/test_qubitekk/test_qubitekk_mc1.py
@@ -9,7 +9,7 @@ Module containing tests for the Qubitekk MC1
 
 import pytest
 
-import instruments.units as u
+from instruments.units import ureg as u
 import instruments as ik
 from instruments.tests import expected_protocol
 
@@ -75,7 +75,7 @@ def test_mc1_direction():
             ],
             sep="\r"
     ) as mc:
-        assert mc.direction == -100
+        assert mc.direction == -100 * u.ms
 
 
 def test_mc1_firmware():
@@ -103,7 +103,7 @@ def test_mc1_inertia():
             ],
             sep="\r"
     ) as mc:
-        assert mc.inertia == 20
+        assert mc.inertia == 20 * u.ms
 
 
 def test_mc1_step():

--- a/instruments/tests/test_split_str.py
+++ b/instruments/tests/test_split_str.py
@@ -9,7 +9,7 @@ Module containing tests for the util_fns.split_unit_str utility function
 
 import pytest
 
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (
     split_unit_str
 )

--- a/instruments/tests/test_srs/test_srs345.py
+++ b/instruments/tests/test_srs/test_srs345.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import instruments as ik
 from instruments.tests import expected_protocol
-import instruments.units as u
+from instruments.units import ureg as u
 
 # TESTS #######################################################################
 

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -12,7 +12,7 @@ import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
-import instruments.units as u
+from instruments.units import ureg as u
 
 # TESTS #######################################################################
 

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -7,7 +7,7 @@ Module containing tests for the SRS DG645
 # IMPORTS ####################################################################
 
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test, unit_eq
@@ -72,7 +72,7 @@ def test_srsdg645_output_polarity():
 
 
 def test_srsdg645_trigger_source():
-    with expected_protocol(ik.srs.SRSDG645, "DLAY?2\nDLAY 3,2,60.0\n", "0,42\n") as ddg:
+    with expected_protocol(ik.srs.SRSDG645, "DLAY?2\nDLAY 3,2,60\n", "0,42\n") as ddg:
         ref, t = ddg.channel["A"].delay
         assert ref == ddg.Channels.T0
         assert abs((t - u.Quantity(42, "s")).magnitude) < 1e5
@@ -150,7 +150,7 @@ def test_srsdg645_burst_period():
                 "100E-9"
             ]
     ) as ddg:
-        unit_eq(ddg.burst_period, u.Quantity(100, "ns").rescale(u.s))
+        unit_eq(ddg.burst_period, u.Quantity(100, "ns").to(u.sec))
         ddg.burst_period = u.Quantity(13, "s")
 
 

--- a/instruments/tests/test_thorlabs/test_thorlabs_apt.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_apt.py
@@ -12,7 +12,7 @@ Module containing tests for the Thorlabs TC200
 import struct
 
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.thorlabs._packets import ThorLabsPacket, hw_info_data

--- a/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
@@ -8,7 +8,7 @@ Module containing tests for the Thorlabs LCC25
 
 
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, unit_eq

--- a/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_sc10.py
@@ -8,7 +8,7 @@ Module containing tests for the Thorlabs SC10
 
 
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol, unit_eq

--- a/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
@@ -9,7 +9,7 @@ Module containing tests for the Thorlabs TC200
 
 from enum import IntEnum
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -141,7 +141,7 @@ def test_tc200_temperature():
             ],
             sep="\r"
     ) as tc:
-        assert tc.temperature == 30.0 * u.degC
+        assert tc.temperature == u.Quantity(30.0, u.degC)
 
 
 def test_tc200_temperature_set():
@@ -150,20 +150,20 @@ def test_tc200_temperature_set():
             [
                 "tset?",
                 "tmax?",
-                "tset=40.0"
+                "tset=40"
             ],
             [
                 "tset?",
                 "30 C",
                 "> tmax?",
                 "250",
-                "> tset=40.0",
+                "> tset=40",
                 "> "
             ],
             sep="\r"
     ) as tc:
-        assert tc.temperature_set == 30.0 * u.degC
-        tc.temperature_set = 40 * u.degC
+        assert tc.temperature_set == u.Quantity(30.0, u.degC)
+        tc.temperature_set = u.Quantity(40, u.degC)
 
 
 def test_tc200_temperature_range():
@@ -179,7 +179,7 @@ def test_tc200_temperature_range():
             ],
             sep="\r"
     ) as tc:
-        tc.temperature_set = 50 * u.degC
+        tc.temperature_set = u.Quantity(50, u.degC)
 
 
 def test_tc200_pid():
@@ -378,8 +378,8 @@ def test_tc200_degrees():
             ],
             sep="\r"
     ) as tc:
-        assert str(tc.degrees).split(" ")[1] == "K"
-        assert str(tc.degrees).split(" ")[1] == "degC"
+        assert tc.degrees == u.degK
+        assert tc.degrees == u.degC
         assert tc.degrees == u.degF
 
         tc.degrees = u.degC
@@ -550,8 +550,8 @@ def test_tc200_max_temperature():
             ],
             sep="\r"
     ) as tc:
-        assert tc.max_temperature == 200.0 * u.degC
-        tc.max_temperature = 180 * u.degC
+        assert tc.max_temperature == u.Quantity(200.0, u.degC)
+        tc.max_temperature = u.Quantity(180, u.degC)
 
 
 def test_tc200_temp_min():

--- a/instruments/tests/test_toptica/test_toptica_topmode.py
+++ b/instruments/tests/test_toptica/test_toptica_topmode.py
@@ -8,7 +8,7 @@ Module containing tests for the Toptica Topmode
 
 from datetime import datetime
 import pytest
-import instruments.units as u
+from instruments.units import ureg as u
 
 
 import instruments as ik

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -8,9 +8,10 @@ Module containing tests for util_fns.py
 
 from enum import Enum
 
+import pint
 import pytest
 
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (
     ProxyList,
     assume_units, convert_temperature,
@@ -126,47 +127,15 @@ def test_assume_units_correct():
     m = u.Quantity(1, 'm')
 
     # Check that unitful quantities are kept unitful.
-    assert assume_units(m, 'mm').rescale('mm').magnitude == 1000
+    assert assume_units(m, 'mm').to('mm').magnitude == 1000
 
     # Check that raw scalars are made unitful.
-    assert assume_units(1, 'm').rescale('mm').magnitude == 1000
-
-
-def test_temperature_conversion():
-    blo = 70.0 * u.degF
-    out = convert_temperature(blo, u.degC)
-    assert out.magnitude == 21.11111111111111
-    out = convert_temperature(blo, u.degK)
-    assert out.magnitude == 294.2055555555555
-    out = convert_temperature(blo, u.degF)
-    assert out.magnitude == 70.0
-
-    blo = 20.0 * u.degC
-    out = convert_temperature(blo, u.degF)
-    assert out.magnitude == 68
-    out = convert_temperature(blo, u.degC)
-    assert out.magnitude == 20.0
-    out = convert_temperature(blo, u.degK)
-    assert out.magnitude == 293.15
-
-    blo = 270 * u.degK
-    out = convert_temperature(blo, u.degC)
-    assert out.magnitude == -3.1499999999999773
-    out = convert_temperature(blo, u.degF)
-    assert out.magnitude == 141.94736842105263
-    out = convert_temperature(blo, u.K)
-    assert out.magnitude == 270
-
-
-def test_temperater_conversion_failure():
-    with pytest.raises(ValueError):
-        blo = 70.0 * u.degF
-        convert_temperature(blo, u.V)
+    assert assume_units(1, 'm').to('mm').magnitude == 1000
 
 
 def test_assume_units_failures():
-    with pytest.raises(ValueError):
-        assume_units(1, 'm').rescale('s')
+    with pytest.raises(pint.errors.DimensionalityError):
+        assume_units(1, 'm').to('s')
 
 def test_setattr_expression_simple():
     class A:

--- a/instruments/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/instruments/tests/test_yokogawa/test_yokogawa_6370.py
@@ -14,7 +14,7 @@ from hypothesis import (
     strategies as st,
 )
 import numpy as np
-import instruments.units as u
+from instruments.units import ureg as u
 
 import instruments as ik
 from instruments.tests import expected_protocol

--- a/instruments/thorlabs/_abstract.py
+++ b/instruments/thorlabs/_abstract.py
@@ -73,7 +73,7 @@ class ThorLabsInstrument(Instrument):
         t_start = time.time()
 
         if timeout:
-            timeout = assume_units(timeout, second).rescale('second').magnitude
+            timeout = assume_units(timeout, second).to('second').magnitude
 
         while True:
             self._file.write_raw(packet.pack())

--- a/instruments/thorlabs/lcc25.py
+++ b/instruments/thorlabs/lcc25.py
@@ -13,7 +13,7 @@ from enum import IntEnum
 from instruments.thorlabs.thorlabs_utils import check_cmd
 
 from instruments.abstract_instruments import Instrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import enum_property, bool_property, unitful_property
 
 # CLASSES #####################################################################

--- a/instruments/thorlabs/pm100usb.py
+++ b/instruments/thorlabs/pm100usb.py
@@ -12,7 +12,7 @@ from collections import defaultdict, namedtuple
 
 from enum import Enum, IntEnum
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import enum_property

--- a/instruments/thorlabs/sc10.py
+++ b/instruments/thorlabs/sc10.py
@@ -12,7 +12,7 @@ from enum import IntEnum
 
 from instruments.abstract_instruments import Instrument
 from instruments.thorlabs.thorlabs_utils import check_cmd
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (
     bool_property, enum_property, int_property, unitful_property
 )

--- a/instruments/thorlabs/tc200.py
+++ b/instruments/thorlabs/tc200.py
@@ -11,7 +11,7 @@ Class originally contributed by Catherine Holloway.
 from enum import IntEnum, Enum
 
 from instruments.abstract_instruments import Instrument
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import (
     convert_temperature, enum_property, unitful_property, int_property
 )
@@ -167,7 +167,7 @@ class TC200(Instrument):
         units=u.degC,
         format_code="{:.1f}",
         set_fmt="{}={}",
-        valid_range=(20*u.degC, 205*u.degC),
+        valid_range=(u.Quantity(20, u.degC), u.Quantity(205, u.degC)),
         doc="""
         Gets/sets the maximum temperature
 
@@ -191,15 +191,15 @@ class TC200(Instrument):
         """
         response = self.query("tset?").replace(
             " C", "").replace(" F", "").replace(" K", "")
-        return float(response) * u.degC
+        return u.Quantity(float(response), u.degC)
 
     @temperature_set.setter
     def temperature_set(self, newval):
         # the set temperature is always in celsius
-        newval = convert_temperature(newval, u.degC).magnitude
-        if newval < 20.0 or newval > self.max_temperature:
+        newval = convert_temperature(newval, u.degC)
+        if newval < u.Quantity(20.0, u.degC) or newval > self.max_temperature:
             raise ValueError("Temperature set is out of range.")
-        out_query = "tset={}".format(newval)
+        out_query = "tset={}".format(newval.magnitude)
         self.sendcmd(out_query)
 
     @property
@@ -293,11 +293,11 @@ class TC200(Instrument):
 
     @degrees.setter
     def degrees(self, newval):
-        if newval is u.degC:
+        if newval == u.degC:
             self.sendcmd("unit=c")
-        elif newval is u.degF:
+        elif newval == u.degF:
             self.sendcmd("unit=f")
-        elif newval is u.degK:
+        elif newval == u.degK:
             self.sendcmd("unit=k")
         else:
             raise TypeError("Invalid temperature type")

--- a/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/thorlabs/thorlabsapt.py
@@ -14,7 +14,7 @@ import codecs
 import warnings
 
 from instruments.thorlabs import _abstract, _packets, _cmds
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import assume_units
 
 # LOGGING #####################################################################
@@ -696,7 +696,7 @@ class APTMotorController(ThorLabsAPT):
                     scaled_pos = (pos * self.scale_factors[0])
                     # Force a unit error.
                     try:
-                        pos_ec = int(scaled_pos.rescale(u.counts).magnitude)
+                        pos_ec = int(scaled_pos.to(u.counts).magnitude)
                     except:
                         raise ValueError("Provided units are not compatible "
                                          "with current motor scale factor.")

--- a/instruments/toptica/topmode.py
+++ b/instruments/toptica/topmode.py
@@ -13,7 +13,7 @@ from enum import IntEnum
 from instruments.abstract_instruments import Instrument
 from instruments.toptica.toptica_utils import convert_toptica_boolean as ctbool
 from instruments.toptica.toptica_utils import convert_toptica_datetime as ctdate
-import instruments.units as u
+from instruments.units import ureg as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################
@@ -359,7 +359,7 @@ class TopMode(Instrument):
         For example, the following would print the wavelength from laser 1:
 
         >>> import instruments as ik
-        >>> import instruments.units as u
+        >>> from instruments.units import ureg as u
         >>> tm = ik.toptica.TopMode.open_serial('/dev/ttyUSB0', 115200)
         >>> print(tm.laser[0].wavelength)
 

--- a/instruments/units.py
+++ b/instruments/units.py
@@ -12,7 +12,11 @@ Module containing custom units used by various instruments.
 from quantities import *
 from quantities.unitquantity import IrreducibleUnit
 
+from pint import _DEFAULT_REGISTRY as ureg
+
 # UNITS #######################################################################
+
+ureg.define("percent = []")
 
 # IRREDUCIBLE UNITS #
 
@@ -36,16 +40,6 @@ dBm = UnitLogPower('decibel-milliwatt', symbol='dBm')
 # easier later on.
 
 # TODO: move custom units out to another module.
-
-mHz = UnitQuantity(
-    'millihertz',
-    milli * Hz,
-    symbol='mHz',
-    doc="""
-    `~quantities.UnitQuantity` representing millihertz, the native unit of the
-    Phase Matrix FSW-0020.
-    """
-)
 
 #: Centibel-milliwatts, the native log-power unit supported by the
 #: Phase Matrix FSW-0020.

--- a/instruments/util_fns.py
+++ b/instruments/util_fns.py
@@ -10,7 +10,7 @@ Module containing various utility functions
 import re
 
 from enum import Enum, IntEnum
-import instruments.units as u
+from instruments.units import ureg as u
 
 # CONSTANTS ###################################################################
 
@@ -85,27 +85,7 @@ def convert_temperature(temperature, base):
     # quantities reports equivalence between degC and degK, so a string
     # comparison is needed
     newval = assume_units(temperature, u.degC)
-    if newval.units == u.degF and str(base).split(" ")[1] == 'degC':
-        return_val = ((newval.magnitude - 32.0) * 5.0 / 9.0) * base
-    elif str(newval.units).split(" ")[1] == 'K' and str(base).split(" ")[1] == 'degC':
-        return_val = (newval.magnitude - 273.15) * base
-    elif str(newval.units).split(" ")[1] == 'K' and base == u.degF:
-        return_val = (newval.magnitude / 1.8 - 459 / 57) * base
-    elif str(newval.units).split(" ")[1] == 'degC' and base == u.degF:
-        return_val = (newval.magnitude * 9.0 / 5.0 + 32.0) * base
-    elif newval.units == u.degF and str(base).split(" ")[1] == 'K':
-        return_val = ((newval.magnitude + 459.57) * 5.0 / 9.0) * base
-    elif str(newval.units).split(" ")[1] == 'degC' and str(base).split(" ")[1] == 'K':
-        return_val = (newval.magnitude + 273.15) * base
-    elif str(newval.units).split(" ")[1] == 'degC' and str(base).split(" ")[1] == 'degC':
-        return_val = newval
-    elif newval.units == u.degF and base == u.degF:
-        return_val = newval
-    elif str(newval.units).split(" ")[1] == 'K' and str(base).split(" ")[1] == 'K':
-        return_val = newval
-    else:
-        raise ValueError(f"Unable to convert {str(newval.units)} to {str(base)}")
-    return return_val
+    return newval.to(base)
 
 
 def split_unit_str(s, default_units=u.dimensionless, lookup=None):
@@ -468,7 +448,7 @@ def unitful_property(command, units, set_cmd=None, format_code='{:e}', doc=None,
 
     def _getter(self):
         raw = _in_decor_fcn(self.query("{}?".format(command)))
-        return u.Quantity(*split_unit_str(raw, units)).rescale(units)
+        return u.Quantity(*split_unit_str(raw, units)).to(units)
 
     def _setter(self, newval):
         min_value, max_value = valid_range
@@ -487,7 +467,7 @@ def unitful_property(command, units, set_cmd=None, format_code='{:e}', doc=None,
         # Rescale to the correct unit before printing. This will also
         # catch bad units.
         strval = format_code.format(
-            assume_units(newval, units).rescale(units).item())
+            assume_units(newval, units).to(units).magnitude)
         self.sendcmd(set_fmt.format(
             command if set_cmd is None else set_cmd,
             _out_decor_fcn(strval)
@@ -545,13 +525,13 @@ def bounded_unitful_property(command, units, min_fmt_str="{}:MIN?",
         if valid_range[0] == "query":
             return u.Quantity(*split_unit_str(self.query(min_fmt_str.format(command)), units))
 
-        return assume_units(valid_range[0], units).rescale(units)
+        return assume_units(valid_range[0], units).to(units)
 
     def _max_getter(self):
         if valid_range[1] == "query":
             return u.Quantity(*split_unit_str(self.query(max_fmt_str.format(command)), units))
 
-        return assume_units(valid_range[1], units).rescale(units)
+        return assume_units(valid_range[1], units).to(units)
 
     new_range = (
         None if valid_range[0] is None else _min_getter,

--- a/instruments/yokogawa/yokogawa6370.py
+++ b/instruments/yokogawa/yokogawa6370.py
@@ -9,7 +9,7 @@ Provides support for the Yokogawa 6370 optical spectrum analyzer.
 
 from enum import IntEnum, Enum
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import (
     OpticalSpectrumAnalyzer,
@@ -31,7 +31,7 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> inst = ik.yokogawa.Yokogawa6370.open_visa('TCPIP0:192.168.0.35')
     >>> inst.start_wl = 1030e-9 * u.m
     """

--- a/instruments/yokogawa/yokogawa7651.py
+++ b/instruments/yokogawa/yokogawa7651.py
@@ -9,7 +9,7 @@ Provides support for the Yokogawa 7651 power supply.
 
 from enum import IntEnum
 
-import instruments.units as u
+from instruments.units import ureg as u
 
 from instruments.abstract_instruments import (
     PowerSupply,
@@ -29,7 +29,7 @@ class Yokogawa7651(PowerSupply, Instrument):
     Example usage:
 
     >>> import instruments as ik
-    >>> import instruments.units as u
+    >>> from instruments.units import ureg as u
     >>> inst = ik.yokogawa.Yokogawa7651.open_gpibusb("/dev/ttyUSB0", 1)
     >>> inst.voltage = 10 * u.V
     """
@@ -91,7 +91,7 @@ class Yokogawa7651(PowerSupply, Instrument):
 
         @voltage.setter
         def voltage(self, newval):
-            newval = assume_units(newval, u.volt).rescale(u.volt).magnitude
+            newval = assume_units(newval, u.volt).to(u.volt).magnitude
             self.mode = self._parent.Mode.voltage
             self._parent.sendcmd('SA{};'.format(newval))
             self._parent.trigger()
@@ -113,7 +113,7 @@ class Yokogawa7651(PowerSupply, Instrument):
 
         @current.setter
         def current(self, newval):
-            newval = assume_units(newval, u.amp).rescale(u.amp).magnitude
+            newval = assume_units(newval, u.amp).to(u.amp).magnitude
             self.mode = self._parent.Mode.current
             self._parent.sendcmd('SA{};'.format(newval))
             self._parent.trigger()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-vxi11>=0.8
 pyusb
 python-usbtmc
 ruamel.yaml~=0.15.37
+pint>=0.14.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ INSTALL_REQUIRES = [
     "python-vxi11>=0.8",
     "python-usbtmc",
     "pyusb",
-    "ruamel.yaml~=0.15.37"
+    "ruamel.yaml~=0.15.37",
+    "pint>=0.14.0"
 ]
 
 


### PR DESCRIPTION
This is a work-in-progress of replacing `quantities` with `pint` for handling units.

This is for issue #92 and issue #190 

Currently, all unit tests pass except for any that reference our logarithmic units we created under `quantities`. Taking a look at the `pint` issues and open pull requests, @5igno has taken it upon themselves to add `dB`-type units to `pint` https://github.com/hgrecco/pint/pull/1027 . With this feature we will be able to finish the transition and remove all remaining references.