### PR TITLE
Support of Teledyne-LeCroy MAUI enabled oscilloscopes

### DIFF
--- a/doc/examples/ex_maui.ipynb
+++ b/doc/examples/ex_maui.ipynb
@@ -1,0 +1,862 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MAUI Oscilloscope controller\n",
+    "\n",
+    "The middle to high-end Teledyne-LeCroy oscilloscope come with the MAUI (Most Advanced User Interface) control interface. Each of these MAUI-enabled scopes can be controlled in the same way, assuming they have the same functionality, etc. The `MAUI` class presents a control interface to remotely access and setup an oscilloscope. Not every functionality is incorporated at this point, but the most imporant and basic ones are, i.e.:\n",
+    " * General Oscilloscope controls, i.e., triggering\n",
+    " * Channels\n",
+    " * Math functions\n",
+    " * Measurement setup and data retrieval\n",
+    " * Waveform retrieval\n",
+    "Here, some detailed examples for various applications are shown. \n",
+    "\n",
+    "## Communications\n",
+    "These Oscilloscopes have many different ways of communicating with the host computer. This class only supports the `LXI (VXI11)` protocol, which should come by default on theses oscilloscopes. The reason for this is that this protocoll supports the NI-VISA protocol, which can be completely replaced with the open PyVISA. Thus the oscilloscope can be controlled from any OS, in fact, most of the development have taken place on Linux. *Note*: The scope that the software was developed with is an older wavesurfer 3054, which was at least supposed to support the `LXI (VXI11)` protocol. However, it could not be activated. After contacting Teledyne-LeCroy, they responded fairly quickly and sent an activation code to enable the protocol, free of charge.\n",
+    "\n",
+    "In order to successfully communicate with the oscilloscope, PyVISA requires the [pyvisa-py](https://pyvisa-py.readthedocs.io/en/latest/) backend. This should be the requirements for the package now. If not or not yet installed on your setup, you can install it by typing:\n",
+    "\n",
+    "    pip install pyvisa-py\n",
+    "\n",
+    "## Importing the pre-requisites\n",
+    "First let's import some packages that we'll need, mostly instrumentkit of course :)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "\n",
+    "# if you run this script from a cloned InstrumentKit path without a full installation, leave the following line in\n",
+    "sys.path.insert(0, os.path.abspath('../../'))\n",
+    "\n",
+    "# import the instrument kit\n",
+    "import instruments as ik\n",
+    "import instruments.units as u\n",
+    "\n",
+    "# imports for specific functions in this script\n",
+    "import matplotlib.pyplot as plt\n",
+    "from time import sleep"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Enabling the oscilloscope\n",
+    "\n",
+    "First let us look at how to establish communications with the oscilloscope. ON the oscilloscope itself, go to `Utilities` -> `Utilities Setup` -> `Remote` and select on the left side the `LXI (VXI11)` communications protocol. Connect the oscilloscope to your local area network and check it's IP address. The example IP address that will be used here is `192.168.8.154`.\n",
+    "\n",
+    "Then you can load the oscilloscope and enable communications in the following way:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inst = ik.teledyne.MAUI.open_visa(\"TCPIP0::192.168.0.10::INSTR\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Specifying your oscilloscope setup\n",
+    "\n",
+    "The MAUI interface works for mulitple different Teledyne-LeCroy oscilloscopes. Not all of these oscilloscopes will have the same options, so some commands might not be available on your scope. To make the oscilloscope controller versatile, the number of available channels (default 4), available functions (default 2), and available measurements (default 6) can be adjusted. The number of channels is simply how many inputs are available on the front. The number of functions is how many functions can be set up in the scopes math menu, usually labeled as `F1`, ... `Fn` in th oscilloscope software. The number of available measurements is the number of measurements that can be configured on the scope, usually labeled as `P1`, ... `Pn`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# setting and getting the number of channels\n",
+    "inst.number_channels = 4\n",
+    "inst.number_channels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# setting and getting the number of functions\n",
+    "inst.number_functions = 2\n",
+    "inst.number_functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# setting and getting the number of measurements\n",
+    "inst.number_measurements = 6\n",
+    "inst.number_measurements"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Triggering the scope\n",
+    "\n",
+    "The simplest possible way to stop and start the oscilloscope from triggering is as following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# stop the oscilloscope from triggering\n",
+    "inst.stop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# start the oscilloscope in automatic triggering mode\n",
+    "inst.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, the four triggering states can also be controlled manually. These states are: automatic triggering `auto`, normal triggering `normal`, a single trigger `single` and no triggering `stop`. These trigger states are implemented as a `inst.TriggerState` subclass under the instrument class. Reading the trigger state (should be `auto` from just before) and then setting it to `normal` can be done in the following way:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<TriggerState.auto: 'AUTO'>"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# get the current trigger state\n",
+    "inst.trigger_state"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# restart the trigger with a single trigger\n",
+    "inst.trigger_state = inst.TriggerState.normal"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition, e.g., for a measurement, a trigger can also be forced upon request. For this to work, set the oscilloscope into stop mode, then force a trigger."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stop the triggering\n",
+    "inst.stop()\n",
+    "\n",
+    "# A trigger can also be forced by calling:\n",
+    "inst.force_trigger()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The oscilloscope will be put back into stopped mode. To continue triggering in normal mode, run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inst.trigger_state = inst.TriggerState.normal"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to selecting the triggering state, the triggering source, type, and level can also be chosen. For most oscilloscopes, all channels and an external triggering source can be chosen from, optional settings are possible. Possible triggering sources are stored in the `enum` class `TriggerSource`, while triggering types are stored in the `TriggerType` `enum` class.\n",
+    "\n",
+    "Let's set the triggering source to the external trigger and trigger on the edge. This can be accomplished with the following commands:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inst.trigger_source = inst.TriggerSource.ext\n",
+    "inst.trigger_type = inst.TriggerType.edge"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Time base\n",
+    "\n",
+    "The timebase is the same for all channels and therefore implemented on the instrument level. Setting the timebase of the scope expects a unitful value. If no units are given, seconds are assumed. To set the time per division to 20 ns and read it back out, run the following commands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(2.e-08) * s"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "inst.time_div = u.Quantity(20, u.ns)\n",
+    "inst.time_div"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To shift the timebase with respect to the trigger, a trigger delay can be called. This call is unitful as well. To set a trigger delay of 60 ns and read it back, run the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(6.e-08) * s"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "inst.trigger_delay = u.Quantity(60, u.ns)\n",
+    "inst.trigger_delay"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controlling a channel\n",
+    "\n",
+    "To control a channel, several functions are implemented. The first channel is referred to as `0`, as is common in python. To create an instance of the first channel you can run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "channel = inst.channel[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Turning a trace on and off can be done by setting the `channel.trace` with a bool. For example, to turn the trace on (no matter what state it is in) and then read its state back, run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "channel.trace = True\n",
+    "channel.trace"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Control over the coupling of the specific channel is supplied via the `channel.Coupling` class. To set the coupling to $50\\,\\Omega$ and then read it back, run the following commands:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Coupling.dc50: 'D50'>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "channel.coupling = channel.Coupling.dc50\n",
+    "channel.coupling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The scale (i.e., the volts per division) of a channel can be set unitful as well. If no units are given it is assumed that the user means Volts per division. To set the scale to 1 V per division and read its state back, run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(1.) * V"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "channel.scale = u.Quantity(1, u.V)\n",
+    "channel.scale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the same manner, the trace can also be shifted to, let's say -2950 mV in vertical position. This offset can be set / read as following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(-2.95) * V"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "channel.offset = u.Quantity(-2950, u.mV)\n",
+    "channel.offset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, after having gone through all configurations, the waveform can be read back to the computer. The waveform is reutrned as a two dimensional numpy array representing the timebase and the signal. We can directly unpack the waveform via:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timebase, signal = channel.read_waveform()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Furthermore we know that the signal has been shifted by -2.95 V in the negative direction and by 60 ns in the positive time base direction. Let's see how the signal looks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0, 0.5, 'Signal (V)')"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAEGCAYAAAB2EqL0AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy86wFpkAAAACXBIWXMAAAsTAAALEwEAmpwYAAAoGElEQVR4nO3deZwcdZ3/8de758iQhJBABhJCIFweiBAkIiz+VkRFZBV0hQV3V0Fxs+qq67ru4ye6i9f68Nj1/OnioiKILh6ga0QOURDwAAkYjhAC4Q4EMgRyXzPdn98fVT3p6enu6UmqZtKd9/Px6MdUV1VXfaa6pz/zPUsRgZmZ2UgK4x2AmZm1BicMMzNrihOGmZk1xQnDzMya4oRhZmZN6RzvAEZr+vTpMWfOnPEOw8yspdx+++3PRETvjhyj5RLGnDlzWLhw4XiHYWbWUiQ9uqPHcJWUmZk1xQnDzMya4oRhZmZNccIwM7OmOGGYmVlTnDDMzKwpThhmZtYUJwwzaxsbtgxwwW8e5KG+9eMdSltywjCztnHzA3187pr7+Nw19413KG3JCcPM2sazG/oBWL9lYJwjaU9OGGbWNlZv2grAhM6OcY6kPTlhmFnbWLMpKWGUfOvpXDhhmFnbWLMxSRgbtxbHOZL2lFvCkNQj6Y+S7pS0WNInauxzjqQ+SYvSxzvzisfM2l+5hLG53wkjD3lOb74FODEi1kvqAn4r6eqIuKVqvx9GxHtzjMPMdhGb0kThEkY+cksYERFAuTN0V/pwxaKZ5WZLfwmATU4Yuci1DUNSh6RFwErguoi4tcZub5Z0l6TLJc2uc5z5khZKWtjX15dnyGbWwrYMJIlik6ukcpFrwoiIYkTMBfYDjpF0eNUuPwfmRMQRwHXAJXWOc2FEzIuIeb29O3SHQTNrY1uLLmHkaUx6SUXEauAG4OSq9asiYkv69FvA0WMRj5m1p3KVVNHdanORZy+pXklT0+XdgNcA91XtM7Pi6anAkrziMbP2t2UgTRglJ4w85NlLaiZwiaQOksT0o4i4UtIngYURsQB4v6RTgQHgWeCcHOMxsza3tSJhRASSxjmi9pJnL6m7gKNqrD+/Yvk84Ly8YjCzXUu50RuSpNHZ4YSRJY/0NrO2Ua6SAhhwtVTmnDDMrG1sGSjRlZYq3I6RPScMM2sLA8USxVIwsTupaXdPqew5YZhZWyiPwZjYnUxtXiw6YWTNCcPM2kK5h9RuacJwG0b2nDDMrC0MK2E4YWTOCcPM2kJ/WgXV01kuYZQa7W7bwQnDzNrCQFrC6OlyCSMvThhm1hb6BxNG8rXmNozsOWGYWVvYOpBWSaUljJITRuacMMysLZTbLHbrci+pvDhhmFlb6HcbRu6cMMysLZSrpDwOIz9OGGbWFspVUttKGO5WmzUnDDNrC8N6SXlqkMw5YZhZW6geuOc2jOw5YZhZWxjW6O3ZajPnhGFmbaGcMHbr9sC9vOSWMCT1SPqjpDslLZb0iRr7TJD0Q0nLJN0qaU5e8ZhZeytXSZXHYXh68+zlWcLYApwYEUcCc4GTJR1btc+5wHMRcQjwJeBzOcZjZm2sXMKY4IF7ucktYURiffq0K31Uv4OnAZeky5cDr5Lku7ab2aj1p/fDcKN3fnJtw5DUIWkRsBK4LiJurdplFvA4QEQMAGuAvfKMyczaU7lEUe5W60bv7OWaMCKiGBFzgf2AYyQdvj3HkTRf0kJJC/v6+jKN0czaw9aqXlKefDB7Y9JLKiJWAzcAJ1dtegKYDSCpE9gDWFXj9RdGxLyImNfb25tztGbWisoD9SZ0Jl9rJZcwMpdnL6leSVPT5d2A1wD3Ve22ADg7XT4duD7C77KZjV5/sURB0NWRVkm5hJG5zhyPPRO4RFIHSWL6UURcKemTwMKIWAB8G7hU0jLgWeCsHOMxsza2tViis6NAoZD0m3EJI3u5JYyIuAs4qsb68yuWNwNn5BWDme06BopBd0eBDpUTxjgH1IY80tvM2kJ/sURnh0gLGK6SyoEThpm1hf5iiS5XSeXKCcPM2kJ/dZWUSxiZc8Iws7awrUoqSRieSip7Thhm1hYGipFWSSXPXcLInhOGmbWFrWkbRofbMHLjhGFmbSFp9K6sknLCyJoThpm1hcEqKTd658YJw8zawtZiic6CKqqkxjmgNuSEYWZtob9Yoruz4IF7OXLCMLO2UK6SkoTkRu88OGGYWVvoT6ukADokJ4wcOGGYWVsYKAWdHUnCKBREej8ly5AThpm1hVIpBntIFVwllQsnDDNrC8WIwR5SHZK71ebACcPM2kKxFIMTDxYK8sC9HDhhmFlbKJVicGrzgksYuXDCMLO2UIxtJYwOlzBy4YRhZm2hWGJoCcP5InO5JQxJsyXdIOleSYsl/WONfU6QtEbSovRxfq1jmZmNJCIGR3kX5Lmk8tCZ47EHgH+OiDsk7Q7cLum6iLi3ar+bI+L1OcZhZruAIb2kCvLUIDnIrYQRESsi4o50eR2wBJiV1/nMbNdWHDIOw1VSeRiTNgxJc4CjgFtrbD5O0p2Srpb0ojqvny9poaSFfX19eYZqZi2qVNpWwigUPHAvD7knDEmTgSuAD0TE2qrNdwAHRMSRwP8D/rfWMSLiwoiYFxHzent7c43XzFpT9cA9V0llL9eEIamLJFl8PyJ+Ur09ItZGxPp0+SqgS9L0PGMys/ZUKrGtSqrgyQfzkGcvKQHfBpZExBfr7DMj3Q9Jx6TxrMorJjNrX0kJI1kueLbaXOTZS+p44K3A3ZIWpes+AuwPEBHfAE4H3i1pANgEnBXhd9nMRq9yahBXSeUjt4QREb8FNMI+XwO+llcMZrZrKI+5GBy4V3AvqTx4pLeZtbzyNCDbpgbxwL08OGGYWcsrVpcw5Lmk8uCEYWYtr9zA3eG5pHLlhGFmLa9cwqicrdZVUtlzwjCzllfODaqYfNC9pLLnhGFmLa9cmhhaJeWEkTUnDDNrecWqNowOj/TOhROGmbW8wXEYFbPVukoqew0H7knaDzgL+D/AviSjse8BfgFcHRGl3CM0MxtBdQnDA/fyUTdhSPoOyf0rrgQ+B6wEeoDnAScDH5X04Yi4aSwCNTOrZ1gvKXl68zw0KmF8ISLuqbH+HuAnkrpJ54UyMxtPpbSuY8jAPRcxMteoDeN1aZVUTRGxNSKW5RCTmdmobKuSSp67SiofjRLGvsAfJN0s6T2SfOciM9spFasavTvkgXt5qJswIuKfSKqc/hV4MXCXpGsknS1p97EK0MxsJMOmBinguaRy0LBbbSRujIh3A/sBXwI+ADw9BrGZmTWlutHbA/fy0dT9MCS9mKR77ZnAM8B5eQZlZjYa1bPVei6pfDTqVnsoSZI4CygCPwBOioiHxig2M7OmlGJ4CcNVUtlrVMK4BrgMOLNO91ozs51CsdZcUh5WnLlGCePQkUZyS1K9e3BLmg18F9gHCODCiPhK9euBrwCnABuBcyLijlHEb2Y2bLbajoIH7uWhUaP39ZLeJ2nI4DxJ3ZJOlHQJcHaD1w8A/xwRhwHHAv8g6bCqfV4HHJo+5gMXjPo3MLNdXnUvqY6CB+7loVEJ42TgHcBlkg4EVpNMDdIB/BL4ckT8qd6LI2IFsCJdXidpCclUI/dW7HYa8N20lHKLpKmSZqavNTNrSnUvKfmOe7momzAiYjPwX8B/SeoCpgObImL1aE8iaQ5wFHBr1aZZwOMVz5en64YkDEnzSUog7L+/ZyMxs6FK1b2k3K02F01Nbx4R/RGxYjuTxWTgCuADEbF2tK9Pz39hRMyLiHm9vR5wbmZD1bofhqukspfr/TDSkskVwPcj4ic1dnkCmF3xfL90nZlZ06qnBpFnq81Fbgkj7QH1bWBJRHyxzm4LgLcpcSywxu0XZjZawxq9PZdULpoa6b2djgfeCtwtaVG67iOkU6JHxDeAq0i61C4j6Vb79hzjMbM2VUwHAAzeD6PggXt5aDTSex3J+Ilhm0immZrS6MAR8dt030b7BPAPTcRpZlbXtqlBkufuJZWPRr2kPCOtmbWE4eMwcJVUDpqukpK0N8k4DAAi4rFcIjIzG6Xht2h1lVQeRmz0lnSqpAeAh4EbgUeAq3OOy8ysaeUSRnkchiQioM7MRbadmukl9SmSqT3uj4gDgVcBt+QalZnZKAwrYaSJw7VS2WomYfRHxCqgIKkQETcA83KOy8ysadWz1ZZ/evBetpppw1idjta+Cfi+pJXAhnzDMjNrXrnmqTxbbfmnB+9lq5kSxmnAJuCfSO6R8SDwhjyDMjMbjWFTg6hcJeWEkaURSxgRUVmauCTHWMzMtku9NgxXSWWrmV5SfynpAUlrJK2VtE7Sdk0iaGaWh1q9pADfdS9jzbRhfB54Q0QsyTsYM7PtMXwcRrLeVVLZaqYN42knCzPbmRWr74dRrpJywshUMyWMhZJ+CPwvsKW8ss505WZmY656apBtVVJOGFlqJmFMIZlJ9qSKdQE4YZjZTqHWbLXggXtZa6aXlKccN7Od2rZG7+R5OXG4SipbIyYMSV+tsXoNsDAifpZ9SGZmo1Pd6F1uy3CVVLaaafTuAeYCD6SPI0hupXqupC/nFpmZWZOqpwYpuJdULpppwzgCOD4iigCSLgBuBl4O3J1jbGZmTSlFIG1r7PbAvXw0U8KYBkyueD4J2DNNIFtqv8TMbOwUSzFYHQVQ8NQguWgmYXweWCTpO5IuBv4E/IekScCv6r1I0kWSVkq6p872E9LR44vSx/nb8wuYmRUjBtstoDJhjFdE7amZXlLflnQVcEy66iMR8WS6/C8NXnox8DXguw32uTkiXt9MoGZm9URsa7eA5Bat4CqprNUtYUh6QfrzJcBM4PH0MSNd11BE3AQ8m1GcZmZ11auScsLIVqMSxgeB+cAXamwL4MQMzn+cpDuBJ4EPRcTiWjtJmp/Gwv7775/Bac2snRRLtauk3ISRrboJIyLmpz9fmdO57wAOiIj1kk4hmXrk0DqxXAhcCDBv3jx/BMxsiFLEYM8o8FxSeWlUJfVSSTMqnr9N0s8kfVXSnjt64ohYGxHr0+WrgC5J03f0uGa26xlWJeVutblo1Evqv4GtAJL+HPgsSQP2GtL/9neEpBlKO01LOiaNZdWOHtfMdj2lYb2kkp/hEkamGrVhdEREudH6TODCiLgCuELSopEOLOky4ARguqTlwMeALoCI+AZwOvBuSQMkt4A9K/zumtl2qC5hdLjROxcNE4akzogYAF5F2ujcxOsAiIi3jLD9ayTdbs3MdkixxJA2jILbMHLR6Iv/MuBGSc+QlABuBpB0CEm1lJnZTiGpktr23L2k8tGol9SnJf2aZAzGLyuqiwrA+8YiODOzZgyrkvLAvVw0rFqKiFtqrLs/v3DMzEav3tQgrpLKVjNzSZmZ7dRKdUZ6ux9NtpwwzKzlFUt1Bu6Vxiui9uSEYWYtrxTbShXguaTy4oRhZi2vupdUuYThKqlsOWGYWcsbPlttut4JI1NOGGbW8oZNDeK5pHLhhGFmLa/e1CAuYGTLCcPMWl69+2G4hJEtJwwza3mlqJ7ePPnpNoxsOWGYWcurNw7DvaSy5YRhZi2vGNSpkhqviNqTE4aZtbxkapBtzz2XVD6cMMys5blKamw4YZhZyytFVE0Nkvx0L6lsOWGYWcurLmF44F4+cksYki6StFLSPXW2S9JXJS2TdJekl+QVi5m1t+r7YXjgXj7yLGFcDJzcYPvrgEPTx3zgghxjMbM2FvVmq3XGyFRuCSMibgKebbDLacB3I3ELMFXSzLziMbP2VazuJeVbtOZiPNswZgGPVzxfnq4bRtJ8SQslLezr6xuT4MysdVRPDdKVZox+D8TIVEs0ekfEhRExLyLm9fb2jnc4ZraTGT41iOgsyAkjY+OZMJ4AZlc83y9dZ2Y2KtW9pAC6Ogr0F10llaXxTBgLgLelvaWOBdZExIpxjMfMWlT1/TAAujrE1gGXMLLUmdeBJV0GnABMl7Qc+BjQBRAR3wCuAk4BlgEbgbfnFYuZtbfq+2EAdHcWXCWVsdwSRkS8ZYTtAfxDXuc3s11H/SopJ4wstUSjt5lZI6WqcRjgNow8OGGYWctLShhD13V1iK0uYWTKCcPMWl711CCQljDc6J0pJwwza3mlUtBZcKN33pwwzKzlDdToJeU2jOw5YZhZSyul80V1FIZ+nbkNI3tOGGbW0gYGE8bQ9e5Wmz0nDDNraaWoV8JwwsiaE4aZtbT6JQzRP+A2jCw5YZhZSyvWbcMouA0jY04YZtbSBhPG0E5STOzuYNPW4jhE1L6cMMyspQ2UklJER1Wd1KQJnazfMjAeIbUtJwwza2lpvhg2cG/3CZ1s2DpA+L7emXHCMLOWNljCqBq4N2lCJxGw0dVSmXHCMLOWVi5hVE9vPmlCcvcGV0tlxwnDzFraYAmjukqqxwkja04YZtbStg3cqyphdKcJY7MTRlacMMyspW0buDc0YUxOSxgbXMLITK4JQ9LJkpZKWibpwzW2nyOpT9Ki9PHOPOMxs/YzUKyTMNyGkbnc7uktqQP4OvAaYDlwm6QFEXFv1a4/jIj35hWHmbW3cpVUdbdaN3pnL88SxjHAsoh4KCK2Aj8ATsvxfGa2CypXSVXfca9cwnCVVHbyTBizgMcrni9P11V7s6S7JF0uaXaO8ZhZGyrfD6O6hFFOGOucMDIz3o3ePwfmRMQRwHXAJbV2kjRf0kJJC/v6+sY0QDPbuQ02elcN3OvpKtBRkEsYGcozYTwBVJYY9kvXDYqIVRGxJX36LeDoWgeKiAsjYl5EzOvt7c0lWDNrTaU6vaQkMam7gw1bPNI7K3kmjNuAQyUdKKkbOAtYULmDpJkVT08FluQYj5m1oXrdaiGpllrncRiZya2XVEQMSHovcC3QAVwUEYslfRJYGBELgPdLOhUYAJ4FzskrHjNrT8VGCaOn01VSGcotYQBExFXAVVXrzq9YPg84L88YzKy9FQcbvYdXmHiK82yNd6O3mdkO2datdvi2yU4YmXLCMLOWtm3g3vCvMyeMbDlhmFlL29boPXzbpAluw8iSE4aZtbQt/Um32e6OjmHbXMLIlhOGmbW0zQPJ/TB6umpXSW3Y4tu0ZsUJw8xaWrmEMaGrRgmjp5NSwKZ+D97LghOGmbW0LQ1KGIMz1nrwXiacMMyspW3uLyJBd41W78kTklKH2zGy4YRhZi1tc3+Rns4OpFpTg3QBeD6pjDhhmFlL29xfqlkdBTApLWGs29I/liG1LScMM2tpm/uL9NRo8AbY3SWMTDlhmFlL2zxQqpswJvckjd7fvOmhsQypbTlhmFlL29xfZEJn7a+yA/acyLSJXdzz5Bq2pr2pbPs5YZhZS2tUJVUoiA+e9Hw2bi1y8lduGuPI2o8Thpm1tL51W5g+eULd7W9+ySyOnD2Vh/o28Mz6LXX3s5E5YZhZS3tq7WZm7FE/YUzs7uSjp7wQgLuWrx6jqNqTE4aZtazN/UVWb+xnxpSehvsdPmsKBcGlf3iU/77xQZY/t3GMImwvud5xz8wsT4+uSr74Z03breF+E7s7OfagvbhhaR83LO3jwb71fP70I8cixLayyySMOx57jot/9whLVqxl1rTdWLd5gFlTh37IlqxYywtnTgHg/qfXsam/SGdBTOjs4JC9Jw875n1PreUFM6YMWffosxvpndzNY89u5Mj9pgKw6PHVg8eFpM5VSn7O2KOHLQOlEf9DqvTUms1M6CrwzPqtdBTgoOnDY6v26KoN9O4+gUdXbRyM5cG+9cyeNpHuOj1MxtKm/iJPrdnMgdMnDVn/8DMbmLFHD/tMmcDqjf088PR6CgUxZ6+JPNi3nhfMmEIA961Yy8TuDnp3n8DE7sYf6/ufXsfBe0+mo8bI4LJiBA+uXA/AgdMn8VDfBkoRTJvYzYSuAtMmdo/4Ow2Nq4eJ3cMbZpc+tY5D95lMoUEs1ZasWMuc6ZNqXq/xtmTFWl6y/zSOPXhPBorBnctXs3bTtmk57n963eD1LBTEgdMn1rzxUbX+Yok/PbaaF87cneXPbRr8DD+1ZjMAL541dcRjfO/cl7FloMTff+92frVkJa/90k0c1DuJR1ZtJCI4qHcSi59M4j/6gGlcd+/TbNgywL5Td6OjIHq6Orjz8dVIsHpjPy+cOaXme5qnV71wb06bO2tMz1lJeU77K+lk4CtAB/CtiPhs1fYJwHeBo4FVwJkR8UijY86bNy8WLlw46lhuWLqSt3/ntiHrDthr4uAf6sPPbABg+uRuVm/sH7wpS9nUiV1DviTWbOrn2Q1b6e4oDP53M1Aq8fizm2qef69J3UzZrWvIuSrN2WtizakNqkUEj6waWpzed4+emjN1llXHNX3yBCZ0FnhidbJuZ/jSKV+T/abtRlc6J1B/scTy52pfz7J9pkzg6bVDGzIb/T6b+4usSL9kGu1X6z1q9hz1jlH9mo1bBwZjb/Y9WLd5YEjDbeX1Gm/1rtmsqbvR3VkYcu0rbc+1nDaxi6np3+P+e07kO+e8lEKhuaS74M4n+cxVS2rGUssBe00cLMlUG+u/nbccM5v5f37wdr1W0u0RMW9Hzp9bwpDUAdwPvAZYDtwGvCUi7q3Y5z3AERHxLklnAW+KiDMbHXd7EwbAjxc+zr9cftfg84c/c8rgl/R7/+cOrrxrBRedM4/r71vJ9255bMhrP/aGw3j78QcOO9bZxx3AJ047HEi+4A796NU1z/2lM4/kTUftB8CcD/9i2PZHPvsXTf0OEcGB5101ZN1tH301vbvXb/Srjus757yUlx64J4d/7NpRnTtP5Wty36dOHuwiubm/yAv+7ZqGr7v2A3/OJ36+mN8/uGpwXaPf56k1mzn2M79m+uRuFv7ra+rud/SnrmPVhq11tzdzzf76m7c0jOuhvvWc+IUbOWTvyfzqg68Y8XgAv3/wGf76m7cOPl/67yczoXNs/8ut512X3s41i58atv6eT7yWyRM6WbFmE8d95voh27o7Ctz/6deNeOzqv5lPvfFw3nrsAdsd67KV63n1F29sat+HP3MKJ/znb2omjZ3hb6dZWSSMPKukjgGWRcRDAJJ+AJwG3Fuxz2nAx9Ply4GvSVLklMXecOS+LH1qHS+aNYWBYgz5j/781x/GrKm78fJDepk7expLn1rH6o39bC2WmLPXJP5q3uyax3rPKw8ZXNfVUeDTbzqcSd2dLFmxlhl79HDPE2uZOrGL1x0+c3C/r//1S9i4dYD7nlrHYTOn0NnRfHWEJL585lyKpeDy25czb860hsmiVlzHHzKd7s4C//b6wzhq/6lNnztPP5x/LEufXjekP31PVwefPO1FTOzu5PfLnuH4Q6bzxOpN9HQV2GdKDw+uXM+he0/m86cfwfdvfYyZe/TUrDqsNGOPHv7ltc/nlc/fu+F+l577Mm5YupKCxL5Te7j90efo7ihwyN6TG3bhrPS5Nx/BZX98jBl14jpw+iT+8VWH8oYjZ9Z4dW3HzNmTd73iYF44c3fWbOrfaZIFwMdPfREH7DWRfab0cO3ip9g8UOKkw/ZhcjrF+IwpPXzopOcxe8+JPLZqI92dBY47eK+mjv2T9/wZ5//sHt5x/IHc++Ra3vySHauWObg3ufYH9U5ixZrNDBRLzN5zIt+8+SE2bS1y5H5TOe7gvShISOLjp76IBYueZN3mfhY/uZY9duviI2nPq11JniWM04GTI+Kd6fO3Ai+LiPdW7HNPus/y9PmD6T7PVB1rPjAfYP/99z/60UcfzSVmM7N2lUUJY+eo/BxBRFwYEfMiYl5vb+94h2NmtkvKM2E8AVTW4+yXrqu5j6ROYA+Sxm8zM9vJ5JkwbgMOlXSgpG7gLGBB1T4LgLPT5dOB6/NqvzAzsx2TW6N3RAxIei9wLUm32osiYrGkTwILI2IB8G3gUknLgGdJkoqZme2Ech24FxFXAVdVrTu/YnkzcEaeMZiZWTZaotHbzMzGnxOGmZk1xQnDzMyakutcUnmQ1AeM18i96cAzI+419hzX6Diu0XFco7OzxvX8iNh9Rw7QcrPVRsS4jdyTtHBHR0rmwXGNjuMaHcc1OjtzXDt6DFdJmZlZU5wwzMysKU4Yo3PheAdQh+MaHcc1Oo5rdNo2rpZr9DYzs/HhEoaZmTXFCcPMzJrihFFF0hmSFksqSarbNU7SI5LulrSosruapD0lXSfpgfTntLGISdJsSTdIujfd9x8rtn1c0hNprIsknbKjMY0mtnS/kyUtlbRM0ocr1h8o6dZ0/Q/TmY13NKYR3wNJr6y4HoskbZb0xnTbxZIertg2d0djGk1s6X7FivMvqFg/XtdrrqQ/pO/1XZLOrNiW6fWq91mp2D4h/d2XpddiTsW289L1SyW9dkfi2I64Ppj+/d0l6deSDqjYVvP9HKO4zpHUV3H+d1ZsOzt93x+QdHb1a4eJCD8qHsALgecDvwHmNdjvEWB6jfWfBz6cLn8Y+NxYxATMBF6SLu9Ocj/1w9LnHwc+NF7Xi2S24geBg4Bu4M6K2H4EnJUufwN4dwYxjeo9APYkmS15Yvr8YuD0nK5XU7EB6+usH5frBTwPODRd3hdYAUzN+no1+qxU7PMe4Bvp8lnAD9Plw9L9JwAHpsfpGMO4XlnxGXp3Oa5G7+cYxXUO8LUar90TeCj9OS1dntbofC5hVImIJRGxdAcOcRpwSbp8CfDGsYgpIlZExB3p8jpgCbBjNz7OKDYq7u8eEVuBHwCnSRJwIsn93CGj68Xo34PTgasjYmMG5x7Jdn8+xvN6RcT9EfFAuvwksBLIYxBtzc9Kg3gvB16VXpvTgB9ExJaIeBhYlh5vTOKKiBsqPkO3kNw0Lm/NXK96XgtcFxHPRsRzwHXAyY1e4ISx/QL4paTbldxzvGyfiFiRLj8F7DPWgaVF9KOAWytWvzctKl+URTXZKM0CHq94vjxdtxewOiIGqtbvqNG+B2cBl1Wt+3R6vb4kaUIGMY02th5JCyXdUq4qYye5XpKOIflv9sGK1Vldr3qflZr7pNdiDcm1aea1ecZV6Vzg6orntd7PsYzrzen7c7mk8p1QR329Wm5qkCxI+hUwo8amj0bEz5o8zMsj4glJewPXSbovIm6q3CEiQlJT/ZYziglJk4ErgA9ExNp09QXAp0iS3KeALwDvGMUxM4ktS41iqnwy0nsgaSbwYpIbfZWdR/LF2U3Sd/3/Ap8c49gOSD9fBwHXS7qb5Itxu2R8vS4Fzo6IUrp6h65Xu5H0t8A84BUVq4e9nxHxYO0jZO7nwGURsUXS35OUzk7cngPtkgkjIl6dwTGeSH+ulPRTkqLhTcDTkmZGxIr0j2vlWMUkqYskWXw/In5SceynK/b5JnDlaI6bQWz17u++CpgqqTP9T7HWfd9HHZOk0bwHfwX8NCL6K45d/m97i6TvAB9qJqYsY6v4fD0k6TckJcYrGMfrJWkK8AuSfxRuqTj2Dl2vKvU+K7X2WS6pE9iD5LPUzGvzjAtJryZJwq+IiC3l9XXezywSxohxRcSqiqffImmzKr/2hKrX/qbRyVwltR0kTZK0e3kZOAm4J91ceZ/ys4Ex+Q88rcP9NrAkIr5YtW1mxdM3sS3WsVLz/u6RtLzdQNKGANldr9G8B2+hqjqqfL3Sa/pGsr1eI8YmaVq5WkfSdOB44N7xvF7p+/ZT4LsRcXnVtiyvV83PSoN4TweuT6/NAuAsJb2oDgQOBf64A7GMKi5JRwH/DZwaESsr1td8P8cwrsq//1NJ2jchKVWflMY3jeR7rLKkPVzWrfat/iD5Ql0ObAGeBq5N1+8LXJUuH0TSG+FOYDHJf1zl1+8F/Bp4APgVsOcYxfRykiqnu4BF6eOUdNulwN3ptgXAzLG8XunzU0h6bj1Ydb0OIvmjXgb8GJiQQUw13wOSaoJvVew3h+S/rELV669Pr9c9wPeAyRlerxFjA/4sPf+d6c9zx/t6AX8L9Fd8thYBc/O4XrU+KyRVXKemyz3p774svRYHVbz2o+nrlgKvy+p9azKuX6V/A+Xrs2Ck93OM4voMyffUnST/cLyg4rXvSK/jMuDtI53LU4OYmVlTXCVlZmZNccIwM7OmOGGYmVlTnDDMzKwpThhmZuMonX1hpaQd7r6tBpNqZsEJw8aFpL0qPtRPadtsuusl/dcYxTBP0ldzPP5cNZgZOO/zNzjvUZK+3WB7r6RrxjKmXdzFjDCHU7Mimc9qbkTMJRnNvRH4ZRbHhl10pLeNv0hGn86FZPp1ktk8/3OMY1gILBxxx+03l2Qsw1XVG9LR2nmfv3yegarVHwH+vd5rIqJP0gpJx0fE7/KMzyAiblLFFO0Akg4Gvk4yweNG4O8i4r5RHjrzSTVdwrCdiqQTJF2ZLn9c0iWSbpb0qKS/lPR5JfchuSadCgVJR0u6UclEkNdWjWwtH/cMSfdIulPSTXXOdZGk30h6SNL7K177NiUTt90p6dJ0Xa+kKyTdlj6OrzpfN8ngqTPTktOZ6TkulfQ74NKq8/cquRfFYknfSn/f6em2f1Nyv4PfSrpM0ofS9Qen1+H29Bq9IF1/saRvSLqVbdNAlOPaHTgiIu5Mn7+ioqT3p3Q7wP8Cf7P976TtoAuB90XE0SRTrWxPqbvWpJo7JssRh374sT0PKu7XQTK3zZUV638LdAFHkvyn9bp0209JpqHoAn4P9KbrzwQuqnGOu4FZ6fLUOuf6Pcm9FKaTzE3UBbyIZBTt9HS/8ijo/yGZgBJgf5IpWarPeQ4V9yFIz3E7sFuN838NOC9dPplk1P504KUko4Z7SO5z8kDFtfo12+5R8TKSKTIgqeK4khr3giC5Z8MVFc9/DhyfLk8GOtPlWcDd4/3Z2FUeJLMO3FPxPmxi6Kj6Jem2vyQZUV/9uLbqeDOBPqAryzhdJWU7u6sjol/JbK0dQLlu/W6SP7LnA4eTzBhMus+KGsf5HXCxpB8BP6mxHeAXkUwYt0XSSpJpvk8EfhwRzwBExLPpvq8GDkvPCTBF0uSIWD/C77MgIjbVWP9ykmlWiIhrJD2Xrj8e+FlEbAY2S/o5DM5K/GfAjytiqJxW/McRUaxxnvIXSdnvgC9K+j7wk4hYnq5fSTK9i429Ask09nOrN0QyqWi9z2+lYZNqZsEJw3Z2WwAioiSpP9J/n4ASyedXwOKIOK7RQSLiXZJeBvwFcLuko+udK1Wk8d9HATg2/SIfjQ2j3L/R+Wt+qYxwnk0kpRUAIuKzkn5BMh/R7yS9NpK68p50XxtjEbFWyS1vz4iIHyv5j2CwGrFJbyGZdj5TbsOwVrcU6JV0HCRTvEt6UfVOkg6OiFsj4nyS/7BnV+9Tx/XAGZL2So+zZ7r+l8D7Ko4/t8Zr15FUIzXjdyT/FSLpJJJbZpbXv0FST1qqeD0kXyrAw5LOSF8jSUc2cZ4lwCEVcR8cEXdHxOdIZj59QbrpeYz9rMa7JEmXAX8Ani9puaRzSdqPzpVUnuC02bvolW+gNhu4MetYXcKwlhYRWyWdDnxV0h4kn+kvk/yRVfoPSYeSlEh+TTJz5ysYQUQslvRp4EZJReBPJG0T7we+Lumu9Jw3Ae+qevkNwIclLSKZMbSRTwCXSXoryZfHU8C6iLhN0gKSmYafJqmKK99I6W+ACyT9K0l7yw/S36vR73OfpD0k7R7JrXw/IOmVJCW2xWy7S9wrSe59YTmLiLfU2bRdXW0j4hFyuj2zZ6s12wkouV9CMSIG0tLSBeXqpnLbiKSJJIlpfqT3b9/Oc/0TSTL6VoN9bgJOi+Rez2aASxhmO4v9gR9JKgBbgb+r2HahpMNI2hUu2ZFkkboAOKPeRkm9wBedLKyaSxhmZtYUN3qbmVlTnDDMzKwpThhmZtYUJwwzM2uKE4aZmTXl/wNvDW/WklPOOAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(timebase, signal)\n",
+    "plt.xlabel(\"Time since trigger (s)\")\n",
+    "plt.ylabel(\"Signal (V)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The offset in horizontal and vertical access are automatically taken into account such that the signal that is returned can directly be interpreted in time relative to the trigger and in the signal in absolute voltage. Clearly, this peak is almost 4 V heigh and very short. Let us move the peak in horizontal and vertical direction to the center of the oscilloscope display and read back one waveform with 1 V per division on the vertical axis and one waveform with 250 mV per division. The latter will surely clip the peak at the top."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 1.0, '1 V / division: Signal visible')"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtAAAAEWCAYAAABPDqCoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy86wFpkAAAACXBIWXMAAAsTAAALEwEAmpwYAABHl0lEQVR4nO3deZxcZZX/8c+p6n3L2iErJIEk7FvCEhFQEUVQGRFZRJYRZdzXGX+iDuPojOM44zIoLlGRRVbZRAURlV2ChECAEAIhZN86ne70Xt1ddX5/3FudStNd6equ251Ofd+vV17prnrq3lPd1U+dOvfc55q7IyIiIiIiAxMb6QBEREREREYTJdAiIiIiIjlQAi0iIiIikgMl0CIiIiIiOVACLSIiIiKSAyXQIiIiIiI5UAItI87MLjOzxzO+bzGz2QN43FfM7BcDGHe/mV061DiHwsz2D59XfBj25WZ2UI6PeYuZbcj4frmZvSXfsQ0gjuvM7D+Ge78ihc7MZoZzR1H4/YDmTTM72cxWDmDcgObrqA3X3GZmD5vZRwbxuIvM7E8DGPdTM/vX8Ovd5u8+xmpejYAS6L2EmZWa2S/NbK2ZNZvZc2b2roz705NbS8a/f+31+GvNrMnMtpjZF/IU15fN7NE+bp9oZp1mdniWxz5gZu/IdZ/uXuXuqwcw7lvuvscJyt3f5e7X5xpHrsxsupndaWbbzWynmb1oZpeFMawLn1cy6jjywd0Pc/eHRzoOkX2ZmX3KzJaYWcLMrssy7kQzazWzqj7ue9bMPpXlsVea2bdyjW2g86a7P+bu8wYwbkDz9VCZWYmZfdfMNoTvk2vM7AcZcezVc5u73+Tue3zfdPePufs3hyMm6VvRSAcgPYqA9cCpwDrgTOB2MzvC3ddkjBvr7t19PP7rwBzgAGAy8JCZveTufxxiXL8G/sPMZrn76xm3XwC84O4v9vUgM6sEFgCPDHH/o8mNwDKC30ECOILgdyEi0pdNwH8A7wTK+xvk7ovDCuO5wHXp28MCxqHALVn2cRbw5XwEO0pcSfDeczywmWA+PmVEI5J9kirQewl3b3X3r7v7GndPufvvgdeB+QPcxKXAN929wd1XAD8HLutrYNgy8YSZfd/MGs1stZm9Kbx9vZltSx+6c/cNwF+Bi3tt5hLghizxnAY84e6JPvY/wczuDavlfwcO7HW/m9lBZnZCWE2PZ9z3PjN7Pvz662b26/DrMjP7tZnVh8/paTPbL7yv51CamcXM7GthpX+bmd1gZmPC+9JV/kvNbF1YSf5qlufY23HAdeHvstvdn3X3+3ttO314dJaZPRoebfizmV2T8VyyxmFmx5vZk+Hz3GxmPzKzkoEEaGbjzexXZrbJzBrM7J5+xq0xs7dn/JzvMLPbwniXmtlRvcZeaWYvhdv8lZmVZdz/bguOqDSa2d/M7MiM+44Jt9dsZrcBZYgUCHe/y93vAeoHMPx6gnk30yXAfe7e5+PNbBwwF3iyj/viZva/4fyymiDRzrz/YTP7iAVHNxst42ijmdWaWbuZTbI3tn/9PzPbGP5NrzSz08Lbe+br8Pv3WtBO0Rju65CM+9aY2T+b2fMWHM27LXNO2YPjgLvdfZMH1rh7z3tVr7mt3MyuD+etFWb2pV7Ppd84zGycmf3ezOrCx//ezKbvKTgzmxr+7MZn3HZM+HsotoyWRgt834L3qiYzeyH9e7A+2jIsaJPZHsZ9UZYY+p2TZeCUQO+lLEj+5gLLe9211oJDU78ys4nh2HHAFILqZ9oy4LAsuzgBeB6YANwM3Eow8RwEfAj4ke06XHg9GQm0mc0Djg4f158zgT/0c981QEcY84fDf2/g7k8BrcDbMm7+YD/7vRQYA8wIn9PHgPY+xl0W/nsrMBuoAn7Ua8ybgXkEHwKuSk/sZvZmM2vs5zkBLAauMbMLzGz/LOMIn8Pfw1i/zhs/oPQbB5AEPg9MBBaG939iD/tLuxGoIHhtTAK+P8DHnQ38Bhgfxn6PmRVn3H8RQRXtQILX7dcgeGMArgX+ieC5/gy4N3xTLgHuCWMaH27//QOMR6TQ3AicYmYzICgGEMyH2dos3gn8pZ/WsY8C7waOIajYntvXBsIiyF3AhRk3nwc84u7bMseG7w2fAo5z9+pw/2t6b9PM5hJUzT8H1AL3Ab+z3QsB5wFnALOAI8koCIWJ35v7ec6LgS+Y2SfM7Agzs37GAfwbMJPgveB0gve+3vqLIwb8iqDCvT/B+03v95I3cPdNBB9oMue6DwJ3uHtXr+HvIKiezyV4fzuP/j9sTSZ4T5hG8H64KPx97CbbnLyn2GV3SqD3QmFichNwvbu/HN68nSDBPYCgKl0djoEgCQTYmbGZneGY/rzu7r8KJ9bbCBLPb7h7wt3/BHQSJNMAdwP7mdmbwu8vAe5397os2z+TYFLs/dziBBPHVWGl9kWyvwHcQjhxm1l1uN2+Dld2EUwGB7l70t2fcfemPsZdBHzP3Ve7ewvB4b4LLKwMh/7d3dvdfRnBB5GjANz9cXcfmyXWDwCPAf8KvB5+wj+uj5/B/gS/y6vcvdPdHwfu7WN7/cXxjLsvDqvcawgmwFOzxJXe7xTgXcDHwiMVXe4+0BabZ9w9PcF/j6BSfGLG/T9y9/XuvgP4T3a92V4B/Mzdnwp/L9cTtLecGP4rBn4QxnIH8PQA4xEpKO6+HniYXR+2TwNK6b9QAUFV+Q3zcOg8gr+99N/tf2XZzs0EbXtp/RUykmFMh5pZcVj9fa2PcecDf3D3B8M55X8JWljelDHm6rCKvAP4HUHRBgB3HxvOm335L+C/Ceb6JcBG6/9kyPOAb4Xz4Qbg6j7G9BmHu9e7+53u3ubuzQTz3h7n4dDN7HpfM4KfbV8/zy6C9/GDAXP3Fe6+Oct2/zV8D3+E4HVxXh9jss3JkgMl0HuZsKpwI0EC23NiiLu3uPuSMGnaGt73jjCpbAmH1WRsqgZozrKrrRlft4f76H1bVXh7G0F18JLwj/0isrRvmNkRwM5wwu+tll393mlrs8R5M3BO+On4HGCpu/c1/kbgAeBWC9oTvtOrQpo2tdf+1obx7Jdx25aMr9vY9QElq3AS/rK7HxZu7zmCSm3vCshUYEf4c03r62fVZxxmNjc8XLjFzJqAbxFUHvZkRrjfhoE8n1564nP3FLCB4Hm84X6Cn2n6vgOAL4YVo8awgj8jvH8qsNHdvddjRaRvmUcDLwZu7aNqCfS8l5wO9HcezFQGPg8/BFRY0FY3kyCJvLv3IHdfRVBV/jqwzcxuNbOpvcfRax4O55T1BNXTtMHOw0l3v8bdTwLGEiS212a2iPSKI/NnkMs8XGFmP7OgHbAJeBQYawNbaelOYGFY1DgFSBEUX3o/l78SVLWvIfh5LjKzmt7jQg3u3prxfeY8nCnbnCw5UAK9FwkTrV8SJF/v729iDKWTjliYEG0mrFCGjuKN7R9DcT3Bp9nTCT4R/y7L2D6rz6E6oJvgDzat33YHd3+JYCJ4F/1XPQgrmP/u7ocSVDHezRv7BSE4aeeAXvvuZvcPFEPm7tsJqipTCdoTMm0GxptZRcZtMxi4nwAvA3PcvQb4CpDtMGXa+nC/Y3PYV1pPfOEb83SCn+Ub7if4mabvWw/8Z1gxSv+rcPdbCH4O03p9wNhT64tIIbsLmG5mbyUoKGQ7enccsDbLkcLNDHweTgK3E1RNLwR+H1Zd+xp7s7u/mWCedYJqcG+7zcPhHDAD2NjvsxmE8AjeNUADwcmWvW0mmMvScpmHv0jQYndCOA+nT1Tc41wcvmf/iaAS/0GCD0Lez9ir3X0+QfxzgX/pZ7PjLDh5Py1zHs6UbU6WHCiB3rv8BDgEeI+779a/G37yn2fBSXATCA41Pezu6baNG4CvWXBiw8EE/W3X5TG2x4BGYBHBH3tnlrH99j+HE/FdwNfDT/CHEvRrZXMz8FmCCeo3fQ0ws7eG/W5xoIng0Feqj6G3AJ+34CS+KoLq7W3e98omOTGz/zazw82sKDwy8HFglfc6wSesoC8h+BmUmNlC4D057Kqa4Dm2hL/rjw/kQeGhv/uBH4evk2IzG+jZ6fPN7Jyw1eVzBIf8Fmfc/0kLlvEbD3yVoC0IgpNZPxa+fs3MKs3srPDn8yTBh5fPhLGcQ3DmvEhBCOeKMiAOxC04Gbrf1bHCCuMdBL23a919SZbNZzsPBYKE+DPh3+049rxSx80ECd9F9FPICN+j3hYeMewgOJLZ1zx8O3CWmZ0WHin8IsGc8rc9xLBHZvY5C05sLA9/vpcSzJnP9hPHleF8OI2Mo74DUE3w/BrDee/fcgz1ZoIiz7n0//M8Lpw7iwnOB+qg759n2r+H7yknExSR+nq/zDYnSw6UQO8lzOwAgqb+o4Ettmut5/SZtLMJDsU1Ay8STDaZJ3X8G/AaQbX2EeB/fOhL2PUIPx3fQFA1yNa+MZbgk3K2ifBTBIfBthAk+b/aw+5vIegt+2tY2e3LZII3liZgBcHP4MY+xl0b3v4owSonHcCn97B/oOeCAS1ZhlQQHNZsBFYT/Kze28/YiwhOAKwnWMbqNoLf6UD8M0HVoplgMrwt+/DdXEzw4eJlYBtBMjwQvyV482wIt3FOryMkNxNUVFYTvA7/AyB8g/8owWHIBmAV4Uk44Yewc8Lvd4TbvyuH5yIy2n2NIAn7MsEJbO3hbdlczx7m4VC2/mcI5o4HCM6vWMoe/vZ810ndUwk+iPelFPg2wTk7WwhOVL6yj22tJHi+PwzHvoegcJStMNMjfG88uZ+724DvhvvfDnyS4IhuX9cW+AZBO9rrwJ8J3kMGOg//gKBveztBMSHX99t7CZae3RKe59KXGoLfUwPBe3s98D/9jN0SjttEcH7Ux3zXOVQ9ss3Jkhvr56iByKCY2XnAue7e18kL0g8LlnB72d1zrWJEzsy+TnByZl9nqGNma4CPuPufhzMuEembBas4PQtM6681QN7IzD4OXODuAz0ZUAqYKtCSb40MfGm0ghUemjswbMk5g2CZuHtGOCwR2TeMAb6o5Dk7M5tiZieF8/A8glaSN5wcKdIXXYlQ8sqDJfBkzyYTHDKdQHAI8ePu3lePnohITtz9FeCVkY5jFCghWAZ0FkHx51bgxyMZkIweauEQEREREcmBWjhERERERHIw6lo4Jk6c6DNnzhzpMEREBuWZZ57Z7u61Ix3HcNGcLSKjWX9z9qhLoGfOnMmSJdmWvhQR2XuZWUFdbVFztoiMZv3N2WrhEBERERHJgRJoEREREZEcKIEWEREREcmBEmgRERERkRwogRYRERERyYESaBERERGRHCiBFhERERHJwahbB1pERERkuLywYScPvrSFqrIiPnzSLIriqj2KEmgRERGRfn3zDy/x99d3AHDM/uM4bub4EY5I9gb6GCUiIiLSh/bOJM+ua+At84IrOW9rSoxwRLK3UAItIiIi0odn1jbQlXTee9RUAOqaO0Y4ItlbKIEWERER6cOTq7cTjxmnH7ofRTFjW7Mq0BKILIE2szIz+7uZLTOz5Wb2732MuczM6szsufDfR6KKR0RERCQXT75Wz5HTx1BdVkxtdSl1SqAlFOVJhAngbe7eYmbFwONmdr+7L+417jZ3/1SEcYiIiIjkpKMryfMbdvLRU2YDBAl0ixJoCURWgfZAS/htcfjPo9qfiIiISL5saGinO+XM268agNqqUp1EKD0i7YE2s7iZPQdsAx5096f6GPZ+M3vezO4wsxn9bOcKM1tiZkvq6uqiDFlERIZIc7bsCzY0tAEwfVw5AJNqVIGWXSJNoN096e5HA9OB483s8F5DfgfMdPcjgQeB6/vZziJ3X+DuC2pra6MMWUREhkhztuwL1je0AzB9XAUQVKDrWxIkUzqYLsO0Coe7NwIPAWf0ur3e3dMf534BzB+OeERERESy2dDQRkk8xqTqUiDogU451LeqCi3RrsJRa2Zjw6/LgdOBl3uNmZLx7XuBFVHFIyIiIjJQG3a0M21cObGYAUECDWglDgGiXYVjCnC9mcUJEvXb3f33ZvYNYIm73wt8xszeC3QDO4DLIoxHREREZEA2NLT19D8D1FaXAbCtOcFhIxWU7DUiS6Dd/XngmD5uvyrj6yuBK6OKQURERGQw1je0886pY3q+n6QKtGTQlQhFREREMrQmutnR2tmrAq0EWnZRAi0iIiKSYUO4AseM8RU9t5UVx6kuLVICLYASaBEREZHd9F4DOq2mvJjmju6RCEn2MkqgRURERDJsbEyvAb17Al1REqetUwm0KIEWERER2c22pgTxmDGhsnS32ytLi2jtTI5QVLI3UQItIiIikmFbcwcTKkuIh2tAp1WWxmlLqAItSqBFREREdlPXnGBSTekbbq8oKaJFCbSgBFpERERkN3UtCWqr3phAV5bEaVMLh6AEWkRERGQ325oSPes+Z6ooLdJJhAIogRYRERHpkUw59a2dTAov3Z2psiROa0IVaFECLSIiItJjR2snyZT3WYGuLC2ivStJMuUjEJnsTZRAi4iIiITSVxrsM4EuKQKgvUtV6EKnBFpEREQkVNcSJNCT+uyBjgPQqpU4Cp4SaBEREZHQtqYOIHsFWgm0KIEWERERCaUr0H2uwlESVKC1lJ0ogRYREREJ1TUnqCotoiKsNmeqLFUFWgJKoEVERERC25r7XgMadiXQqkCLEmgRERGRUF22BDps4dDlvCWyBNrMyszs72a2zMyWm9m/9zGm1MxuM7NVZvaUmc2MKh4RERGRPalvSTChsqTP+yp6KtBKoAtdlBXoBPA2dz8KOBo4w8xO7DXmcqDB3Q8Cvg/8d4TxiIiIiGTV2NbFuH4S6HQFWlcjlMgSaA+0hN8Wh/96X7rnbOD68Os7gNPMzKKKSURERKQ/qZTT0NbJ+Ip+KtAlqkBLINIeaDOLm9lzwDbgQXd/qteQacB6AHfvBnYCE6KMSURERKQvzR3dpBzGVhT3eX9JUYziuNGqkwgLXqQJtLsn3f1oYDpwvJkdPpjtmNkVZrbEzJbU1dXlNUYREckvzdkyWjW0dQIwvp8WDghW4mjTSYQFb1hW4XD3RuAh4Ixed20EZgCYWREwBqjv4/GL3H2Buy+ora2NOFoRERkKzdkyWu0IE+hx/bRwQHA1whb1QBe8KFfhqDWzseHX5cDpwMu9ht0LXBp+fS7wV3fv3SctIiIiErnGdAKdpQJdURJXD7Twxsvs5M8U4HozixMk6re7++/N7BvAEne/F/glcKOZrQJ2ABdEGI+IiIhIv3a0dgEwrp8eaAiWslMPtESWQLv788Axfdx+VcbXHcAHoopBREREZKDSFeixWVs44uqBFl2JUERERARgR2sn8ZhRU9Z/fbGiRBVoUQItIiIiAkBDWxfjKorJdkmKqtI4rapAFzwl0CIiIiJAQ2tn1hU4IOiB1kmEogRaREREhGAd6D0l0JUlcV3KW5RAi4iIiAA0tnUxrrL/FTgAyorjdHQn0aq7hU0JtIiIiAjBhVT2VIEuLYrhDl1JJdCFTAm0iIiIFDx3p7GtM+tFVABKi+IAJLrVxlHIlECLiIhIwWtJdNOV9KwXUQEoLQ5Sp0R3ajjCkr2UEmgREREpeI1t6asQ7rmFA5RAFzol0CIiIlLwdrYHCXRN+Z5PIgRIdKmFo5ApgRYREZGC19wRrO1cneUqhKAKtASUQIuIiEjBawmvLlhduoce6J6TCJVAFzIl0CIiIlLwWhJBC0fVQCvQauEoaEqgRUREpOC1hC0cVaV7SKC1CoegBFpERESElvDy3HvugQ5aODpUgS5oSqBFRESk4LUkuiiKWU+LRn90EqGAEmgRERERWjq6qSorwsyyjutZxk4JdEFTAi0iIiIFrznRvcf+Z8isQKuFo5ApgRYREZGC19Ix0AQ6fSEVVaALWWQJtJnNMLOHzOwlM1tuZp/tY8xbzGynmT0X/rsqqnhERERE+tMy0Aq0VuEQYM+vlMHrBr7o7kvNrBp4xswedPeXeo17zN3fHWEcIiIiIlm1JLoZX1myx3ElcbVwSIQVaHff7O5Lw6+bgRXAtKj2JyIiIjJYA23hiMWMknhMFegCNyw90GY2EzgGeKqPuxea2TIzu9/MDuvn8VeY2RIzW1JXVxdlqCIiMkSas2U0ak5073EN6LTSoph6oAtc5Am0mVUBdwKfc/emXncvBQ5w96OAHwL39LUNd1/k7gvcfUFtbW2k8YqIyNBozpbRaKAVaAj6oDvUwlHQIk2gzayYIHm+yd3v6n2/uze5e0v49X1AsZlNjDImERERkUzdyRTtXUmqSosHNL60KK4KdIGLchUOA34JrHD37/UzZnI4DjM7PoynPqqYRERERHprDS/jXTXQFo7imE4iLHBRrsJxEnAx8IKZPRfe9hVgfwB3/ylwLvBxM+sG2oEL3N0jjElERERkN82JLgCqB9rCURTXSYQFLrIE2t0fB7JeD9PdfwT8KKoYRERERPakJdEN5FCBLtIqHIVOVyIUERGRgtaaTqAHXIGOkehSC0chUwItIiIiBa25I0igKwe8CodaOAqdEmgREREpaOkWjpzWgVYCXdCUQIuIiEhBa+kYRAuHVuEoaEqgRUREpKDlehJhWbHWgS50SqBFRESkoPX0QJeoAi0DowRaREREClpLopuKkjjxWNbVd3voSoSiBFpEREQKWntXkoqS+IDHB1ciVAJdyJRAi4iISEHr6ExSVpxDAl0UozOZIpXSxZMLVdZmHzObDlwAnAxMJbjc9ovAH4D73V0fv0RERGRUa+9KUp5TAh2M7UymKIsN/HGy7+i3Am1mvwKuBTqB/wYuBD4B/Bk4A3jczE4ZjiBFREREotLelaQ8lxaOoiB9Uh904cpWgf6uu7/Yx+0vAneZWQmwfzRhiYiIiAyP9hxbONJjg5U4iiOKSvZm2Xqg3xW2cPTJ3TvdfVUEMYmIiIgMm46cWzjCCrROJCxY2RLoqcCTZvaYmX3CzGqHKygRERGR4ZJzD3RxOoHWWtCFqt8E2t0/T9Ci8TXgCOB5M/ujmV1qZtXDFaCIiIhIlHLvgQ7GdqgHumBlXcbOA4+4+8eB6cD3gc8BW4chNhEREZHItXemcl7GDlSBLmQDumalmR1BsJzd+cB24MoogxIREREZLonB9kCrAl2w+k2gzWwOQdJ8AZAEbgXe4e6rhyk2ERERkcgFLRwDv7Zcac8qHEqgC1W2V8sfgVLgfHc/0t2/lUvybGYzzOwhM3vJzJab2Wf7GGNmdrWZrTKz583s2EE8BxEREZFB6Uqm6E75IFfhUAtHocrWwjFnT1caNDNz9/6uY9kNfNHdl4YnHT5jZg+6+0sZY94FzAn/nQD8JPxfREREJHLtXUESPJh1oHUSYeHKVoH+q5l92sx2u1iKmZWY2dvM7Hrg0v4e7O6b3X1p+HUzsAKY1mvY2cAN4cmKi4GxZjZlUM9EREREJEcdnUECncsqHGXhMnYdXapAF6psCfQZBL3Pt5jZprAVYzXwKsFlvX/g7tcNZCdmNhM4Bniq113TgPUZ32/gjUk2ZnaFmS0xsyV1dXUD2aWIiIwQzdkymqQr0Lm0cJT1LGOnBLpQ9dvC4e4dwI+BH5tZMTARaHf3xlx2YGZVwJ3A59y9aTBBuvsiYBHAggUL+msZERGRvYDmbBlNBpVAh2Pb1cJRsAa0jJ27dwGbc914mHjfCdzk7nf1MWQjMCPj++nhbSIiIiKRaw9bOMpyupCKWjgK3cDXbMmRmRnwS2CFu3+vn2H3ApeEq3GcCOx095wTdREREZHBGEwFOhYzSotidGgVjoI1oAr0IJ0EXAy8YGbPhbd9heDy4Lj7T4H7gDOBVUAb8I8RxiMiIiKym45BJNAQtHGkT0CUwhNZAu3ujwO2hzEOfDKqGERERESyae8M+phzWYUDgoRby9gVrmxXImwG+jr5wwhy35rIohIREREZBoNp4YBgKTu1cBSubKtwVA9nICIiIiLDbTAXUkmPb1cLR8EacAuHmU0CytLfu/u6SCISERERGSaDuZAKQGlxnI5utXAUqj2uwmFm7zWzV4HXgUeANcD9EcclIiIiErmeCnRRbguTlRfHtIxdARvIq+WbwInAK+4+CzgNWBxpVCIiIiLDoL0rSUk8RlE8twS6rDhOQgl0wRrIq6XL3euBmJnF3P0hYEHEcYmIiIhErr0zSVlx7pfFKCuK91SvpfAMpAe6Mbwc96PATWa2DWiNNiwRERGR6HV0JXPuf4ZwFQ4tY1ewBvKR62ygHfg88EfgNeA9UQYlIiIiMhzau5I5L2EHwUmH6oEuXHusQLt7ZrX5+ghjERERERlWQQtH7gl0qVo4CtpAVuE4x8xeNbOdZtZkZs1m1jQcwYmIiIhEqX3QLRxxEmrhKFgD6YH+DvAed18RdTAiIiIiw6ljkC0cZcUxOpMpkiknHrMIIpO92UB6oLcqeRYREZF90aB7oMPHJHQ574I0kAr0EjO7DbgHSKRvdPe7ogpKREREZDi0dyYpG2QLR/rxFSUDvrCz7CMG8huvAdqAd2Tc5oASaBERERnVOrpSg27hAHQ57wI1kFU4/nE4AhEREREZboNt4UhXoLWUXWHaYwJtZlf3cfNOYIm7/zb/IYmIiIgMj/bOwa/CkX68FJ6BnERYBhwNvBr+OxKYDlxuZj+ILDIRERGRCLk77V2DWwe6TCcRFrSB9EAfCZzk7kkAM/sJ8BjwZuCFCGMTERERiUwi7F8eVAtHUdgDrbWgC9JAKtDjgKqM7yuB8WFCnej7IWBm15rZNjN7sZ/73xJenOW58N9VOUUuIiIiMgTp9ovy4oGkQ7tTC0dhG+iFVJ4zs4cBA04BvmVmlcCfszzuOuBHwA1Zxjzm7u8eWKgiIiIi+ZO+FPdgeqDTj+lQC0dBGsgqHL80s/uA48ObvuLum8Kv/yXL4x41s5lDD1FEREQk/9IJ9KB6oIvSq3CohaMQ9XvMwswODv8/FpgCrA//TQ5vy4eFZrbMzO43s8OyxHKFmS0xsyV1dXV52rWIiERBc7aMFrtaOIawDrSWsStI2SrQXwCuAL7bx30OvG2I+14KHODuLWZ2JsGVDuf0NdDdFwGLABYsWOBD3K+IiERIc7aMFh1DaOFIX71QCXRh6jeBdvcrwv/fGsWO3b0p4+v7zOzHZjbR3bdHsT8RERGRTPlp4VACXYiytXAcZ2aTM76/xMx+a2ZXm9n4oe7YzCabmYVfHx/GUj/U7YqIiIgMxFBaOIrjRszUA12osq3b8jOgE8DMTgG+TbCixk7CQ3PZmNktwJPAPDPbYGaXm9nHzOxj4ZBzgRfNbBlwNXCBu+tQn4iIiAyLoVSgzYyy4njPNqSwZOuBjrv7jvDr84FF7n4ncKeZPbenDbv7hXu4/0cEy9yJiIiIDLuh9EBDULlWC0dhylaBjptZOsE+Dfhrxn0DWT9aREREZK81lBYOCCrXauEoTNkS4VuAR8xsO9BOcPluzOwggjYOERERkVGrvWvwl/IGKC2O6UIqBSrbKhz/aWZ/IVgD+k8Z/ckx4NPDEZyIiIhIVNL9y6VFuV/KG4KVODp0Ke+ClLUVw90X93HbK9GFIyIiIjI8OrqSlBXHiMVsUI+vKi2iJdGd56hkNBjcRy4RERGRUa69Mzno9g2AmvIimjuUQBciJdAiIiJSkNq7hphAlxXT1NGVx4hktFACLSIiIgWpvSvZc0nuwagpL2ZnuxLoQqQEWkRERApSx1BbOMqCHuhUSteBKzRKoEVERKQgDbmFo7wYd2jWiYQFRwm0iIiIFKT2ruSgr0IIQQIN0KQ2joKjBFpEREQKUntnkrIhnkQI6ETCAqQEWkRERApSx5BbOILLaehEwsKjBFpEREQK0lB7oMf0tHCoB7rQKIEWERGRgtTeOcQeaLVwFCwl0CIiIlKQOrpSQ+uB1kmEBUsJtIiIiBSc7mSKzmRqSC0c1aVFmCmBLkRKoEVERKTgdHSnACgvGXwqFIsZ1aVFNHWoB7rQFI10ACL7isWr67nmoVWkfHBXpKqtKuV/PnAUxXF9rhURiVp7ZxJgSBVoCNo4VIEuPJG9U5vZtWa2zcxe7Od+M7OrzWyVmT1vZsdGFYvIcLj/hc08+Vo9ia5Uzv+27Ozgnuc2sba+daSfhohIQejoChLoofRAQ3AioU4iLDxRVqCvA34E3NDP/e8C5oT/TgB+Ev4vMio1tncxfVw5d3z8TTk/dvHqei5YtJgtOxMcNKk6guhERCRTe5hAD2UVDgjWgtYydoUnsgq0uz8K7Mgy5GzgBg8sBsaa2ZSo4hGJWkNbF2MqSgb12Mk1ZQBsaerIZ0giItKPfLVwjCkv1oVUCtBINltOA9ZnfL8hvO0NzOwKM1tiZkvq6uqGJTiRXO1s62RsuKRRrvYLE+itSqBlH6A5W0aDngq0WjhkEEbF2UruvsjdF7j7gtra2pEOR6RPje1djK0YXAJdXhKnpqxICbTsEzRny2iQTqDLhtzCoZMIC9FIJtAbgRkZ308PbxMZlRrbugZdgQaYPKaMLTuVQIuIDIe8rcJRVkxrZ5LuZCofYckoMZIJ9L3AJeFqHCcCO9198wjGIzJoyZTT1DH4HmgI2jhUgRYRGR6tieDEv6rSoa2nMKY8eLzWgi4ska3CYWa3AG8BJprZBuDfgGIAd/8pcB9wJrAKaAP+MapYRKLW3NGFO0OrQNeU8crW5jxGJSIi/WkLK9CVQ0ygx1UGhZMdrZ2Mrxx8EUVGl8gSaHe/cA/3O/DJqPYvMpwa24L+t8H2QEPQwlHXnKA7maJIF1MREYlUS1iBrhhiD/SEylIA6lsSHDSpashxyeigd2mRPGho6wSGlkDvV1NGyqG+tTNfYYmISD/aOruJx4zSoqGlQuMzKtBSOJRAi+RBY3gG9pjyofVAAzqRUERkGLQmklSUxDGzIW1nYlUw729XAl1QlECL5MHOsIVj3FBaOHQxFRGRYdPW2U1lydA7WdM90PUtiSFvS0YPJdAiedDY08IxhAr0mKCPTitxiIhEr7UzSWXp0PqfAYrjMcaUF6uFo8AogRbJg3QLR03Z4KsZEytLiRlsa1IVQ0Qkam2J7iGvwJE2oaqE+hYl0IVECbRIHjS2dVFdVjSk1TNiMWN8ZSn1rUqgRUSilu6BzocJlSVsVwtHQVECLZIHO4dwGe9ME6tK2K4qhohI5Frz1AMNwVJ2auEoLEqgRfKgoa2TsUNYgSNtYlWpTkQRERkGbZ1JKvLZwqEEuqAogRbJg8a2/FSgNQmLiAyP1kQ3lXls4Who6ySZ8rxsT/Z+SqBF8mBnexdjhnAZ77QJlaVsb1YFWkQkam2dyTyeRFiK+66Lasm+Twm0SB40tnXmJ4GuKqG1M0l7ZzIPUYmISF/cPeyBzk8FenzPWtBKoAuFEmiRIXJ3mju6qclDAl1bFawFrZU4RESi096VxJ289kCD5u5CogRaZIjau5J0p5zqIawBnZaehLUSh4hIdFoTwVG+fFWgJ6aLH5q7C4YSaJEhau7oBqCmLB8tHOlJWFUMEZGotHUG83ZFnpaxG6/LeRccJdAiQ9TcEVyFMC8VaPXRiYhErqcCnacWjvEVJVSXFbFya3Netid7PyXQIkPUlMcKdPow4Hb10YmIRCZdga4szU8LRyxmnDBrPE++Vp+X7cneTwm0yBA1tQcV6JryoVcyykviVJbE2d6sCrSISFRaw5WO8tXCAXDi7AmsqW9j8872vG1T9l5KoEWGKN0DXZ2HCjQEfdA6k1tEJDqtifxWoAEWHjgBgMWrVYUuBJEm0GZ2hpmtNLNVZvblPu6/zMzqzOy58N9HooxHJAq7Eug8XhJWPdAiIpHpSaDzWIE+ZHINY8qL1cZRIPL3yunFzOLANcDpwAbgaTO7191f6jX0Nnf/VFRxiEStqeckwvxUoCdWlbKuvi0v2xIRkTdq62nhyF8FOhYzjp81niVrGvK2Tdl7RVmBPh5Y5e6r3b0TuBU4O8L9iYyI5o4uYpa/9UTn7VfNqroWGnVJWBGRSLT2nESY3zriwZOrWbujjc7uVF63K3ufKBPoacD6jO83hLf19n4ze97M7jCzGX1tyMyuMLMlZrakrq4uilhFBq25o5vqsmLMLC/be/uh+5FMOQ+v1GtdRifN2bK3a0skiceM0qL8pkGzaytJppx1O1rzul3Z+4z0SYS/A2a6+5HAg8D1fQ1y90XuvsDdF9TW1g5rgCJ7EiTQ+atiHDltDLXVpTy4YmvetikynDRny96utbObipJ43gofabMmVgHwWp0S6H1dlAn0RiCzojw9vK2Hu9e7e3q5gV8A8yOMRyQSTe1deVkDOi0WM047eBKPrKwj0Z3M23ZFRCTQmujO6wmEabNrKwFYrQR6nxdlAv00MMfMZplZCXABcG/mADObkvHte4EVEcYjEol8V6ABTj90P1oS3WrjEBGJQGtnkoo8LmGXVlNWzMSqUlbXteR927J3iSyBdvdu4FPAAwSJ8e3uvtzMvmFm7w2HfcbMlpvZMuAzwGVRxSMSlaaOrrytwJF26txapo4p47on1uR1uyIiAg2tnYyrKIlk27NrK1m9XRXofV2kPdDufp+7z3X3A939P8PbrnL3e8Ovr3T3w9z9KHd/q7u/HGU8IlFo7uimJs8V6KJ4jEveNJMnV9ezYnNTXrctIlLo6poT1FaVRrLtA2srVYEuACN9EqHIqNfU0UVNeX4r0AAXHDeDsuIYNz+1Lu/bFhEpZHUtCWqro0mgZ0+soqGti4ZWLUW6L1MCLTIEqZTTksh/DzTA2IoS3nTgRB5ftT3v2xYRKVSJ7iSNbV1MiiiBPnBScCLhK1ubI9m+7B2UQIsMQWtnN+75u4x3bwtnT+D17a1s2dkRyfZFRArN9pagMhxVBfqYGeMwg6de3xHJ9mXvoARaZAiaOoKrWeVzGbtMCw+cAMCTq1WFFhHJh7rmYPXcqBLocZUlHDy5hsWr6yPZvuwdlECLDEFzRxdA3lfhSDtkSg01ZUUsfk2VDBGRfNjWFBzRm1RdFtk+Fs6ewDNrG7SW/z5MCbTIEDSHFeioWjjiMeOE2RN4UpUMEZG8qGuJtgINwdHDRHeKZ9c1RrYPGVlKoEWGoLEtqECPiWAVjrSFsyewbkcbGxvbI9uHiEih2NaUwAwmVEWzDjTA8bPGEzP422sqfuyrlECLDMHa+mCx/BnjKyLbR08ftCZiEZEhq2tJML6ihOJ4dCnQmPJiFhwwnt8v24S7R7YfGTlKoEWG4PXtrdSUFTGuIroK9Lz9qhlXUawEWkQkD+qao1sDOtO5C6azensrS9c1RL4vGX5KoEWGYE19K7MmVmJmke0jFjNOnD2BxavrVckQERmibcOUQJ91xBQqSuLc8ORaNja2a/7exyiBFhmCNdvbmDmxMvL9nDh7Ahsb21m/Q33QIiJDsX2YEujK0iLOOmIKv31uEyd9+688sHxr5PuU4aMEWmSQOrqSbNrZzqxhSKBPOijog374lW2R70tEZF/l7sPWwgHwlTMP4f8uOJrqsiIeXqn5e1+iBFpkkNbtaMOdYUmgD6yt4uDJ1dzxzIbI9yUisq/a0tRBZzLFlJro1oDONK6yhLOPnsYJs8brwir7GCXQIoP0+vZgBY6ZE6JPoM2M8xbM4PkNO3l5S1Pk+xMR2Relk9gFM8cP635PnD2BNfVtvLBhJ7f+fR3JlPPSpiYee7VuWOOQ/Inm6g8iBWBNOoEehgo0wD8cM43/un8F3/3TK3zpnfOYs181bZ3ddCU90nWoRUT2FU++Vk9NWRGHTKkZ1v2mlyP94M8X05zo5vmNO/nD85tJdCf5+1ffTk1EV7OV6CiBFhmk17e3Mr6yZNiS1/GVJXz4pFksemw1D760lQMmVLC1qYPy4ji//sgJHDZ1zLDEISIyWi1evYMTZk8gHotu5aS+HDK5hrEVxTS2dXHUjLHc/NQ6SopidHan+P2yzXzwhP2HNR4ZOrVwiAxCMuU8vLKOo2eMHdb9XnnmITx15Wl88+zDmD2xkg/Mn0F5cZwP/vwpvvPHl3W1QhGRfmxsbGfdjjYWzp4w7PuOxYxPvuUgvnTGPG796Imcc+w0Fl08nzmTqvjNM+uHPR4ZOlWgRQbhsVfr2NLUwVXvOXTY9z2ppoyLF87k4oUzAbjilNl85e4X+Nmjq7njmQ3c/NETOWhS1bDHJSKyN3ti1XZgVzvFcPvoKbN7vv7eeUcD8OrWFv7zvhUs+I8HgaAqXlYc45v/cDiplHPVb5eTTDlfOH0u5x03g87uFJ++ZSmHTR3DZ06b07O9h1Zu4+q/vMr/nX8M+08IrozblUzxmVueZd7kaj739rmRPKctOzv45M1L+ejJszjj8CmR7GNvFWkCbWZnAP8HxIFfuPu3e91fCtwAzAfqgfPdfU2UMYnkw2+e2cC4imJOO2TSSIfCjPEV3Hj5CbyytZkP/nwx/3DNE7zjsP048/ApHDl9THpOBqCmrJiy4vig99WVTA3p8rfuTnfKs25jR2sn3akUMPR4ZXTLfL2lv858DXUnU8RjhpnR1tlNS6IbgIqSIqpKi3B3trd04gQXsKitKs15bHtnkuZE125jAba3JEiFF8aYWFlKLLb72PLiONVhX2suY9PPM5lyjKBy2d/PJC1zbF8/M4D6lgTJMIYJlaXEs4zNjAHIOjYtlQp+cunWiPTPs7Q41tPfm/m3Pb6ihKJwG+mxJUWx3Vri0r+nzLHZXhuplJNypyge6/P+e57dyIzx5czbr5q9xfnHz2BLUwftXcme255aXc9nb3kWd5g8poyK0iK+es8LTB9XzgPLt/DA8q08sDxo41t44AS2N3fy2Vuepamjm0/evJSfX7KAWAx+8vBr3P/iFu5/cQv7j6/gzXMm5jV2d/j0LUt5Zm0DKzY3MWVMOVPG7lrdZEx5MaVFu+bvhtZOIFiZZPft7P43HTPL+lpOf53L2ChYVFfGMbM48ApwOrABeBq40N1fyhjzCeBId/+YmV0AvM/dz8+23QULFviSJUsiiVlkIP722nYuvfbvXHTCAXz9vYeNdDi7eX17K9c8tIoHX9rKzvauN9w/rqKYz58+l40N7VSXFTFrYhVPvV7PvMnVHDV9LBBMOH97rZ6d7V0cu/84lq5rYGtTB5sa21mytoG3H7Ifn3jLgcEElnL+9tp2Glo7OXXuJMZWFDNjfEWffeEvbWriyrueZ8XmZk6eM5F3HTGFgydXs3lnBw+t3EZLRzcrNjfx6raWnsdUlxXxr2cdyvvnTyceM+qaE/zy8deZOraMMw6bzKRhWooqn8zsGXdfMNJxDJfBztnPrW/kQ794ik+/7SAqSov49n0ruPay47jpqXUsXdfAjZefwEeuf5qZEyr5zGlzuOgXT/UkxaVFMX71j8fxmyUbuPvZjT3bfMu8Wr54+ryeE7nSY3956XHc/exG7ly6a5nIk+dM5P+dcTAX/nwxzR3B2JKiGL+4ZAG/f34Tty/ZNfakgybwlTMP4cJFi2nKGLvo4vk8sHwrt/x9Xc/YhbMncNV7DuWCRYt7/kZL4jF+8qFjeWjlNh5YvpVbrziRz9/2HOXFcW68/ARKioIE4LfPbeTLd77A1Rcew+mH7gcE69Gfv2gxJXHjP/7hCC78+WI+MH86R04fyz//ZhnfP/9onnq9nl89saYnhvkHjOPb5xzBBYsW875jpjH/gHF84fZlfO+8o1i6roE7l27k1itO5Mq7XiCZcv73A0dywaLFvOeoqZw4ewKfu/U5vnPukbznqKkAdHan+NAvniLRneS2f1pIaVGMz976HPcu20Q8ZnzvvKNYuaWZHz/8Wk8Mh0+r4Tf/9CbKimN84fZl3P3sRuIx438/cCTvO2Y6L27cyYWLgt/ToVNquOPjC6koCT68PLxyG5+4aSnfPPtw1u1o41dPvM4tV5zIf933MttbEvz4omO56BdPcfKcibznqKn8043P8JGTZ3P1X17l82+fy2ffvqtyuzdaV9/GWT98jJgZv//0m6kpK+asHz7GhoagRe+ShQewbMNOlq1v7HlMdVkRXzh9Lv/+u5d229ZFJ+zPS5ubeHZdI1H56pmH8NNHXqM+TJDTpo0t5+5PvolJ1WV8/8FX+L+/vArAF0+fy6fD6rm786U7nufxVdu56SMn8ImbllJbXcqX33UwFy5azIffPItpY8v5t3uX8+OLjuWPL27hoZXbuPmjJ/Lpm59lbEUxXzvrUC78+WIuXXgAs2or+erdL3LNB4/lwRVb+fNLW7n7kycxbWz5oJ9ff3N2lAn0QuDr7v7O8PsrAdz9vzLGPBCOedLMioAtQK1nCWowk/FrdS3c/8JmXtzYxMIDJ/Qc3mju6OaRlXVUlMQ56aCJlBb3/ymlpaObR16po6w4xpsPqg3GOqzY0sTKLc1c/uZZ1FaX8vKW5p6xpUUxTp4zkdLiODi8vKWZZesbOX7WeGbVBis3tCaCGIqLYpySMXbl1maeXdfA8bMmMDsc25ZI8sgr24jHgrFlJcHYV7Y2s3RdA8fNHM+B4aH7tkSSR1+pIxaDU+bU9ox9dVszz6zdfWx7Z5JHVtZhBqfMraW8pP+KX3tnsF13OHXerrGvbWvh6TU7mH/AOOZMqgaDjs4kj75aRyoVbLeidPexx+4/jrn7ZY7dTjKV4tS5k3rGrq5r5bn1jVx43AzmTq7mxY076egKxnZ1pzh1Xi2VpbkfSFmzvZWnVu/gyBljOGRyDRgkulI8vqqOjq4Up86tpaos2O7a7a0sXr2DI6aPIdGVZNFjq5kxroJbrjiRiVXDsxh/rjq7Uzy5up71O9p6bnPgjmc2sGx9I8VxoysZ/JmlT2TprSQeozOZoiQeY8rYMmrKijl82hjuWrqBRK/x6bEAxXHjyOljKS+Oc+wB4ygtivGH5zfz0uYmJlSW8M7DJ/PIyrrd+rWrS4uYUFXC5DFlvHXeJCpLi3Dgd8s28ffXdzCxqoQ5k6pZsaWJne1duIMZLDhgHO86fErP31OmrTs7eOzV7cyaWElFaZzFq3fQHcY4rqKEEw+cwLL1jWwK4zCDo2eMZf4B4zAzkknn6TU72LSzg1Pn1jKhKqiabGvq4IHlW3n/sdM568jcD1kqgd6zxrZOzrr6cTbtbMcIqprdKae0KEZHVwqzXa859yAJHl9ZwifeehAGXPvE62xsaCfRneKDJ+zPoVNqWLejjUWPrqasOMbY8hI++bZg7HV/W8P6HW0kulNcePwMDps6hvUNbfzskdWUhhXRT582BwNueHINa+uDsecvmMER08ewsbGdnzz8GqVFMarLivns24Oxv168ljX1rXR0pfjA/OkcNWMsm3e2c81D6bFFfPa0OZgZNz21jtV1LSS6g+eWfp4AFxw3g3cePpnWRDdfuuN52ruSVJcW8Z1zj6S0OM5vn93IPc9tAoLHZf5M0n+/ie5UT6Jc15zg//7yatax6Z9v+u+8r7EVxXG+c+5RVJTGuf+FzT0fKP7h6KlMG1fONQ+9xodO3J/lm5pYvqmJzu4UZx05hYWzJ9DY1sl3H3yFdx85lZkTKvjhX1dx0Qn78/KWZl7a1MS3338E33vwFRJdKS5eeAD/+6eVnHnEFM6dP53O7hRfvvN5Gtu7KI4Hc1dmvH29NtJfm8FjX3or08dV5OfFHaFXtzZjZj3teJsa23lo5Taqy4p51+GTaeno5oHlW+gOjxKcMGs8c/ar5m+rtrM6XCGquqyIM4+YQmuimz++uGtsPs0YX8Gpc2tZs72Vx8MWGQjeg77zwMscNX0sZx05hat+u5wzDptMyp0HV2zlm2cfzrRx5Sxb38gP/vzqG35vZcXB79M9eI/qGuDrs6+xR88Yy2dOm8P4ihKOGsR5SyORQJ8LnOHuHwm/vxg4wd0/lTHmxXDMhvD718Ix23tt6wrgCoD9999//tq1a3OK5YJFT7J49Q6mjClj886O3e4bW1FMoiu12+GT/owpL6YrmaKtc/exVaVFtHV2k/na7G/s1DFlbOoVQ01ZEcmU0zrAsSmnp9KSbWx1WRE+0LFhEtrca2xf+hvb13arSoswo6eCs6exMaOngpO5v+ZENzGj52dcWRInHrM3jM1FX6+HipI4xfHYG6q36bExg5Pn1PLd847aa5PnbJIp57n1Dczdr5rWRJL1DW0cPWMsr9W1sK4+SLbNjMOm1lBTXswLG3Zy2LSa3ZZY2tDQxkubdq1Ffdi0MYwtL+bpNTvo6Erx7LoGnl3XSHtXkuWbdpJyOHb/sZx5xBTOOXY64ytLcHde2LiTLTs7qCorYsEB43uqbJlSKedPL23hDy9sYcvOdsZXlvAv75yHO9z3whbuf3EzL29p7vf5Tqoupb61k2TKOXhyNdXhh6J1O9rY2pSgpqyIuftVYxZM+C9uauo5bA3Bh4Ex5SVsb0nstt3p48r5/Nvn8v7503P+HRRCAj3UOftb963gV0+8znX/eDxX/fZFEt0p/vcDR3HZr/7OKXNqedvBk/jyXS/wtbMO4aXNTfxu2SZuvWIh8w8YB8DKLc38wzVPcNJBE1h08QJiMeupdN39bFBdTa8DvGpbM2f/6AmOnzWeX156XE/LxJfvfJ47ntnATR85gRPCk85eq2vh7B89wbEHjOO6y3aN/erdL3Dr0+v59eUn9PTXrg7HHjVjLNd/+Pie1oarfvsiNz21jhs+fDwnHRQcUl9b38q7f/g4R0wbw4XH78+nb3mWz7ztIJo6urnub2t6fi4Tq0r4yYfm85Hrl+w2R33yrQfS0ZXi2ideZ9HFC/jxw6tYW9/Gzy6ez0dvWMKcSVXc/NETew5l/9d9K1j02Gp++qH5LHp0NavrWvj5JQv46A1LmF1bxRWnzOZjv36Gj548m3jM+Okjr/GTi47l2sfX8Mq2Zn5+yQI+duMzu1UcP3zSLCpK4vzooVUAvOPQ/fjZxfPZ1pzgrKsfZ9rYMm7/2MKeQ/rfe/AVrg4rkm8/ZBKLLl7A9pYEZ/3wceqaExTHjVs+Gvyerv7Lq3zvwVd69lVdWsS1/3gcn7p5KRMqS/nSGfO4/PolnH/cDKaNLed/HljJ988/inue3cQzaxu49rLj+Oytz3LIlBquvey4nF6LMnh3PrOBL/5mGQCHTa3hzo+/CXd434+f2G3ePnVuLWcfPZUv3L6Mf3nnPDY0tHP7kvX88tIF/PcfV7KjNcEPLzyWy697mqP3H8u586fz2Vuf4wunz2Vbcwe3/H09v7hkAd99cCVbm4IjEB++7mmOnD6G84/bn8/c8mzPfq7/8PE5P49RnUBnGkw1Y8XmJsZVBNWtNdtbaWgL/uiL4zEOnlxNV9JZubWZbD+L4niMeZOrSaaclVuae/rZpowpp7wkzs/DysaJsydQWhTn4ClvHDt5TBlTxpSzrr6N+tbgDbkoFmw35buP3a+mjKljy1m/o63nzbu/sZNqypjWa2w8Zhw8uYaUO69sbe5JCvobO29y0BO2ckvzbglEb/2NnVhVyozxFWxsbGdbU8duYw3j5S1NWcfGLBgbM2PlluaePrmJVaXUVpfyy8dfJ9GV5KSDJlJWHO9zbC4mVJay/4QKNu9sZ8vO3WOIx4LtdoXVyvGVJRwwoZJtTR3EY8aEUZg4j5T6lgTJlEfaapH595SpqrSIgyZV0djWRaI7xeQxu2JIpZzX61uZMa5it8S9obWTNfWtPd/Prq2iurSIV7Y10x5+wK0sLWLOpCrMBrcMViEk0JkGM2cnupMsXdvIwgMn0NbZTTLlVJcVU9+SYGxFCfGYsa25g0nVZaRSTn1r5xsuzVzfkmBMefFuvbO5jE335fYeu6O1k5qyogGPrS4r2q0H092pa0kwqbqs37HbmjuoDeeZlzY39RwhmjWxkrEVJexo7WRt+DotL4n39PSmt5voTtLemWRsRQkNrZ1Ulhbt9jrPjCFzbGNbJ+UlcUqL4rvFkB7b2Z2iNdHNuMpgbPpiUqVFcQ6ZEr4vbG2mszvFYVPH9Hxo2NnWRWlxbLfzGdyD991EV4rDptb0/Dx3tnWxentLz/tleuwrW1to6wwKJjPGVzCxqpSd7V2UFgXbrWtOMLGqBLNdr43uZIqmjm7GV5bQ1tmNYVmPsEr+vb69lca2Tg6ZUtPz++/oSrJic1CEiYUFm6LwdT+pumy3v6eOriSJ7hRjyovf8Dcy0LFr61vD74sHdYJ9QbdwiIjsLZRAi4iMHv3N2VGuA/00MMfMZplZCXABcG+vMfcCl4Zfnwv8NVvyLCIiIiIy0iJbxs7du83sU8ADBMvYXevuy83sG8ASd78X+CVwo5mtAnYQJNkiIiIiInutSNeBdvf7gPt63XZVxtcdwAeijEFEREREJJ90KW8RERERkRwogRYRERERyYESaBERERGRHCiBFhERERHJgRJoEREREZEcRHYhlaiYWR2Q23VhR8ZEoN8rKo5yem6jk57b3uEAd68d6SCGyyias2F0vY5ypec2Oum5jbw+5+xRl0CPFma2ZF+92pie2+ik5yaS3b78OtJzG5303PZeauEQEREREcmBEmgRERERkRwogY7OopEOIEJ6bqOTnptIdvvy60jPbXTSc9tLqQdaRERERCQHqkCLiIiIiORACbSIiIiISA6UQEfIzP7HzF42s+fN7G4zGzvSMeWLmX3AzJabWcrMRu0yNJnM7AwzW2lmq8zsyyMdT76Y2bVmts3MXhzpWPLNzGaY2UNm9lL4evzsSMcko5vm7dFF8/bos6/M20qgo/UgcLi7Hwm8Alw5wvHk04vAOcCjIx1IPphZHLgGeBdwKHChmR06slHlzXXAGSMdRES6gS+6+6HAicAn96Hfm4wMzdujhObtUWufmLeVQEfI3f/k7t3ht4uB6SMZTz65+wp3XznSceTR8cAqd1/t7p3ArcDZIxxTXrj7o8COkY4jCu6+2d2Xhl83AyuAaSMblYxmmrdHFc3bo9C+Mm8rgR4+HwbuH+kgpF/TgPUZ329gFP5BFzIzmwkcAzw1wqHIvkPz9t5N8/YoN5rn7aKRDmC0M7M/A5P7uOur7v7bcMxXCQ5Z3DScsQ3VQJ6byN7AzKqAO4HPuXvTSMcjezfN2yIjb7TP20qgh8jd357tfjO7DHg3cJqPskW39/Tc9jEbgRkZ308Pb5O9nJkVE0zCN7n7XSMdj+z9NG/vMzRvj1L7wrytFo4ImdkZwJeA97p720jHI1k9Dcwxs1lmVgJcANw7wjHJHpiZAb8EVrj790Y6Hhn9NG+PKpq3R6F9Zd5WAh2tHwHVwINm9pyZ/XSkA8oXM3ufmW0AFgJ/MLMHRjqmoQhPGvoU8ADBCQ23u/vykY0qP8zsFuBJYJ6ZbTCzy0c6pjw6CbgYeFv4N/acmZ050kHJqKZ5e5TQvD1q7RPzti7lLSIiIiKSA1WgRURERERyoARaRERERCQHSqBFRERERHKgBFpEREREJAdKoEVEADO71sy2mdmLedred8xsuZmtMLOrw6WbREQkD0Z6zlYCLaOamU3IWAZni5ltDL9uMbMfR7TPz5nZJVnuf7eZfSOKfUukrgPOyMeGzOxNBEs1HQkcDhwHnJqPbYuMZpqzJY+uYwTnbCXQMqq5e727H+3uRwM/Bb4ffl/l7p/I9/7MrAj4MHBzlmF/AN5jZhX53r9Ex90fBXZk3mZmB5rZH83sGTN7zMwOHujmgDKgBCgFioGteQ1YZBTSnC35MtJzthJo2SeZ2VvM7Pfh1183s+vDP6a1ZnZOeKjmhfAPrTgcN9/MHgn/8B4wsyl9bPptwNJwAX/M7DNm9pKZPW9mtwKEl/59mOBSwDK6LQI+7e7zgX8GBlQhc/cngYeAzeG/B9x9RWRRioxymrMlT4Ztzi4aYqAio8WBwFuBQwmu7vR+d/+Smd0NnGVmfwB+CJzt7nVmdj7wnwSVi0wnAc9kfP9lYJa7J8xsbMbtS4CTgdsjeTYSOTOrAt4E/CajFa40vO8coK9Dvhvd/Z1mdhBwCDA9vP1BMzvZ3R+LOGyRfYXmbMnJcM/ZSqClUNzv7l1m9gIQB/4Y3v4CMBOYR9D39GD4hxcn+BTa2xSCS8amPQ/cZGb3APdk3L4NmJq/8GUExIDG8FDzbtz9LuCuLI99H7DY3VsAzOx+gssnK4EWGRjN2ZKrYZ2z1cIhhSIB4O4poMt3XcM+RfBB0oDl6d48dz/C3d/Rx3baCfqk0s4CrgGOBZ4O++0Ix7RH8DxkmLh7E/C6mX0AwAJHDfDh64BTzawoPNx8Kru/iYtIdpqzJSfDPWcrgRYJrARqzWwhgJkVm9lhfYxbARwUjokBM9z9IeD/AWOAqnDcXCAvS+vI8DCzWwgOFc8zsw1mdjlwEXC5mS0DlgNnD3BzdwCvEVTLlgHL3P13EYQtUqg0Zxe4kZ6z1cIhArh7p5mdC1xtZmMI/jZ+QPAHmOl+4Mbw6zjw63C8AVe7e2N431uBK6OOW/LH3S/s566cl0ly9yTwT0OLSET6ozlbRnrOtl1HRURkIMKTWL7k7q/2c/9+wM3uftrwRiYiIr1pzpYoKIEWyZGZzQP2C9eg7Ov+4wh69p4b1sBEROQNNGdLFJRAi4iIiIjkQCcRioiIiIjkQAm0iIiIiEgOlECLiIiIiORACbSIiIiISA6UQIuIiIiI5OD/A6AZDT1irX9dAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 864x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# set offsets to zero\n",
+    "inst.trigger_delay = 0\n",
+    "channel.offset = 0\n",
+    "\n",
+    "# set horizontal axis to 5 ns per division\n",
+    "inst.time_div = u.Quantity(5, u.ns)\n",
+    "\n",
+    "# set to 250 mV per division and read waveform back\n",
+    "channel.scale = u.Quantity(250, u.mV)\n",
+    "x1, y1 = channel.read_waveform()\n",
+    "\n",
+    "# allow for 250 ms to not have it read to fast\n",
+    "sleep(0.25)\n",
+    "\n",
+    "# set to 1 V per division and read the waveform back\n",
+    "channel.scale = u.Quantity(1, u.V)\n",
+    "x2, y2 = channel.read_waveform()\n",
+    "\n",
+    "# plot the results\n",
+    "fig, ax = plt.subplots(1, 2, sharey=True, figsize=(12,4))\n",
+    "\n",
+    "ax[0].plot(x1, y1)\n",
+    "ax[0].set_xlabel(\"Time (s)\")\n",
+    "ax[0].set_ylabel(\"Signal (V)\")\n",
+    "ax[0].set_title(\"250 mV / division: Signal clipped\")\n",
+    "ax[1].plot(x2, y2)\n",
+    "ax[1].set_xlabel(\"Time (s)\")\n",
+    "ax[1].set_title(\"1 V / division: Signal visible\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clearly, the left signal is clipped on top. This results from the fact that the signal did not fit on the oscilloscope screen. If the signal is off scale, the data returned is simple the largest possible one, in this case, full signal. Since we artificially scale the two figures to the same y scale, this of course does not show up on top but at 1 V, which is equivalent to 4 divisions up.\n",
+    "\n",
+    "**Remember**: Reading a wave form only returns the data that is displayed on the oscilloscope screen."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Math functions\n",
+    "\n",
+    "Many math functions are available on these oscilloscopes, depending on the options that the oscilloscope is shipped with, more or less functions are available. For an overview of the implemented functions and how they work, have a look at the InstrumentKit documentation. You will find all functions in the `Math.Operators` subclass.\n",
+    "\n",
+    "For now, let's set up averaging of the first channel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Access the first math function `F1`\n",
+    "function = inst.math[0]\n",
+    "\n",
+    "# turn on the trace of this math function\n",
+    "function.trace = True\n",
+    "\n",
+    "# set it to averaging of channel 1 (0 in python)\n",
+    "function.operator.average(('C', 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This will have set up the first function to average the first channel. The parameter that is passed on to to average, the required parameter, is the source it should average. Different operators have of course different parameters that are required / optional. \n",
+    "\n",
+    "**Note**: There are two ways that sources can be specified. If an integer is given, it is assumed that the source is a channel. Alternatively another source, e.g., a math function could also be defined. This would be done by submitting a tuple, i.e., `('F', 0)` to select the first math function (called `F1` in the oscilloscope).\n",
+    "\n",
+    "To check if this all worked we can read back the channel itself and the average math function and plot the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 1.0, 'Average of the channel (math)')"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAtAAAAEWCAYAAABPDqCoAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy86wFpkAAAACXBIWXMAAAsTAAALEwEAmpwYAABOhElEQVR4nO3dd3xc1Zn/8c+j0agXN7nbuGCK6eDQQichJo2EJZseSEhogbTdbJLd/WWTbE12E0iBEBISCAFCCUnoxIDpYLDB3bgXucuSrDYjTdH5/XHvyGMjyRpprkbyfN+v17w8M/fMnTOy9OjRuc85x5xziIiIiIhI3xTkugMiIiIiIsOJEmgRERERkQwogRYRERERyYASaBERERGRDCiBFhERERHJgBJoEREREZEMKIGWQWNm3zOzP+S6Hwcys+fM7Is5eu87zOw/cvHeIiLZYmbXmtkuM2s1s9F9aH+Fmb00CP1yZnZ40O+TCTM7z8y2HqTNvWb2kUHqT6//F2b2JzO7eDD6MpwogZasMrNPmdlCP4juMLMnzOysXPfrUDdYv4xEpO/8P84bzaw4130JkpmFgZ8AFznnKpxz9Qccn+YnsoW56eHwYmbHAycAfw3g3P35v/ghoIGeAyiBlqwxs28ANwH/BYwDpgK3AJfksFtZpV8AItIXZjYNOBtwwIcDOP9QikXjgBJgRa47coi4GrjbDZGd7pxzrwNVZjYn130ZSpRAS1aYWTXwA+DLzrmHnHNtzrm4c+4R59w305oWmdnvzazFzFak/0Ca2bfNbL1/bKWZfTTt2BVm9pKZ/Z8/orMx/ZKSP9Lz72b2sv/6v5nZmLTjp5vZK2a218yWmNl5ffxc3zOzB83sD2bWDFxhZtVmdrs/wr7NzP7DzEJ++5lm9qyZ1ZvZHjO728xGpJ3vJDN70+/jfXi/dNLf70tmts7MGszsYTOb6D//jlGDVOmJmR0N3Aqc4Y/87+3LZxORQH0OeA24A7gcwMyK/Rh0bKqRmdWYWdTMxvqPP2hmi/12r/ijkam2m8zsW2a2FGgzs8KDxM2Qmf3Yj0Ubzez69DjSWyw7kN/3m8xsu3+7yX/uCGC132yvmT3bzctfSDveamZnpJ23p5ieSd9CZvbPaV+HRWY2Ja3Je8xsrf81vdnMzH/dweL1JjP7RzNbamZNZnafmZX4x84zs61m9g9mttvv5+cP+Hr9n5ltMa+05VYzK+2u/924GHg+7VxXmPe77Ub/M2wwszP952v99788rf0HzOwtM2v2j39vIP8XvueAD/Sx//nBOaebbgO+AXOBBFDYS5vvAe3A+4EQ8N/Aa2nHPwZMxPvD7uNAGzDBP3YFEAe+5L/2WmA7YP7x54D1wBFAqf/4f/xjk4B6/30LgPf6j2vSXvvFXvocBz7iv7YU+DPwK6AcGAu8Dlzttz/cP38xUIMXrG7yjxUBm4GvA2HgMv/c/+EfvwDYA5zsv/7nwAv+sWl4I1mFaX3r6rf/9Xkp198Huummm3cD1gHXAaf4P+fj/Od/C/xnWrsvA0/6908CdgOn+XHucmATUOwf3wQsBqYApf5zvcXNa4CVwGRgJPB0ehzpLZZ183l+gPcHwVg/tr0C/Lt/7B3x6YDXdhe/rqD3mJ5J374JLAOOBAyv/GG0f8wBjwIj8K6K1gFz/WM9xuu0r/fr/td3FLAKuMY/dh7e77wf4MXz9wMRYKR//EbgYf91lcAjwH+nvXZrD5+l3O9zzQFfqwTwef9r9R/AFuBmv+8XAS1ARdr5j/O/J44HdgEf6e//hd/mG8BDuf65Gkq3nHdAt0PjBnwa2HmQNt8Dnk57PBuI9tJ+MXCJf/8KYF3asTI/CIz3Hz8H/Gva8evY90vpW8BdB5z7KeDytNf2lkC/kPZ4HNCB/8vLf+6TwPweXv8R4C3//jndBKVX2JdA3w78KO1YhR/UpvUQ9Lr6jRJo3XQbMjfgLP9nd4z/+G3g6/799wDr09q+DHzOv/9L/KQ07fhq4Fz//ibgCwd57/S4+SxpSaf/3g4o7EcsWw+8P+3x+4BN/v13xKcDXttd/Ooxpvejb6tTn7mbYw44K+3x/cC3e2jbFa/Tvt6fSXv8I+BW//55QPSAz7QbOB0viW8DZqYdOwPYmPbanhLoSX6fSw74Wq1Ne3yc32Zc2nP1wIk9nPMm4Mb+/F+kPfcl4Nlc/UwNxdtQqqGS4a0eGGNmhc65RC/tdqbdjwAlqdeY2efw/sqd5h+vAMZ091rnXMS/ClfRy7lTxw4DPmZmH0o7HgbmH/RTeWrT7h/mv3aH//7g/ZVfC2Bm44Cf4tU+VvrHGv12E4Ftzo9Gvs1p9ycCb6YeOOdazaweL6Bu62NfRST3Lgf+5pzb4z++x3/uRry4U2Zmp+GNDJ6IN9oKXny53MxuSDtXEV5sSEmPRxwkbk48oH2fY1k3JrJ/vNp8QL/6o6eYPirDvk3BS/AP+j6k/W44SLzu6bXpn7n+gN93qXPX4CWhi9L6b3ijuwez1/+3Eu+KbcqutPtRAOfcgc+lPtdpwP8Ax+J9/xQDDxzkfQ/2+7UyrW8CSqAla17FGzH4CPBgpi82s8OAXwMXAq8655Jmthgv6AxULd4I9Jf6+fr0hLcW73OO6eEPhf/y2x/nnGswbxmiX/jHdgCTzMzSkuip7Av82/F+qQFgZuXAaLzkuc1/ugxo9u+P76GPIpIjfp3r3wMhM0slJcXACDM7wTm3xMzuxxtR3QU86pxr8dvV4pV3/Gcvb9H1s96HuLkDr3wjJb0u+GCx7ECp+JSaKDjVf64vMo1PmfatFpgJLM/wfXqL1wOxBy+hPcY5l9Hgh3OuzcxS5Yh1/Xz/e/A+x8XOuXYzu4l9f1T193fF0cCSfr72kKRJhJIVzrkm4LvAzWb2ETMrM7OwmV1sZj/qwylSdV91AP5kjGN7fUXf/QH4kJm9z59sUuJPAJl80FcewDm3A/gb8GMzqzKzAn8iyrl+k0qgFWgys0l4tXkpr+LVsX3F/9pcCpyadvxe4PNmdqJ5y179F7DAObfJOVeHl0h/xv8MX8D7hZGyC5hsZkWZfiYRyaqPAEm8ErUT/dvRwIt4EwvBS3A+jlf6dk/aa38NXGNmp5mn3J8QVtnDex0sbt4PfNXMJvmT476VOtCHWHage4F/NW/S4xi8eN/Xdf3rgE5gRl8a96NvvwH+3cxm+V+3460Pa1HTe7zuN+dcJ97/5Y22b3LoJDN7Xx9P8TjQ02fti0qgwU+eTwU+lXYso/+LNOcCTwygT4ccJdCSNc65H+NdSvxXvB/SWuB64C99eO1K4Md4SeYuvBqvl7PUr1q8pfT+Oa1f36T/3/+fw7ssthLvct+DwAT/2PfxJgE2AY8BD6X1IwZcildv1oD3CzT9+NPA/wP+hDdyNBP4RNr7fsnvdz1wDF79dMqzeCNDO81sDyKSK5cDv3PObXHO7Uzd8EYEP+2XrC3Au6o0kbSkxDm3EO/n/Bd4sWUdXrzoVh/i5q/xEtGlwFt4iVkCL8GH3mPZgf4DWOifaxleuVmf1gZ2zkWA/wRe9leROL0PL8ukbz/B+2Phb3hX6G7Hm/B9MD3G6yz4Ft7/32vmreD0NN4kx764De97pb9XYK8DfmBmLXh/6NyfOtCf/wszexfQ6rzl7MSXmu0qIiIihzB/abJbnXOHHbSx5JSZ3QPc75z7yxDoy5+A251zj+e6L0OJEmgREZFDkF+PfT7eyOw4vKtbrznnvpbLfokcCpRAi4iIHILMrAxvQ46j8Ca1PQZ81TnX3OsLReSglECLiIiIiGRAkwhFRERERDIw7NaBHjNmjJs2bVquuyEi0i+LFi3a45yryXU/BotitogMZz3F7GGXQE+bNo2FCxfmuhsiIv1iZpsP3urQoZgtIsNZTzFbJRwiIiIiIhlQAi0iIiIikgEl0CIiIiIiGVACLSIiIiKSASXQIiIiIiIZUAItIiIiIpIBJdAiIiIiIhlQAi0yyJ5asZN1u1tz3Q0REemj1o4Edy/YTCLZmeuuyBChBFpkED2zahdX37WIG59ek+uuiIhIHzjn+Mf7l/Avf17O65sact0dGSKUQIsMkt3N7Xzj/iUArNrenOPeiIhIX9y9YAtPrtgJwPq6thz3RoYKJdAig+S5NXU0ReO875hxbKxvo60jkesuiYjIQfzlrW0cM7GKsqIQG+pUficeJdAig2Tl9mbKikL83cmTcQ7e3qlRaBGRoayz07FqRzNzDhvJ9DHlbNyjEWjxBJZAm1mJmb1uZkvMbIWZfb+bNleYWZ2ZLfZvXwyqPyK5tnJ7M0dPqOK4ydUArFAZh4jIkLa5IUJbLMnsiVXMqKlgg0o4xBfkCHQHcIFz7gTgRGCumZ3eTbv7nHMn+rffBNgfkZzp7HSs3NHM7AlVjK8qYVR5ESu2KYEWERnKVvoDHcdMrGb6mHK2NkboSCRz3CsZCgJLoJ0nVSwU9m8uqPcTGcpqGyO0diQ4ZmIVZsbsCVWs3KEEWkRkKFuxvYnCAmPWuApm1pTT6WBzfSTX3ZIhINAaaDMLmdliYDcwzzm3oJtmf2dmS83sQTOb0sN5rjKzhWa2sK6uLsguiwQiVa4xe2IVAEeNr2TNrhac09+UcuhRzJZDxcodzRw+toLiwhAzxlQAaCKhAAEn0M65pHPuRGAycKqZHXtAk0eAac6544F5wJ09nOc259wc59ycmpqaILssEoiV25sJFRhHjKsEYFRFER2JTjoSWpRfDj2K2XKoWLG9mWMmevNWpo0pA7SUnXgGZRUO59xeYD4w94Dn651zHf7D3wCnDEZ/RAbbml0tzBhTTkk4BEBlSRiA5vZ4LrslIiI92BuJUdfSwVHjvYGPypIwo8uL2NoYzXHPZCgIchWOGjMb4d8vBd4LvH1AmwlpDz8MrAqqPyK5VNsYZeqosq7HlcWFALS0ay1oEZGhqLbBS5Snjt4Xu6tLw7Ro4EOAwgDPPQG408xCeIn6/c65R83sB8BC59zDwFfM7MNAAmgArgiwPyI5s7UxwqnTRnY9rixRAi0iMpRtbfQmC04eWdr1XGVJoeK2AAEm0M65pcBJ3Tz/3bT73wG+E1QfRIaCpkiclvYEU9JHoP0SDo1kiIgMTbVdCfS+2F1RUqi4LYB2IhQJXG0PoxgArRrJEBEZkrY2RqkqKaS6NNz1XGVxWCPQAiiBFgnc1m5GMVTCISIytNU2RPaL26ASDtlHCbRIwFIztqeMfGcJh1bhEBEZmrY2RpkyqnS/5ypLNIlQPEqgRQJW2xChsriQqtJ9Uw4qtAqHiMiQ5Zxja2O02xHotliSZKc2wcp3SqBFAra1McrkUWWYWddzoQKjoliXAkVEhqL6thjReJIpIw8cgdb8FfEogRYJmDeKUfqO5ys1m1tEZEiqbXjn3BWAKpXfiU8JtEiAnHPUNkZ6SaA1iiEiMtSk5q5MfkcNtMrvxKMEWiRAze0JIrEkE6u7S6DDtHRoFENEZKjZ0eQl0BNHvHMSIWgNf1ECLRKo+tYOAMZUFr3jmEagRUSGprqWDkrCBVQW77/fnEagJUUJtEiAGtpiAIwqL37HMW85JAVhEZGhZndLBzWVxftN/oa0BFpXD/OeEmiRAO1p9RLo0eXvHIH2VuFQEBYRGWrqWjoYW1nyjuf3lXBo8CPfKYEWCVBqBHpMxTtHoKtKCmlWEBYRGXLqWjqo6SZuq4RDUpRAiwQoVQM9sjz8jmOVJYXEEp10JJKD3S0REelFqoTjQCXhEEWhAi1jJ0qgRYJU3xajsqSQ4sLQO47pUqCIyNDTkUjSFI0ztpsEGjQBXDxKoEUCVN8W67b+GXQpUERkKErNXeluBBqUQItHCbRIgOpbOxjdTR0daD1REZGhqK7FK73rOYEOK26LEmiRIDVoBFpEZFjZ3dwO0O0qHKARaPEogRYJ0J7WGKMrDpZAayRDRGSoqGs92Ai0liAVJdAigensdDRGYozuZhMV8NaBBmjr0CocIiJDRaqEo+fBD22CJQEm0GZWYmavm9kSM1thZt/vpk2xmd1nZuvMbIGZTQuqPyKDrSkaJ9npGNVDCUdJ2FuZo13L2ImIDBm7WzoYVV5EONR9iqQSDoFgR6A7gAuccycAJwJzzez0A9pcCTQ65w4HbgR+GGB/RAZVfVvvoxgl/tJ20ZgSaBGRocLbhbD7K4cAZUUhonHF7XwXWALtPK3+w7B/cwc0uwS407//IHChHbjxvMgwVd/a8y6EACVF3o9fR6Jz0PokIiK9q2vp6DFugzf4kex0xJOK3fks0BpoMwuZ2WJgNzDPObfggCaTgFoA51wCaAJGd3Oeq8xsoZktrKurC7LLIllT72/j3VMJR1GoADNo10iGHGIUs2U4a47GGVH2zt1jU4rDXuqk2J3fAk2gnXNJ59yJwGTgVDM7tp/nuc05N8c5N6empiarfRQJSiqB7mkZOzOjpDCkICyHHMVsGc6aonGqS3tOoFPzV3T1ML8Nyioczrm9wHxg7gGHtgFTAMysEKgG6gejTyJBa4p4CXR1LyMZJeEC1dKJiAwRzjma2+NU9ZZA+/NXNPiR34JchaPGzEb490uB9wJvH9DsYeBy//5lwLPOuQPrpEWGpb2ROKXhEMV+sO1OaThEe1yjGCIiQ0F7vJN40lFV0pcSDsXufFYY4LknAHeaWQgvUb/fOfeomf0AWOicexi4HbjLzNYBDcAnAuyPyKBqOkgdHXiXAjWKISIyNDT7G6RUlfacHqUGRTq0BGleCyyBds4tBU7q5vnvpt1vBz4WVB9EcmnvQeroAIo1Ai0iMmQ0Rf0EupcR6BKNQAvaiVAkME2RgyfQJeECjUCLiAwRzakEupfYrRFoASXQIoHpSwlHqUo4RESGjFQJR++rcPhr+GsEOq8pgRYJyN5ojBGl3S9hl1ISDmkrbxGRIaI56m3RXVXSc4Vrahk7DX7kNyXQIgFpisZ7XcIOUiUcGsUQERkK9k0i7K2EQ7vIihJokUC0x5O0xzv7UAMdIhrTKIaIyFDQFPES6EqNQMtBKIEWCUBqJndflrHTRBQRkaGhuT1OSbig1/X7UyPQSqDzmxJokQCkEuiDjkAXahk7EZGhojma6NOVQ1AJR75TAi0SgL3+ZcCDTyLUMnYiIkNFc3u81zWgIX0EWgl0PlMCLRKAvZEYcPASjtJwiESnI55UIBYRybXm9nivEwgBCkMFFBaYVlDKc0qgRQLQ5xIOTUYRERkymqLxXpewSykJh7QOdJ5TAi0SgK4Eug/L2IEuBYqIDAXN0cRBR6DBL7/TCHReUwItEoC9kTihAqOyuPeRjGKNQIuIDBnN7fGDXjkEbztvxe38pgRaJACpy4Bm1mu70q7Z3ArEIiK55JyjOXrwSYQAxeECrcKR55RAiwRgbzTOiLLeV+CAfTXQ0ZgCsYhILrXFknQ6qCrtQw10YYgOjUDnNSXQIgFoivbtMmBXDbRGoEVEcio1d0Uj0NIXSqBFAtAUPfhSSLCvhEO1dCIiudXSntrGuw+DH6qBzntKoEUCEOlIUFHc81awKfuWsdNIhohILrV1eAlxeZ9id4Hidp5TAi0SgEgsSWm4L2uJej+CUY1kiIjkVDTmxeGyooPH7uLCkCZ/57nAEmgzm2Jm881spZmtMLOvdtPmPDNrMrPF/u27QfVHZDBFYgnKig4+ilFcqBIOEZGhoC2WAOhT7NYItBz8z6z+SwD/4Jx708wqgUVmNs85t/KAdi865z4YYD9EBl0klqSsD5cBS/1ArdncIiK5tW8Eum+DHxr4yG+BjUA753Y4597077cAq4BJQb2fyFCR7HR0JDop61MJh2qgRUSGgn0j0H0rv9MqHPltUGqgzWwacBKwoJvDZ5jZEjN7wsyO6eH1V5nZQjNbWFdXF2RXRQYs4gfhPk1EKVQNtBx6FLNlOOoage7jBHCNQOe3wBNoM6sA/gR8zTnXfMDhN4HDnHMnAD8H/tLdOZxztznn5jjn5tTU1ATaX5GBivhBuLQPlwELQwUUFpgCsRxSFLNlOEqtwlEW7ksJhzcC7ZwLulsyRAWaQJtZGC95vts599CBx51zzc65Vv/+40DYzMYE2SeRoKUS6PI+XAYEby1olXCIiORWJJ6gKFRAYejgqVGxn2SrjCN/BbkKhwG3A6uccz/poc14vx1mdqrfn/qg+iQyGNo6vBKOvoxAgxeItROhiEhuRfs4+Rv2zV/p0OBH3gpyFY53A58FlpnZYv+5fwamAjjnbgUuA641swQQBT7hdD1EhrlUPXNfZnKDvxxSTAm0iEgutXUk+1S+AV4JB+CvBX3wnQvl0BNYAu2cewmwg7T5BfCLoPogkgupEei+zOQGv4RDI9AiIjkVjScoK+5b3NYKSqKdCEWyLJO1RCE1m1tBWEQkl9o6khldOQQ0+JHHlECLZFmmkwi9Ha0UhEVEcika63sCndpFVjXQ+UsJtEiWpdaB7vMkwsKQZnKLiORYJJ7oc+mdRqBFCbRIlkUyLuHQCLSISK5FOpIZDXwAit15TAm0SJa1pTZS6fNsbo1Ai4jkWiSWpDzDGmiVcOQvJdAiWRaNJSgNhygo6HURmi7FGoEWEcm5tlgmJRz+CLRKOPKWEmiRLGuLJSnv42L8oBFoEZFcc85lOInQr4HWCHTeUgItkmXRWN/r6EA10CIiuRZLdpLodBktPwqpjVQkHymBFsmyto5En5ewA41Ai4jk2r71+/tYwlGojVTyXa/fKWY2GfgEcDYwEW+77eXAY8ATzjl954gcIBrPbAS6uLCAWKKTzk7X57ppERHJnkxXTyoOp2/lLfmoxxFoM/sd8FsgBvwQ+CRwHfA0MBd4yczOGYxOigwnkQzq6GDfpcBYUn+PiojkQubr96sGOt/1NgL9Y+fc8m6eXw48ZGZFwNRguiUyfLV1JBhVXtbn9qlA3BHv7EqmRURk8GS6g6yZUVxYQIfmr+St3mqgL/ZLOLrlnIs559YF0CeRYS0a798ItJZDEhHJjbaOzEo4wBv80PyV/NVbAj0ReNXMXjSz68ysZrA6JTKctXUk+zwRBfYfgRYRkcEXjXslHGXFfY/dJeGQVlDKYz0m0M65r+OVaPwrcByw1MyeNLPLzaxysDooMtxEYwmNQIuIDCOZTiIEbYKV73pdxs55nnfOXQtMBm4EvgbsGoS+iQw7zjki8b5vBwsagRYRybWIX8JRmsE8lBItQZrX+nStwsyOw1vO7uPAHuA7QXZKZLhqj3fiHJRmUMKhEWgRkdxKrcJRrhIO6aMev1PMbBZe0vwJIAn8EbjIObdhkPomMuy0+UE408uAoBFoEZFcaetPCUdhgZaxy2O9lXA8CRQDH3fOHe+c+69Mkmczm2Jm881spZmtMLOvdtPGzOxnZrbOzJaa2cn9+AwiQ0a0n0EY0EiGiEiORGNJCmxfPO6LknBIG6nksd6uVcw62E6DZmbOOdfD4QTwD865N/1Jh4vMbJ5zbmVam4uBWf7tNOCX/r8iw1JqIkomOxGmSjhUSycikhveBliFmPV9N9iScAENbYrb+aq3P7WeNbMbzGy/zVLMrMjMLjCzO4HLe3qxc26Hc+5N/34LsAqYdECzS4Df+5MVXwNGmNmEfn0SkSEgGtcItIjIcBONJzIa+AAoLgxp7koe6y2BnotX+3yvmW33SzE2AGvxtvW+yTl3R1/exMymAScBCw44NAmoTXu8lXcm2ZjZVWa20MwW1tXV9eUtRXKiazvYcOaTCDUCLYcKxWwZbqKxZEYrcIA3f0VzV/JXj7/lnXPtwC3ALWYWBsYAUefc3kzewMwqgD8BX3PONfenk86524DbAObMmdNTyYhIzqVGkTMZydAItBxqFLNluPFKODJLoFUDnd/6NEzmnIsDOzI9uZ94/wm42zn3UDdNtgFT0h5P9p8TGZaiMW80IqO1RDUCLSKSU9F4sisW91VxoUag81nfp5tmyLxK/NuBVc65n/TQ7GHgc/5qHKcDTc65jBN1kaEiVQOdSQJdFNIItIhILkX7OQKtGuj81fdCzcy9G/gssMzMFvvP/TPe9uA4524FHgfeD6wDIsDnA+yPSOCi/SjhKCgwikIFGoEWEcmRaDxJdWk4o9eUFIaIJx3JTkeooO+rd8ihIbAE2jn3EtDrd5S/BN6Xg+qDyGCLpiYRZjqbO1ygWjoRkRyJxpL9itsAHQlvCTzJL73tRNgCdDf5w/By36rAeiUyTKVqoEsyWIwf/OWQVEsnIpIT0Xjmq3CUdE0A76SsKIheyVDW2yoclYPZEZFDQTSepChUQGEoswS6RCPQIiI5059VOIr9hFvzV/JTn685mNlYoCT12Dm3JZAeiQxj7fEkJeHM5+ZqNreISO5E40lKMp5EmCrhUOzORwf9TW9mHzaztcBG4HlgE/BEwP0SGZYisUS/auG0nqiISG4kOx2xRCdlGWyABd4kQtAIdL7qy1DZvwOnA2ucc9OBC4HXAu2VyDAVjXdmPBEFvBFo1UCLiAy+fasnZTh3JawlSPNZX75b4s65eqDAzAqcc/OBOQH3S2RYisYyX4wfNAItIpIrka7Vk/o3Aq0SjvzUl++Wvf523C8Ad5vZbqAt2G6JDE/t8SSl/ayBbmlPBNAjERHpTXs/dpAFTSLMd335TX8JEAW+DjwJrAc+FGSnRIar/tZAFxdqBFpEJBcicW/wIuNVOAo1iTCfHfQ3vXMufbT5zgD7IjLsReOdjCrvTwmHaqBFRHIhGvNroDNdB1oj0HmtL6twXGpma82sycyazazFzJoHo3Miw017PPPdrEAj0CIiudKVQPd3GTsNfuSlvlxr/hHwIefcqqA7IzLcRWP9q4HWCLSISG50rcKRaQ101yRCDX7ko778pt+l5Fmkb6LxZP9qoLUKh4hITkT8EehMa6BLwvu28pb805ff9AvN7D7gL0BH6knn3ENBdUpkuOr3MnaFBXQkOnHOYWYB9ExERLqTGoHONHYXayOVvNaXBLoKiAAXpT3nACXQImkSyU5iyc6MLwOCNwLtHMSSnV1BWUREghft5wh0OGQUmFbhyFd9WYXj84PREZHhrt0PopnuZgX7L4ekBFpEZPDs24kws9hrZpSEQxqBzlMHTaDN7GfdPN0ELHTO/TX7XRIZnvq7FBLsvyB/VUk4q/0SEZGepWqgS/oxeFFcWEC75q/kpb4MlZUAJwJr/dvxwGTgSjO7KbCeiQwz+5ZCynwSYZmfQKfOISIig6M9nqQkXEBBQebzT0rCIS1jl6f68pv+eODdzrkkgJn9EngROAtYFmDfRIaV/i6FBFBe7L2mrUMJtIjIYOrvDrLgJdDtqoHOS30ZgR4JVKQ9LgdG+Ql1R/cvATP7rZntNrPlPRw/z9+cZbF/+25GPRcZYvbV0WVeA50K3pFYIqt9EhGR3kVj/Zv8DV4JR4dqoPNSXzdSWWxmzwEGnAP8l5mVA0/38ro7gF8Av++lzYvOuQ/2rasiQ1uq/KI/y9h1jUCrhENEZFBF44l+7SALXryPKoHOS31ZheN2M3scONV/6p+dc9v9+9/s5XUvmNm0gXdRZHiIxr3R4/5cCuwage7QCLSIyGDydpDtXwJdXhzqmoQo+aXHa81mdpT/78nABKDWv433n8uGM8xsiZk9YWbH9NKXq8xsoZktrKury9Jbi2RXNOYvY9ePQFxR7CXQGoGWQ4FitgwnkViy3yPQ5UWFtGngIy/1NlT2DeAq4MfdHHPABQN87zeBw5xzrWb2frydDmd119A5dxtwG8CcOXPcAN9XJBADmUSYWsBfNdByKFDMluGkPZ5kRFlRv15bUVxIqxLovNRjAu2cu8r/9/wg3tg515x2/3Ezu8XMxjjn9gTxfiJB69oOth+TCMv9EWgFYhGRwRWJJZk4or8lHBqBzle9lXC8y8zGpz3+nJn91cx+ZmajBvrGZjbezMy/f6rfl/qBnlckV9q7toPNvAa6uLCAAoOIlrETERlUkQHUQJcVh7T8aJ7qbajsV0AMwMzOAf4Hb0WNJvxLc70xs3uBV4EjzWyrmV1pZteY2TV+k8uA5Wa2BPgZ8AnnnC71ybC1bzerzEegzcyrpVMJh4jIoGqP978GuqKokFiyk5jWgs47vQ2VhZxzDf79jwO3Oef+BPzJzBYf7MTOuU8e5Pgv8Ja5EzkkRONJikIFFIYyT6DBG8nQCLSIyOAayAh0qvyurSNBUWH/6qhleOrtN33IzFIJ9oXAs2nH+rdlj8ghLLUdbH9pBFpEZHA554jGk10TuTNVofkreau3RPhe4Hkz2wNE8bbvxswOxyvjEJE00QEshQTeSIbWExURGTztca/0oqS/y9h1LUGqBDrf9LYKx3+a2TN4a0D/La0+uQC4YTA6JzKcROLJfk0gTCkrCmk2t4jIIEqtnlQ2gI1UAMXuPNTrb3vn3GvdPLcmuO6IDF/RWLJf23inlBcXsrulPYs9EhGR3qTW3u/3JMKuEg5dPcw3/S/YFJH9tMeTlA6gBrqsSJMIRUQGU3tqA6x+Xj1Mn0Qo+UUJtEiWRAewFBJoEqGIyGBLzTvp7yocmkSYv5RAi2SJtxTSAGqgtYydiMiginZtgDXwZewkvyiBFsmSgSzGD95IRlssgfYTEhEZHBG/hKO/81c0iTB/KYEWyZJobKA10IV0OujQjlYiIoOifYAj0MWFIcIh0yTCPKQEWiRLovH+72YFGskQERlsA62BhtQa/orb+UYJtEiWeJMIB7IOtPdabaYiIjI4utaBHuAEcE0izD9KoEWyINnpiCU6BzaK4QdwBWIRkcGRmkTY350IwZ+/oridd5RAi2RBtGst0QHUQBenRqAViEVEBkNX7B5g+V2baqDzjhJokSyIZqGOrqKrBlqBWERkMERiScIhIxzqfzpUXqwSjnykBFokC9oHuBQSpNdAKxCLiAyG9gFO/gaVcOQrJdAiWRDpWgqp/5MIy4tSC/JrBFpEZDBEYokBrd8P3gi0Euj8owRaJAuyUwPtBXGNQIuIDI5ovHNAAx/gjUCrhCP/KIEWyYKumdwDWoXDC+JakF9EZHBEY4kBxW3wJxHGktpFNs8ElkCb2W/NbLeZLe/huJnZz8xsnZktNbOTg+qLSNDaszCTuyRcQDhkNEXj2eqWiIj0IhpPDmgNaPBKOJKdTrvI5pkgR6DvAOb2cvxiYJZ/uwr4ZYB9EQlUNmqgzYyRZUXsjcSy1S0REelFJJadSYQALe0q48gngSXQzrkXgIZemlwC/N55XgNGmNmEoPojEqRsrCUKMLKsiIY2JdAiIoMhGksOeBJhdWkYQFcP80wua6AnAbVpj7f6z4kMO6kEumQAkwgBRpaH2RtREBYRGQzRLCxjN7KsCIBGXT3MK8NiEqGZXWVmC81sYV1dXa67I/IO7VnYSAW8QKwgLMOdYrYMF9HYwGugR5X7CbSuHuaVXCbQ24ApaY8n+8+9g3PuNufcHOfcnJqamkHpnEgmslXCMUIJtBwCFLNluIjGkgNehWNEmVfCoauH+SWXCfTDwOf81ThOB5qcczty2B+RfovEkhSFCigcwHawAKPKwzRG4loOSURkEGRjFY5UCUeDBj/yysBWD++Fmd0LnAeMMbOtwL8BYQDn3K3A48D7gXVABPh8UH0RCVp7PElJeOB/j44sKyLZ6WhuT3RNTBERkeyLJTpJdLoBXzksKwpRVFigq4d5JrAE2jn3yYMcd8CXg3p/kcGUjZncsG8kY28kpgRaRCRA+3aQHVjs9pYgDasGOs8Mi0mEIkNdNmZyg7cKB6Cl7EREApbaQTZbgx+NqoHOK0qgRbIgEktSOoBNVFL2jUArEIuIBCk1Aj3QGmjwE2gNfOQVJdAiWdAeT1KapRpo0Ai0iEjQIjFv58BsXT1UDXR+UQItkgXReHZroBWIRUSC1d5VA52dq4e6cphflECLZEE0lp0a6MqSQkIFpgRaRCRgkSxtgAX7NsHq7NQSpPlCCbRIFngj0AMfxSgoMEaUhjUZRUQkYKkEOis10OVFdDpoaU8M+FwyPCiBFskCbwQ6Oz9OI8uL2KsRaBGRQLV1eMluRXE2Sjj8FZQUu/OGEmiRLIjEElm5DAheINYkQhGRYLWmEuiS7K2gpPK7/KEEWmSAnHO0diSoLMnOxicjyopobFMJh4hIkFLlFlkZgS7ftwmW5Acl0CIDFI0n6XTZGcUAmFBdwva9UbzNOkVEJAitHQnCIaO4MBtLkKY2wdLgR75QAi0yQK1ZHMUAmD6mnJaOBHWtHVk5n4iIvFNre4KK4kLMbMDnSo1AN7QpbucLJdAiA9Ti19FVZmkEekZNBQAb6tqycj4REXmn1o5E1q4cVhYXMqq8iPW7FbfzhRJokQHK9gj0jDHlAGzco0AsIhKUlvYEFcXZmbtiZsyeUMWKHU1ZOZ8MfUqgRQYotRRSeZYS6EkjSikuLGBDXWtWziciIu/U2hGnMktxG+CYiVWs2dlKPNmZtXPK0KUEWmSAWrK4lih4m6lMH1OuEg4RkQC1dSQpL87O8qMAsydWEUt2sm63Bj/ygRJokQFKlXBkqwYaYEZNORtUwiEiEhivBjo7JRzgjUADrNzenLVzytClBFpkgFqzPAINMGNMBVsaIsQSuhQoIhKEFn8VjmyZPqaCknABK5RA5wUl0CIDlM3drFKmjykn2enY0hDJ2jlFRGSf1o54Vq8chgqMo8ZXsWK7JhLmAyXQIgPU0p6gKFRAcWH2aulm1HgrcWgioYhI9sWTnbTHO7M6Ag1w9IRK1qoGOi8EmkCb2VwzW21m68zs290cv8LM6sxssX/7YpD9EQlCa0c8q6PPsG8taC1lJyKSfW0BlN6BV37X0BbTlt55ILAE2sxCwM3AxcBs4JNmNrubpvc55070b78Jqj8iQWnNch0dQHVpmDEVRVqJQ0QkAC3t2S+9g31XD9crdh/yghyBPhVY55zb4JyLAX8ELgnw/URyorUj+wk0eCMZG/boUqCISLal5q5kcx1oSN9JVrH7UBdkAj0JqE17vNV/7kB/Z2ZLzexBM5vS3YnM7CozW2hmC+vq6oLoq0i/ZXM72HQzarQWtAxPitky1GV7A6yUKSNLCYdMy5DmgVxPInwEmOacOx6YB9zZXSPn3G3OuTnOuTk1NTWD2kGRgwlsBLqmnPq2GE2ReNbPLRIkxWwZ6loCWD0JoDBUwNRRZWzU4MchL8gEehuQPqI82X+ui3Ou3jnX4T/8DXBKgP0RCUQQNdDglXAArFcZh4hIVnVtgBVA7J6u8ru8EGQC/QYwy8ymm1kR8Ang4fQGZjYh7eGHgVUB9kckEEGVcEzvWspOIxkiItkUxPr9KTNrytlUHyHZ6bJ+bhk6sv+d43POJczseuApIAT81jm3wsx+ACx0zj0MfMXMPgwkgAbgiqD6IxKUlvZEIKMYU0eVUVhgbNRIhohIVqVGoIMqv4slOtnWGGXq6LKsn1+GhsASaADn3OPA4wc89920+98BvhNkH0SCFEt00pHI/mL8AOFQATNrKli6VbtaiYhkU6oGurwo+7H7yPFVACzdtlcJ9CEs15MIRYa1tgAvAwKcNmMUCzc1Ekt0BnJ+EZF8lJq7UlBgWT/3MROrKC8K8er6+qyfW4YOJdAiA9Aa0G5WKWfMGE00nmTZtr2BnF9EJB+1dsQDi9vhUAHvmj6K1zYogT6UKYEWGYDUblaVgY1AjwbQSIaISBa1tCcoLw4Fdv4zZoxmfV0bu5vbA3sPyS0l0CID0BZLjUCHAzn/qPIijhpfyasayRARyZqdze2MqyoJ7PxnzPQHPxS7D1lKoEUGILXJSVA10ABnzhzDwk2NXeUiIiIyMFsbo0wZGdwEv9kTqqgsLlQZxyFMCbTIAGyq99ZonjoquED8gePH05Ho5PGlOwJ7DxGRfNEeT1LX0sHkkaWBvUdhqIBTp4/itQ0Ngb2H5JYSaJEB2LCnjRFlYUaVFwX2HidPHcmMmnIeWFQb2HuIiOSLrY1RACaPCi6BBq+MY+OeNnY2qQ76UKQEWmQANtS1MmNMeaDvYWZ87JQpvLGpkfV12lRFRGQgtjZGAAIt4QA4PTUJfMOeQN9HckMJtMgAbKhrY/qYisDf5+9OnkRpOMR3HlpGIqk1oUVE+qs2NQIdcAI9e0IV1aVhraJ0iFICLdJPLe1xdrd0MKMm2BFogLFVJfzXpcfy+sYGfv7susDfT0TkULW1MUJRqICxlcWBvk9BgXHq9FG8vK5eAx+HICXQIv20aY93GXDmICTQAB89aTIXHDWWBxbW4pwblPcUETnUbG2MMmlkaSC7EB7ooydNYtveKDc9vTbw95LBpQRapJ827PHqkWfUBF/CkXL+kTVsb2qntiE6aO8pInIo2doQCXQFjnTvP24CH58zhV/MX8cbm7Qix6FECbRIP62va8MMDhsdbB1duvRJKe3xJHtaO9jT2kFLe3zQ+iAiMpxtbYwOWgIN8L0PH0N1aZi7Xt0MsF85R7JTVxOHq+B2fxA5xK3a0cyUkWUUFwa3HeyBDh9bwZiKYv705jZ+9ORq6ttiAJjBQ9eeyUlTRw5aX0REhpuGthj1bbHAJxCmKy0KccmJE/njG7XcOG8Nv3t5I3ddeRq3vbCB7U1RHrr2TMyCLyeR7NIItEg/7I3EeH51HRccNXZQ39fMOH3GKF7f2ECi0/G9D83mB5ccQ1k4xD0LtgxqX0REhpuHF28D4PwjBzd2//2cKcQSnfz0mbU0tyf4xG2v8diyHby1ZS9vbmkc1L5IdiiBFumHvy7eTizZycfmTB709z73iBoAfvL3J3DFu6fzuTOm8cHjJ/LYsh20abtvEZEePbBoK8dMrGL2xKpBfd9jJlZxwuRqpo8p5/dfOJVEZycXzR5HWVGIBxZuHdS+SHaohEOkHx5YVMvsCVUcM7F60N/70pMnc8bM0ftdgvzYnMnct7CW7z28gplj901qfPfMMRw3uZqnVuxk4x5v2/HKkkL+7uTJlIT7XnpS19LBW1saueiY8dn7ICIig2jl9mZWbG/m+x8+ZtDf28y464unURQqoCQc4uVvXcDoimK+9aelPLp0B9PHlJOq4igJh/joSZNwwJ/f3Eai0/GhEyYwtrIEgDe3NDKmvJipgzj/Rt5JCbRIhlbtaGb5tmb+7UOzc/L+oQJ7R/3eKYeN5LhJ1TywaP+RjLKiENecO5OfzFuz3/NLa5v44WXH9+n92uNJPn/H6yzf1syPLjuev58zZWAfQEQkBx5YVEtRqIBLTpyYk/evKgl33R9b5SXDnzn9MP7y1jb++4m392s7/+3dJDodL671djF8cNFW/nzdmSQ6HZ/+9QKqS8M89pWzGF0R7FrW0rNAE2gzmwv8FAgBv3HO/c8Bx4uB3wOnAPXAx51zm4LqT2en49YX1nPa9NGccti+yVardjTz5PKdXH/B4YRDXlWLc45bn9/AqdNHcspho7rart7ZwmPLdnD9+YdTVFjA9r1Rfv7sWqKxJJ8+/TCOGFfJjfPW0OBP7po4opRvvPcIXlhTx8NLtvufGz516lRO81dUAFi3u4W/Lt7O9Rcc3jUpzTnH7S9t5JiJ1ZwxM71tK39dvI0vn3941yiic47fvryJo8dXcubhY7rabqhr5aE3t3H9Bfu3/d3LmzhiXCUnHzaCm+ev4+/nTME5L8Bcf/4sSov2jU7e+comZtSUc/Ysr3Tg4SXbeXrlLmoqi/mHi46grKiQ+tYObnx6Dc3RBJeePInz0urLttRHuG/hFq4773DKi/d9y9312mYmjyzdrxattiHCva9v4brzD6cire3dCzYzobqEC44aB8CTy3fw+LKdjCov4h8uOoKV25u55/UtlBWF+OqFRzC+uqTrtU+t2MljS3cwqryIb1x0BFUlYZqicX7yt9U0RuJ84PgJvM8fWZ23chePLNnOyLIw37joSKpL9wW8+xfWUlVSyOsbGwmHjEtOnNTNd1lumBl//fK76Ujsm929p7WDS25+mZ/MW8O7po3kd58/lZAZv5i/lpvnr6e+rYOyooOHgG17oyzf1szMmnK++9flvLh2D+cfWcNHTpzEzfPXsXa3t5xfeXEhX3vPLOpbY/zmpQ0kkt7s8rNnjeGyUyZzy3PrWb2zxW/r/T/tjca47YV9bbtTXhzihgtmMXFEKbFEJzc+vYZtjVHOnDmaT5w6tatdc3ucW59bz6dPP4xJI/bNsH9m1S52NXfwqdP2tW1pj/Pjv+37OZ1QXcLX33sEr66vZ9veKJ85/bCutq0dCW6Zv45PnjqVKaM04pMLtQ0R7l9YyzXnztwvhtyzYAsTRpTsF0O2Nkb44+u1XHPezP1iyB9f38K4qhLOT5u3sH1vlHsWbOHqc2dQ6ceFG+etYW8kxodOmMiFR4/raruzqZ0/vLaZq86dsV8i9MDCWqpLw11XZ55Z5cWQEWVFfP29R1BdGqalPc6N89bS0NbB3GMnMPdYr+381bv561vbGFFWxNfeM4sRZUVd5/3zW1spKQxx8XETup7b3dLOna9s4otnzWBLQ4SX1+/hmnNm8sjS7YRDBbw/re2e1g5+9/JGrjxrBqPK95334SXbMbzl1X753DrOO3Isx07adyVt+bYmnlu9m2vPO5yQv05yZ6fjF/PXsaHO+1mvKCnkqxcewe6Wdn770iaSnV7cOe/IsXz4hInc+sJ6zpw5hsNGlfGblzZw+ZnTukZPwYvfkViSS0/eVwLXFIlz24vrufyMaV3JJXjxu6U9wWWnpLWNxvn1Cxv47BmHMS6t7byVu2iMxPb7I7+5Pc5tz2/g7+dM4S9vbeO9s8ft93XOtROnjGD599+332ocDyys5XuPrATg3z9yLOOrSvjS7xfy/UdWcOKUEUTjSWLJTj79mwUcNb6yz+9VXBjimvNmUlhg3Dx/He3xJADHTR7BF949jXte38KkEaWcPmM0tzy3no+cOJGiwgJunr+OaMxre+ykaq48azp/fKOWBRt632Fx9sQqvnT2DO5fWNu1G2M4VMDV586gvLiQnz2zjmjMKzs8akIVV58zgwcWbeWVdXu62n7pHO/n7Q+vbeZL58xg3e5WFm5q4KpzZvCnN7dRWVLIBUeN5Zb565l77HhGloW589VNXHX2TDbsaWXBxgauPmdGIJM0A0ugzSwE3Ay8F9gKvGFmDzvnVqY1uxJodM4dbmafAH4IfDyoPv36xQ386MnVjCwL89hXzmbiiFIa22JceccbbG9qpz2R5DsXHw3A7S9t5IdPvt31V97kkWU0ReJ84Y432LY3SqQjwT/NPYpr/7CIt3e2UBIO8ezbuzlhygheWV/P1FFlOOd4eMl2NtS18tzqOqpKC6ksCdMYifHs27t57IazmTq6jOb2OFfeuZDN9RGao3G+f8mxANy9YAv/8dgqKooLefSGs5g2ppyW9jhf+v1CNu5pozES4z8+chwAf3yjln9/dCXlRSEeueEsZtRU0NaR4Iu/X8iGujbq2zr470u9EccHFm7lB4+upKwoxGnTRzF/dR1Pr9xN0jnW7W6lrqWDH112AuD91ftvD6+gNBzi4evfTV1rB1/741uMrihmT2sHjZEY/3vZCXztvsW8tqGeypIwf1u5k79++SyOHF9JezzJVXct5O2dLWxrjHLjx0/0kr3F2/h/f1lOcWEBf77u3cyeWEV7PMnVdy1i5Y5mahuj/OwTXttHl27nX/68nKLCAh669kw6Ep1cf89bjCgrojESY8OeNt7a0kiowIjEkry9s4X7rjqDosIC3trSyPX3vEl1aZjGSJydTe3c8umT+acHl/D0qt2MLAvzxPIdPHDNmRhw3d2Lutpub2rnts+egpnx9Mpd/NODSyksMErDId5z9Lj9fikNBQUFtt8fPlNGlXHzp07mlufW8b+XndCVTHzjvUeys6kjo4kr37n4KC49eTI33Psmr2+s55El23lm1W4eW7aDKaNKKSwoYNveKKt3NrOzqZ2W9gRjKouJxBI8vGQ7z62u47FlO5g8spRwyGu7akcLdS0dNEXj1PSyI9j2vVFW7mjhgavP4IdPvs3tL21kXFUxD/tJytxjx+Oc41sPLuWJ5Tt5ad0eHrjmDIoLQyzf1sS1f3iTWLKTkWVhLj5uAs45vv2nZTyxfAeHjS73f04jrK9r44W1dcQSnVSXhvnQCRNxzvHPDy3r+gwPXXdmRqUvMnBeDFnEqh3N1DZEumLII0u2889/XtZtDFmxvZnNDZGuGPL4sh18+6FlXTHk2EnVdCSSXPOHRSzd2sSGPa384pMn880HlvDM27sZURrm8WU7efDaMzh+8ghiiU6u+cMiFtfuZe3uFm79jBcX5q3cxTcfXEo4ZDxwzZmEzLj2D29SUVJIUzTOtr1RfvWZU7q+30aWFfHo0h3cd/UZFBcWcPVdi6goLqQ5Gqe2IcKvPzeHggLjudW7+fp9SwgVGPdVFjNn2igSSS/uvb6xgTc3e/3Y0xpjxfZmHl+2gwIzRpcXcdqM0SQ7HTfc8xavbqhn6dYm7vj8qYQKjFfW7eFrf3wLgCeX7+SxZTv4/aubeewrZ1NTWUxdSwdfuOMNdrd0kOh0fO09RwBwy3Pr+Mm8NUweWUqowNixt501O1vZ3NBGW0eS0RVFRGJJ/rpkO/NW7eKxpTsYXb6RI8dX8sr6et7Y1Mg9XzyNwlABCzc18OV73iLZ6RhVXsR5R46ls9PxjfsX88zbu1mwoYF7rzqdcKiAN7c08uW73yTR6RhZFubCo8fhnOMfH1jCvJW7eGX9Hu67+gzCoQIW1+7lursXEU86RpYV8d7ZXttvPrCEp1bs4p7Xt9AYiXNZDuatHMyBMeXyM6dR2xilsMD4zGlTMTOuO28mtzy3nqdW7GJmTTlfuXAWP31mLW/V7u3z++xu7mDh5gaKCkNs3NPKuKoSYolO/rJ4O4tr9/LIku0UFxZwzhE1zFu5i0eXbKe0KMS63a2Mry4h7rddsrWJR5ZsZ1xVcY/xMNV22bbm/druaelgwcYGRpaFeXtnC+OrS0gkHX9ZvJ3l25p4dOkOxlYWU1rktX11Qz1jKopZXLuXJVv3smxbE3sjcZb5bcMh48KjxvHkip3cv7CWsVXFvLVlL0tqm1ixvYnGSJwCg6vOmTmQ/6JuWVA7mpnZGcD3nHPv8x9/B8A5999pbZ7y27xqZoXATqDG9dKpOXPmuIULF2bUl+88tIyFmxrYsKeNM2aM5q0tjZSEQ4wqL6IpGmdvJM5Zs8bw7Nu7OXxsBQZs2NPG6TNGsaS2ieLCgq62jZEY58yq4Zm3dzNpRCnb9ka59TMnM3tCNR/4+Yu0tCf41w8czRfPngHA9x9Zwe9e3sTE6hIe+8rZjCwvorYhwgd+9iKFoQJGlxfR3B5nT2uM848cy9OrvB+OAjM21bdx8tSRrN7VggFjKoppaU9Q19rxjrab6yOcOHUEa3e14IAav+3ulnYuPHoc81bu3/aEKdWsr2ujoS3GRbPHMW/VLgDee/Q4/rZyFzNqygmZsbkhwvGTqtlU30Y86UgkOxlfXcLD15/FbS9s4KfPrO36Ovz3pcdx4dFjef9PXyKe7GRsZTFtHQm2N7Vz0Wz/vGPKCRUYWxoiHD2hiu17o7THk4yrKiESS7Jtb5T3HTOOp1bs3/aoCVXsamonEkvgHIwoD/PoDWdz7+tb+J8n3qaqpJDHvnI2S7bu5fp73mLSiFLKikLsbGqnuizMYzeczf0La/nPx1d19fdfP3A0l50ymQ/87CWa/XWUq0rCPHrDWTz01jb+/dGVTBtdRjhUwNbGKNPHlNPSEae2IcrvrnjXfiNZ+SQaS/LRW17m7Z0tfOC4CfziUyd1/VH01T8upihUwJ+uPZPjJlfTHk/y0VteYdWOZuYeM55ffubkruTnhnvfIhwyHrzmTE6YMqLH93t82Q6uu/vNrv+3K86cxnfefxQfu/VV1uxqYcrIMhKdjo172rq+d7r+/5vbqSguZGxlMasPaPutuUdx7XleUP2vx1dx2wsbGFdVzPjqUt7e0czUUWUkOx0b0s47sbqkawT0indP49OnHdZjv3tiZoucc3P69cUfhvoTs+9esJk7Xt4E0GsMOWpCFTubokRj3ceQ6WPKKSwwahsjHDmukl3NHURiiW7bpr6//t8HZ3PpSZP4wM9epKUjwfhu2qbHhRk15eyNxLtiSGWxF4v+/NY2fvDoyq7zfmvuUXzqtKl88OcvsrctjhmUFRXy2FfO4tGlO/i3h1dw2Ogyivw/MKeOKiMaT1LfGmNCdQntiSS1DVHmHjOeJ1fspKwoxCmHjeTFtXs4YlwF8aSjrqVjv7ap/k4dVUaxf8V0wohSOp1jQ10b5x5Rw4KN9VQUhxlZ5g0ctLTHOX3GaF5YW8fMGu/34fq6Vj50wkRu8v94eXDRVv7xgSUUFRbw5+vO5JiJ1URiCT5y88us2dXK2bPGsGhzI5FYsqu/k0eWUhoOsaOpndEVRZSGQ2xpiDBpRCmxZCeb6yNd/U213dnUzojyMBXFYTbtaWPyyFLiyU42pbVN/1mvKgkzoizMhrru246vKuHlb1/QNbI+nCT8EecFGxv4zsVHcfW5mSeEr6zbw2duX0Cng999/l2cf+RYkp2Oy3/7Oi+t28OJU0awfW+U3S0dvOfocTz79i46Hdx++RwuPHocnZ2OK+54gxfW1HHS1BFdA1Xd6ex0XHnnG8xfXccJU0bwwNVe20WbG/j4r14j0em49TMnM/fYCXR2Oq66ayFPr9rNcZOqefBabwDkzS2NfPxXrxJPuq7/w8riQo6fUs3L6+qZPaGq63fyBUeN5cW1dfu1LS8KcdLUkby6oZ4ZY8qZM20U/33pcRl/3XqK2UEm0JcBc51zX/QffxY4zTl3fVqb5X6brf7j9X6bPQec6yrgKoCpU6eesnnz5oz68otn17JyRzOjy4v55twjWba1iXsWbMHhffaPnDiJc46o4X+fWs2OJm+Ht1HlRXzzfUexYnsTdy/Y0rV18odPmMj5R43lf59czfamKO8+fEzXL9HXNtR7f12ff3jX5YJYopObnl7DB4+fuN+s39c3NnDnq5u6zvv+47wygv97ajW1jd4W0dWlRXzzfUeyoa6VO17ZRKffdu6xE7j42PH8399WU9uQahvmHy86kk31bfzu5X1t33fMeD5w3AR+PG8Nm+u9SWRVJWH+8X1HsqUhwvOr6/jKhbP4y1vbKCiAD58wiR//bTWb0tp+46Ij2L63ndtf2khhgXH9BYczs6aCZKfjxnlr2LCnlRMmj+Aq/zLJktq9/Oaljftd1rvs5Mnc9PQa1qUuARYX8g8XHcnu5g5ue3FDV9tzj6jhY6dM4aZn1rJut3+5v6iQb1x0BPWt3uX+AoPrzj+cI8ZV0tnpuHn+Ok6bMZpTp3ulNne9uolXN+y7XHTteTM5anwVzjl+/uw63t7ZzFHjq7jhAu//adWOZm59fj3OwTXnzmT2RK/tzfPXsXJHMwClYa88IRpP8rhfwlMYyt9FbDbXt3HPgi1cf8HhVKZdzr7zlU1MqC7Zb7JhbUOEP7y2mS9fcPh+l77venUTNZUlXZeze/OH1zbzyvo9TKwu5Ztzj6S4MMS2vVFunLeGiH8J8MhxVXzlwsO59/VaXlpXB0BhgXe5cFR5ET/52xra/Lazxlby1QtndW3lG0928tOn1zL32PGMqSjmJ/NW0+qvaHJ4TQVfe88RPLhoK8+t2d3Vpw8dP3G/y+t9lQ8J9EBj9hPLdvDI0u1dj3uKId9475Hsae3wyoAOiCE/fWYtaw+IIQ1tMX71/L62Zx1ewyfeNYWfP7uO1buamT2hqit+r9zezK9eWE/c3/TizJlj+PRpU/nFs+tYtXNfXPj6e2fR2pHgl895MeTqc2dwzMRqnHPc8tx6Vmxv4ohxlXzlAu/7bc2uFm6Zv45OB1edM4NjJ3ltf/n8epZvawK8EcmvXXgEHYkkN89fR8zvw7umjeKKM6dx2wsbmD2xipOmjuTnz6zlk6dOJeHHwo6Ed6n95KkjufKs6fz6xQ0s9kcpSwpD3HDhLJxz3Lewlq9eOIsFGxt4cOHWrt+HH5szhdOmj+JHT65md0s74A3I/NPco/Yrn/ntSxuZNqasq6wO9sWFGy6cxVtbGlm5vZmrzpnBHa9s6tqFryhUwJfP90oVb3pmTVcZwTETq7nuvJn8/tXNLNi4L35fd97hlBWFuOnptUTj3s9k6v/pD69tfkesrygu5Kan13bFhVSsf2DhVsZUFu3X3+Fmd0s7d7y8iWvOm7lfLM3EXxdvoyPRuV+ZS31rB796YQNXnjWdupYOnly+k6++ZxZPLN9JNJbg4+/aV/7W0Bbj1ufX8/l3T2NCde+b0TS2xfjl8+u54sxpTEwrq3t82Q4aI7H9BiCaInFufm4dnzvjsP3m+Dy5fAd1rTE+c9pUbnluPSdNHcExE6u5ef46Pnv6YURiSf6yeBtfvXAWz6+pY1dzO589/TBufX4Dx0+u5rjJ1fzvk6upb+tg9oQqrr9gVsZfs2GdQKfrz2iGiMhQkQ8JdDrFbBEZznqK2UEOoW0D0qfrT/af67aNX8JRjTeZUERERERkSAoygX4DmGVm082sCPgE8PABbR4GLvfvXwY821v9s4iIiIhIrgW2CodzLmFm1wNP4S1j91vn3Aoz+wGw0Dn3MHA7cJeZrQMa8JJsEREREZEhK9B1oJ1zjwOPH/Dcd9PutwMfC7IPIiIiIiLZlL/LCIiIiIiI9IMSaBERERGRDCiBFhERERHJgBJoEREREZEMBLaRSlDMrA7IbFur3BgD9LghzDCnzzY86bMNDYc552py3YnBMoxiNgyv76NM6bMNT/psuddtzB52CfRwYWYLD9XdxvTZhid9NpHeHcrfR/psw5M+29ClEg4RERERkQwogRYRERERyYAS6ODclusOBEifbXjSZxPp3aH8faTPNjzpsw1RqoEWEREREcmARqBFRERERDKgBFpEREREJANKoANkZv9rZm+b2VIz+7OZjch1n7LFzD5mZivMrNPMhu0yNOnMbK6ZrTazdWb27Vz3J1vM7LdmttvMlue6L9lmZlPMbL6ZrfS/H7+a6z7J8Ka4Pbwobg8/h0rcVgIdrHnAsc6544E1wHdy3J9sWg5cCryQ645kg5mFgJuBi4HZwCfNbHZue5U1dwBzc92JgCSAf3DOzQZOB758CP2/SW4obg8TitvD1iERt5VAB8g59zfnXMJ/+BowOZf9ySbn3Crn3Opc9yOLTgXWOec2OOdiwB+BS3Lcp6xwzr0ANOS6H0Fwzu1wzr3p328BVgGTctsrGc4Ut4cVxe1h6FCJ20qgB88XgCdy3Qnp0SSgNu3xVobhD3Q+M7NpwEnAghx3RQ4dittDm+L2MDec43Zhrjsw3JnZ08D4bg79i3Pur36bf8G7ZHH3YPZtoPry2USGAjOrAP4EfM0515zr/sjQprgtknvDPW4rgR4g59x7ejtuZlcAHwQudMNs0e2DfbZDzDZgStrjyf5zMsSZWRgvCN/tnHso1/2RoU9x+5ChuD1MHQpxWyUcATKzucA/AR92zkVy3R/p1RvALDObbmZFwCeAh3PcJzkIMzPgdmCVc+4nue6PDH+K28OK4vYwdKjEbSXQwfoFUAnMM7PFZnZrrjuULWb2UTPbCpwBPGZmT+W6TwPhTxq6HngKb0LD/c65FbntVXaY2b3Aq8CRZrbVzK7MdZ+y6N3AZ4EL/J+xxWb2/lx3SoY1xe1hQnF72Dok4ra28hYRERERyYBGoEVEREREMqAEWkREREQkA0qgRUREREQyoARaRERERCQDSqBFRAAz+62Z7Taz5Vk634/MbIWZrTKzn/lLN4mISBbkOmYrgZZhzcxGpy2Ds9PMtvn3W83sloDe82tm9rlejn/QzH4QxHtLoO4A5mbjRGZ2Jt5STccDxwLvAs7NxrlFhjPFbMmiO8hhzFYCLcOac67eOXeic+5E4FbgRv9xhXPuumy/n5kVAl8A7uml2WPAh8ysLNvvL8Fxzr0ANKQ/Z2YzzexJM1tkZi+a2VF9PR1QAhQBxUAY2JXVDosMQ4rZki25jtlKoOWQZGbnmdmj/v3vmdmd/g/TZjO71L9Us8z/QQv77U4xs+f9H7ynzGxCN6e+AHjTX8AfM/uKma00s6Vm9kcAf+vf5/C2Apbh7TbgBufcKcA/An0aIXPOvQrMB3b4t6ecc6sC66XIMKeYLVkyaDG7cIAdFRkuZgLnA7Pxdnf6O+fcP5nZn4EPmNljwM+BS5xzdWb2ceA/8UYu0r0bWJT2+NvAdOdch5mNSHt+IXA2cH8gn0YCZ2YVwJnAA2mlcMX+sUuB7i75bnPOvc/MDgeOBib7z88zs7Odcy8G3G2RQ4VitmRksGO2EmjJF0845+JmtgwIAU/6zy8DpgFH4tU9zfN/8EJ4f4UeaALelrEpS4G7zewvwF/Snt8NTMxe9yUHCoC9/qXm/TjnHgIe6uW1HwVec861ApjZE3jbJyuBFukbxWzJ1KDGbJVwSL7oAHDOdQJxt28P+068PyQNWJGqzXPOHeecu6ib80Tx6qRSPgDcDJwMvOHX2+G3iQbwOWSQOOeagY1m9jEA85zQx5dvAc41s0L/cvO57P9LXER6p5gtGRnsmK0EWsSzGqgxszMAzCxsZsd0024VcLjfpgCY4pybD3wLqAYq/HZHAFlZWkcGh5ndi3ep+Egz22pmVwKfBq40syXACuCSPp7uQWA93mjZEmCJc+6RALotkq8Us/NcrmO2SjhEAOdczMwuA35mZtV4Pxs34f0ApnsCuMu/HwL+4Lc34GfOub3+sfOB7wTdb8ke59wneziU8TJJzrkkcPXAeiQiPVHMllzHbNt3VURE+sKfxPJPzrm1PRwfB9zjnLtwcHsmIiIHUsyWICiBFsmQmR0JjPPXoOzu+LvwavYWD2rHRETkHRSzJQhKoEVEREREMqBJhCIiIiIiGVACLSIiIiKSASXQIiIiIiIZUAItIiIiIpIBJdAiIiIiIhn4/xN6NBKVzRBiAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 864x288 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# read channel\n",
+    "x_ch, y_ch = channel.read_waveform()\n",
+    "\n",
+    "# allow for 250 ms to not have it read to fast\n",
+    "sleep(0.25)\n",
+    "\n",
+    "# read math\n",
+    "x_math, y_math = function.read_waveform()\n",
+    "\n",
+    "# plot\n",
+    "fig, ax = plt.subplots(1, 2, sharey=True, figsize=(12, 4))\n",
+    "\n",
+    "ax[0].plot(x_ch, y_ch)\n",
+    "ax[0].set_xlabel(\"Time (s)\")\n",
+    "ax[0].set_ylabel(\"Signal (V)\")\n",
+    "ax[0].set_title(\"Channel readout\")\n",
+    "ax[1].plot(x_math, y_math)\n",
+    "ax[1].set_xlabel(\"Time (s)\")\n",
+    "ax[1].set_title(\"Average of the channel (math)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With a poorer signal generator, the average should look a lot smoother than the channel. To finish up the math section, let's turn off the math trace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "function.trace = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Measurements and statistics\n",
+    "\n",
+    "In addition to mathematical operations on channels, oscilloscopes can take measurements and display the statistics. Many measurement parameters are already implemented, check out the documentation and look for the `inst.MeasurementParameters` class. Currently, only measurement parameters that act on a single source are available.\n",
+    "\n",
+    "As an example, let us set up 2 measurements. Measurement 1 determines the rise time (10% to 90%), measurement 2 the fall time (80% to 20%) of the first channel readout. Setting up the measurement can be done as following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# assign the two measurements\n",
+    "msr1 = inst.measurement[0]\n",
+    "msr2 = inst.measurement[1]\n",
+    "\n",
+    "# turn on the measurements (only one is really necessary, the other one is turned on automatically!)\n",
+    "msr1.measurement_state = msr1.State.both\n",
+    "\n",
+    "# assign the measurement types and which source the measurement should be on\n",
+    "msr1.set_parameter(inst.MeasurementParameters.rise_time_10_90, 0)\n",
+    "msr2.set_parameter(inst.MeasurementParameters.fall_time_80_20, 0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The oscilloscope will now automatically set up these measurements and will start accumulating statistics. The statistics can be returned at any point, which will return a tuple containing 5 floats. These floats are:\n",
+    "\n",
+    " 1. Average\n",
+    " 2. Lowest value measured\n",
+    " 3. Highest value measured\n",
+    " 4. Standard deviation\n",
+    " 5. Number of sweeps\n",
+    " \n",
+    "These returns are not unitful, so you will need to know what was set up. For the rise and fall times, the returns will of course be in the form of time. SI units are always returned, in this case, seconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1.52152e-09, 1.49e-09, 1.56e-09, 2.553e-11, 4.0)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "msr1.statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(9.6247e-10, 9.02e-10, 1.01e-09, 2.415e-11, 24.0)"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "msr2.statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To start a new series of measurements, i.e., reset the number of sweeps, the following command can be executed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1.56e-09, 1.56e-09, 1.56e-09, 0.0, 1.0)"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "inst.clear_sweeps()\n",
+    "\n",
+    "# getting statistics for `msr1` again:\n",
+    "msr1.statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To delete the measurement parameters again and turn off the table, the following commands are used:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete parameters\n",
+    "msr1.delete()\n",
+    "msr2.delete()\n",
+    "\n",
+    "# turn off measurement\n",
+    "msr1.measurement_state = msr1.State.off"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Further information\n",
+    "\n",
+    "Please check out the documention on [readthedocs.io](https://instrumentkit.readthedocs.io/en/latest/) and feel free to open an issue on the github repository if you have any problems / feature requests."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/doc/source/apiref/index.rst
+++ b/doc/source/apiref/index.rst
@@ -30,7 +30,8 @@ Contents:
     qubitekk
     rigol
     srs
-    tektronix  
+    tektronix
+    teledyne
     thorlabs
     toptica
     yokogawa

--- a/doc/source/apiref/teledyne.rst
+++ b/doc/source/apiref/teledyne.rst
@@ -1,0 +1,15 @@
+..
+    TODO: put documentation license header here.
+    
+.. currentmodule:: instruments.teledyne
+    
+===============
+Teledyne-LeCroy
+===============
+
+:class:`MAUI` Oscilloscope Controller
+=======================================
+
+.. autoclass:: MAUI
+    :members:
+    :undoc-members:

--- a/instruments/__init__.py
+++ b/instruments/__init__.py
@@ -27,6 +27,7 @@ from . import qubitekk
 from . import rigol
 from . import srs
 from . import tektronix
+from . import teledyne
 from . import thorlabs
 from . import toptica
 from . import yokogawa

--- a/instruments/teledyne/__init__.py
+++ b/instruments/teledyne/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing Teledyne instruments
+"""
+
+
+from .maui import MAUI

--- a/instruments/teledyne/maui.py
+++ b/instruments/teledyne/maui.py
@@ -1,0 +1,1404 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Provides support for the Teledyne-Lecroy Oscilloscopes that use the
+MAUI interface.
+
+Development follows the IEEE 488.2 Command Reference from the MAUI
+Oscilloscopes Remote Control and Automation Manual, document number
+maui-remote-control-automation_10mar20.pdf
+
+Where possible, commands are sent using the enum_property, ... that
+are usually used for SCPI classes, even though, this is not an SCPI
+class.
+"""
+
+# IMPORTS #####################################################################
+
+from enum import Enum
+import numpy as np
+
+from instruments.abstract_instruments import (
+    Oscilloscope, OscilloscopeChannel, OscilloscopeDataSource
+)
+import instruments.units as u
+from instruments.util_fns import (
+    assume_units, enum_property, bool_property, ProxyList
+)
+
+# CLASSES #####################################################################
+
+
+# pylint: disable=too-many-lines,arguments-differ
+
+
+class MAUI(Oscilloscope):
+
+    """
+    Medium to high-end Teledyne-Lecroy Oscilloscopes are shipped with
+    the MAUI user interface. This class can be used to communicate with
+    these instruments.
+
+    By default, the IEEE 488.2 commands are used. However, commands
+    based on MAUI's `app` definition can be submitted too using the
+    appropriate send / query commands.
+
+    Your scope must be set up to communicate via LXI (VXI11) to be used
+    with pyvisa / pyvisa-py backend.
+
+    This class inherits from: `Oscilloscope`
+
+    Example usage (more examples below):
+        >>> import instruments as ik
+        >>> import instruments.units as u
+        >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+        >>> # start the trigger in automatic mode
+        >>> inst.run()
+        >>> print(inst.trigger_state)  # print the trigger state
+        <TriggerState.auto: 'AUTO'>
+        >>> # set timebase to 20 ns per division
+        >>> inst.time_div = u.Quantity(20, u.ns)
+        >>> # call the first oscilloscope channel
+        >>> channel = inst.channel[0]
+        >>> channel.trace = True  # turn the trace on
+        >>> channel.coupling = channel.Coupling.dc50  # coupling to 50 Ohm
+        >>> channel.scale = u.Quantity(1, u.V)  # vertical scale to 1V/division
+        >>> # transfer a waveform into xdat and ydat:
+        >>> xdat, ydat = channel.read_waveform()
+    """
+
+    # CONSTANTS #
+
+    # number of horizontal and vertical divisions on the scope
+    # HOR_DIVS = 10
+    # VERT_DIVS = 8
+
+    def __init__(self, filelike):
+        super(MAUI, self).__init__(filelike)
+
+        # turn off command headers -> for SCPI like behavior
+        self.sendcmd("COMM_HEADER OFF")
+
+        # constants
+        self._number_channels = 4
+        self._number_functions = 2
+        self._number_measurements = 6
+
+    # ENUMS #
+
+    class MeasurementParameters(Enum):
+        """
+        Enum containing valid measurement parameters that only require
+        one or more sources. Only single source parameters are currently
+        implemented.
+        """
+        amplitude = "AMPL"
+        area = "AREA"
+        base = "BASE"
+        delay = "DLY"
+        duty_cycle = "DUTY"
+        fall_time_80_20 = "FALL82"
+        fall_time_90_10 = "FALL"
+        frequency = "FREQ"
+        maximum = "MAX"
+        minimum = "MIN"
+        mean = "MEAN"
+        none = "NULL"
+        overshoot_pos = "OVSP"
+        overshoot_neg = "OVSN"
+        peak_to_peak = "PKPK"
+        period = "PER"
+        phase = "PHASE"
+        rise_time_20_80 = "RISE28"
+        rise_time_10_90 = "RISE"
+        rms = "RMS"
+        stdev = "SDEV"
+        top = "TOP"
+        width_50_pos = "WID"
+        width_50_neg = "WIDN"
+
+    class TriggerState(Enum):
+
+        """
+        Enum containing valid trigger state for the oscilloscope.
+        """
+        auto = "AUTO"
+        normal = "NORM"
+        single = "SINGLE"
+        stop = "STOP"
+
+    class TriggerType(Enum):
+        """Enum containing valid trigger state.
+
+        Availability depends on oscilloscope options. Please consult
+        your manual. Only simple types are currently included.
+
+        .. warning:: Some of the trigger types are untested and might
+            need further parameters in order to be appropriately set.
+        """
+        dropout = "DROPOUT"
+        edge = "EDGE"
+        glitch = "GLIT"
+        interval = "INTV"
+        pattern = "PA"
+        runt = "RUNT"
+        slew_rate = "SLEW"
+        width = "WIDTH"
+        qualified = "TEQ"
+        tv = "TV"
+
+    class TriggerSource(Enum):
+        """Enum containing valid trigger sources.
+
+        This is an enum for the default values.
+
+        .. note:: This class is initialized like this for four channels,
+            which is the default setting. If you change the number of
+            channels, `TriggerSource` will be recreated using the
+            routine `_create_trigger_source_enum`. This will make
+            further channels available to you or remove channels that
+            are not present in your setup.
+        """
+        c0 = "C1"
+        c1 = "C2"
+        c2 = "C3"
+        c3 = "C4"
+        ext = "EX"
+        ext5 = "EX5"
+        ext10 = "EX10"
+        etm10 = "ETM10"
+        line = "LINE"
+
+    def _create_trigger_source_enum(self):
+        """Create an Enum for the trigger source class.
+
+        Needs to be dynamically generated, in case channel number
+        changes!
+
+        .. note:: Not all trigger sources are available on all scopes.
+            Please consult the manual for your oscilloscope.
+        """
+        names = ['ext', 'ext5', 'ext10', 'etm10', 'line']
+        values = ['EX', 'EX5', 'EX10', 'ETM10', 'LINE']
+        # now add the channels
+        for it in range(self._number_channels):
+            names.append("c{}".format(it))
+            values.append("C{}".format(it+1))  # to send to scope
+        # create and store the enum
+        self.TriggerSource = Enum('TriggerSource', zip(names, values))
+
+    # CLASSES #
+
+    class DataSource(OscilloscopeDataSource):
+
+        """
+        Class representing a data source (channel, math, ref) on a MAUI
+        oscilloscope.
+
+        .. warning:: This class should NOT be manually created by the
+            user. It is designed to be initialized by the `MAUI` class.
+        """
+
+        # PROPERTIES #
+
+        @property
+        def name(self):
+            return self._name
+
+        # METHODS #
+
+        def read_waveform(self, bin_format=False, single=True):
+            """
+            Reads the waveform and returns an array of floats with the
+            data.
+
+            :param bin_format: Not implemented, always False
+            :type bin_format: bool
+            :param single: Run a single trigger? Default True. In case
+                a waveform from a channel is required, this option
+                is recommended to be set to True. This means that the
+                acquisition system is first stopped, a single trigger
+                is issued, then the waveform is transfered, and the
+                system is set back into the state it was in before.
+                If sampling math with multiple samples, set this to
+                false, otherwise the sweeps are cleared by the
+                oscilloscope prior when a single trigger command is
+                issued.
+            :type single: bool
+
+            :return: Data (time, signal) where time is in seconds and
+                signal in V
+            :rtype: ndarray
+
+            :raises NotImplementedError: Bin format was chosen, but
+                it is not implemented.
+
+            Example usage:
+                >>> import instruments as ik
+                >>> import instruments.units as u
+                >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+                >>> channel = inst.channel[0]  # set up channel
+                >>> xdat, ydat = channel.read_waveform()  # read waveform
+            """
+            if bin_format:
+                raise NotImplementedError("Bin format reading is currently "
+                                          "not implemented for the MAUI "
+                                          "routine.")
+
+            if single:
+                # get current trigger state (to reset after read)
+                trig_state = self._parent.trigger_state
+                # trigger state to single
+                self._parent.trigger_state = self._parent.TriggerState.single
+
+            # now read the data
+            retval = self.query("INSPECT? 'SIMPLE'")  # pylint: disable=E1101
+
+            # read the parameters to create time-base array
+            horiz_off = self.query("INSPECT? 'HORIZ_OFFSET'")  # pylint: disable=E1101
+            horiz_int = self.query("INSPECT? 'HORIZ_INTERVAL'")  # pylint: disable=E1101
+
+            if single:
+                # reset trigger
+                self._parent.trigger_state = trig_state
+
+            # format the string to appropriate data
+            dat_val = np.array(retval.replace('"', '').split(),
+                               dtype=np.float)
+
+            # format horizontal data into floats
+            horiz_off = float(horiz_off.replace('"', '').split(':')[1])
+            horiz_int = float(horiz_int.replace('"', '').split(':')[1])
+
+            # create time base
+            dat_time = np.arange(
+                horiz_off,
+                horiz_off + horiz_int * (len(dat_val)),
+                horiz_int
+            )
+
+            # fix length bug, sometimes dat_time is longer than dat_signal
+            if len(dat_time) > len(dat_val):
+                dat_time = dat_time[0:len(dat_val)]
+            else:  # in case the opposite is the case
+                dat_val = dat_val[0:len(dat_time)]
+
+            return np.stack((dat_time, dat_val))
+
+        trace = bool_property(
+            command="TRA",
+            doc="""
+            Gets/Sets if a given trace is turned on or off.
+            
+            Example usage:
+            
+            >>> import instruments as ik
+            >>> address = "TCPIP0::192.168.0.10::INSTR"
+            >>> inst = inst = ik.teledyne.MAUI.open_visa(address)
+            >>> channel = inst.channel[0]
+            >>> channel.trace = False
+            """
+        )
+
+    class Channel(DataSource, OscilloscopeChannel):
+
+        """
+        Class representing a channel on a MAUI oscilloscope.
+
+        .. warning:: This class should NOT be manually created by the
+            user. It is designed to be initialized by the `MAUI` class.
+        """
+
+        def __init__(self, parent, idx):
+            self._parent = parent
+            self._idx = idx + 1   # 1-based
+
+            # Initialize as a data source with name C{}.
+            super(MAUI.Channel, self).__init__(
+                self._parent,
+                "C{}".format(self._idx)
+            )
+
+        # ENUMS #
+
+        class Coupling(Enum):
+            """
+            Enum containing valid coupling modes for the oscilloscope
+            channel. 1 MOhm and 50 Ohm are included.
+            """
+            ac1M = "A1M"
+            dc1M = "D1M"
+            dc50 = "D50"
+            ground = "GND"
+
+        coupling = enum_property(
+            "CPL",
+            Coupling,
+            doc="""
+            Gets/sets the coupling for the specified channel.
+
+            Example usage:
+
+            >>> import instruments as ik
+            >>> address = "TCPIP0::192.168.0.10::INSTR"
+            >>> inst = inst = ik.teledyne.MAUI.open_visa(address)
+            >>> channel = inst.channel[0]
+            >>> channel.coupling = channel.Coupling.dc50
+            """
+        )
+
+        # PROPERTIES #
+
+        @property
+        def offset(self):
+            """
+            Sets/gets the vertical offset of the specified input
+            channel.
+
+            Example:
+                >>> import instruments as ik
+                >>> import instruments.units as u
+                >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+                >>> channel = inst.channel[0]  # set up channel
+                >>> channel.offset = u.Quantity(-1, u.V)
+            """
+            return u.Quantity(
+                float(self.query('OFST?')), u.V
+            )
+
+        @offset.setter
+        def offset(self, newval):
+            newval = assume_units(newval, 'V').rescale(u.V).magnitude
+            self.sendcmd('OFST {}'.format(newval))
+
+        @property
+        def scale(self):
+            """
+            Sets/Gets the vertical scale of the channel.
+
+            Example:
+                >>> import instruments as ik
+                >>> import instruments.units as u
+                >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+                >>> channel = inst.channel[0]  # set up channel
+                >>> channel.scale = u.Quantity(20, u.mV)
+            """
+            return u.Quantity(
+                float(self.query('VDIV?')), u.V
+            )
+
+        @scale.setter
+        def scale(self, newval):
+            newval = assume_units(newval, 'V').rescale(u.V).magnitude
+            self.sendcmd('VDIV {}'.format(newval))
+
+        # METHODS #
+
+        def sendcmd(self, cmd):
+            """
+            Wraps commands sent from property factories in this class
+            with identifiers for the specified channel.
+
+            :param str cmd: Command to send to the instrument
+            """
+            self._parent.sendcmd("C{}:{}".format(self._idx, cmd))
+
+        def query(self, cmd, size=-1):
+            """
+            Executes the given query. Wraps commands sent from property
+            factories in this class with identifiers for the specified
+            channel.
+
+            :param str cmd: String containing the query to
+                execute.
+            :param int size: Number of bytes to be read. Default is read
+                until termination character is found.
+            :return: The result of the query as returned by the
+                connected instrument.
+            :rtype: `str`
+            """
+            return self._parent.query("C{}:{}".format(self._idx, cmd),
+                                      size=size)
+
+    class Math(DataSource):
+
+        """
+        Class representing a function on a MAUI oscilloscope.
+
+        .. warning:: This class should NOT be manually created by the
+            user. It is designed to be initialized by the `MAUI` class.
+        """
+
+        def __init__(self, parent, idx):
+            self._parent = parent
+            self._idx = idx + 1   # 1-based
+
+            # Initialize as a data source with name C{}.
+            super(MAUI.Math, self).__init__(
+                self._parent,
+                "F{}".format(self._idx)
+            )
+
+        # CLASSES #
+
+        class Operators:
+            """
+            Sets the operator for a given channel.
+            Most operators need a source `src`. If the source is given
+            as an integer, it is assume that the a signal channel is
+            requested. If you want to select another math channel for
+            example, you will need to specify the source as a tuple:
+            Example: `src=('f', 0)` would represent the first function
+            channel (called F1 in the MAUI manual). A channel could be
+            selected by calling `src=('c', 1)`, which would request the
+            second channel (oscilloscope channel 2). Please consult the
+            oscilloscope manual / the math setup itself for further
+            possibilities.
+
+            .. note:: Your oscilloscope might not have all functions
+            that are described here. Also: Not all possibilities are
+            currently implemented. However, extension of this
+            functionality should be simple when following the given
+            structure
+            """
+
+            def __init__(self, parent):
+                self._parent = parent
+
+            # PROPERTIES #
+
+            @property
+            def current_setting(self):
+                """
+                Gets the current setting and returns it as the full
+                command, as sent to the scope when setting an operator.
+                """
+                return self._parent.query('DEF?')
+
+            # METHODS - OPERATORS #
+
+            def absolute(self, src):
+                """
+                Absolute of wave form.
+
+                :param int,tuple src: Source, see info above
+                """
+                src_str = _source(src)
+                send_str = "'ABS({})'".format(src_str)
+                self._send_operator(send_str)
+
+            def average(self, src, average_type='summed', sweeps=1000):
+                """
+                Average of wave form.
+
+                :param int,tuple src: Source, see info above
+                :param str average_type: `summed` or `continuous`
+                :param int sweeps: In summed mode, how many sweeps to
+                    collect. In `continuous` mode the weight of each
+                    sweep is equal to 1/`1`sweeps`
+                """
+                src_str = _source(src)
+
+                avgtp_str = 'SUMMED'
+                if average_type == 'continuous':
+                    avgtp_str = 'CONTINUOUS'
+
+                send_str = "'AVG({})',AVERAGETYPE,{},SWEEPS,{}".format(
+                    src_str,
+                    avgtp_str,
+                    sweeps
+                )
+
+                self._send_operator(send_str)
+
+            def derivative(self, src, vscale=1e6, voffset=0,
+                           autoscale=True):
+                """
+                Derivative of waveform using subtraction of adjacent
+                samples. If vscale and voffset are unitless, V/s are
+                assumed.
+
+                :param int,tuple src: Source, see info above
+                :param float vscale: vertical units to display (V/s)
+                :param float voffset: vertical offset (V/s)
+                :param bool autoscale: auto scaling of vscale, voffset?
+                """
+                src_str = _source(src)
+
+                vscale = assume_units(vscale, u.V/u.s).rescale(
+                    u.V/u.s
+                ).magnitude
+
+                voffset = assume_units(voffset, u.V/u.s).rescale(
+                    u.V/u.s
+                ).magnitude
+
+                autoscale_str = 'OFF'
+                if autoscale:
+                    autoscale_str = 'ON'
+
+                send_str = "'DERI({})',VERSCALE,{},VEROFFSET,{}," \
+                           "ENABLEAUTOSCALE,{}".format(
+                               src_str,
+                               vscale,
+                               voffset,
+                               autoscale_str)
+
+                self._send_operator(send_str)
+
+            def difference(self, src1, src2, vscale_variable=False):
+                """
+                Difference between two sources, `src1`-`src2`.
+
+                :param int,tuple src1: Source 1, see info above
+                :param int,tuple src2: Source 2, see info above
+                :param bool vscale_variable: Horizontal and vertical
+                    scale for addition and subtraction must be
+                    identical. Allow for variable vertical scale in
+                    result?
+                """
+                src1_str = _source(src1)
+                src2_str = _source(src2)
+
+                opt_str = 'FALSE'
+                if vscale_variable:
+                    opt_str = 'TRUE'
+
+                send_str = "'{}-{}',VERSCALEVARIABLE,{}".format(
+                    src1_str,
+                    src2_str,
+                    opt_str
+                )
+
+                self._send_operator(send_str)
+
+            def envelope(self, src, sweeps=1000, limit_sweeps=True):
+                """
+                Highest and lowest Y values at each X in N sweeps.
+
+                :param int,tuple src: Source, see info above
+                :param int sweeps: Number of sweeps
+                :param bool limit_sweeps: Limit the number of sweeps?
+                """
+                src_str = _source(src)
+                send_str = "'EXTR({})',SWEEPS,{},LIMITNUMSWEEPS,{}".\
+                    format(src_str, sweeps, limit_sweeps)
+                self._send_operator(send_str)
+
+            def eres(self, src, bits=0.5):
+                """
+                Smoothing function defined by extra bits of resolution.
+
+                :param int,tuple src: Source, see info above
+                :param float bits: Number of bits. Possible values are
+                    (0.5, 1.0, 1.5, 2.0, 2.5, 3.0). If not in list,
+                    default to 0.5.
+                """
+                src_str = _source(src)
+
+                bits_possible = (0.5, 1.0, 1.5, 2.0, 2.5, 3.0)
+                if bits not in bits_possible:
+                    bits = 0.5
+
+                send_str = "'ERES({})',BITS,{}".format(src_str, bits)
+
+                self._send_operator(send_str)
+
+            def fft(self, src, type='powerspectrum', window='vonhann',
+                    suppress_dc=True):
+                """
+                Fast Fourier Transform of signal.
+
+                :param int,tuple src: Source, see info above
+                :param str type: Type of power spectrum. Possible
+                    options are: ['real', 'imaginary', 'magnitude',
+                    'phase', 'powerspectrum', 'powerdensity'].
+                    Default: 'powerspectrum'
+                :param str window: Window. Possible options are:
+                    ['blackmanharris', 'flattop', 'hamming',
+                    'rectangular', 'vonhann']. Default: 'vonhann'
+                :param bool suppress_dc: Supress DC?
+                """
+                src_str = _source(src)
+
+                type_possible = ['real', 'imaginary', 'magnitude', 'phase',
+                                 'powerspectrum', 'powerdensity']
+                if type not in type_possible:
+                    type = 'powerspectrum'
+
+                window_possible = ['blackmanharris', 'flattop', 'hamming',
+                                   'rectangular', 'vonhann']
+                if window not in window_possible:
+                    window = 'vonhann'
+
+                if suppress_dc:
+                    opt = 'ON'
+                else:
+                    opt = 'OFF'
+
+                send_str = "'FFT({})',TYPE,{},WINDOW,{},SUPPRESSDC,{}".format(
+                    src_str,
+                    type,
+                    window,
+                    opt
+                )
+
+                self._send_operator(send_str)
+
+            def floor(self, src, sweeps=1000, limit_sweeps=True):
+                """
+                Lowest vertical value at each X value in N sweeps.
+
+                :param int,tuple src: Source, see info above
+                :param int sweeps: Number of sweeps
+                :param bool limit_sweeps: Limit the number of sweeps?
+                """
+                src_str = _source(src)
+                send_str = "'FLOOR({})',SWEEPS,{},LIMITNUMSWEEPS,{}".\
+                    format(src_str, sweeps, limit_sweeps)
+                self._send_operator(send_str)
+
+            def integral(self, src, multiplier=1, adder=0, vscale=1e-3,
+                         voffset=0):
+                """
+                Integral of waveform.
+
+                :param int,tuple src: Source, see info above
+                :param float multiplier: 0 to 1e15
+                :param float adder: 0 to 1e15
+                :param float vscale: vertical units to display (Wb)
+                :param float voffset: vertical offset (Wb)
+                """
+                src_str = _source(src)
+
+                vscale = assume_units(vscale, u.Wb).rescale(
+                    u.Wb
+                ).magnitude
+
+                voffset = assume_units(voffset, u.Wb).rescale(
+                    u.Wb
+                ).magnitude
+
+                send_str = "'INTG({}),MULTIPLIER,{},ADDER,{},VERSCALE,{}," \
+                           "VEROFFSET,{}".format(
+                               src_str,
+                               multiplier,
+                               adder,
+                               vscale,
+                               voffset)
+
+                self._send_operator(send_str)
+
+            def invert(self, src):
+                """
+                Inversion of waveform (-waveform).
+
+                :param int,tuple src: Source, see info above
+                """
+                src_str = _source(src)
+                self._send_operator("'-{}'".format(src_str))
+
+            def product(self, src1, src2):
+                """
+                Product of two sources, `src1`*`src2`.
+
+                :param int,tuple src1: Source 1, see info above
+                :param int,tuple src2: Source 2, see info above
+                """
+                src1_str = _source(src1)
+                src2_str = _source(src2)
+
+                send_str = "'{}*{}'".format(
+                    src1_str,
+                    src2_str
+                )
+
+                self._send_operator(send_str)
+
+            def ratio(self, src1, src2):
+                """
+                Ratio of two sources, `src1`/`src2`.
+
+                :param int,tuple src1: Source 1, see info above
+                :param int,tuple src2: Source 2, see info above
+                """
+                src1_str = _source(src1)
+                src2_str = _source(src2)
+
+                send_str = "'{}/{}'".format(
+                    src1_str,
+                    src2_str
+                )
+
+                self._send_operator(send_str)
+
+            def reciprocal(self, src):
+                """
+                Reciprocal of waveform (1/waveform).
+
+                :param int,tuple src: Source, see info above
+                """
+                src_str = _source(src)
+                self._send_operator("'1/{}'".format(src_str))
+
+            def rescale(self, src, multiplier=1, adder=0):
+                """
+                Rescales the waveform (w) in the style.
+                multiplier * w + adder
+
+                :param int,tuple src: Source, see info above
+                :param float multiplier: multiplier
+                :param float adder: addition in V or assuming V
+                """
+                src_str = _source(src)
+
+                adder = assume_units(adder, u.V).rescale(
+                    u.V
+                ).magnitude
+
+                send_str = "'RESC({})',MULTIPLIER,{},ADDER,{}".format(
+                    src_str,
+                    multiplier,
+                    adder
+                )
+
+                self._send_operator(send_str)
+
+            def sinx(self, src):
+                """
+                Sin(x)/x interpolation to produce 10x output samples.
+
+                :param int,tuple src: Source, see info above
+                """
+                src_str = _source(src)
+                self._send_operator("'SINX({})'".format(src_str))
+
+            def square(self, src):
+                """
+                Square of the input waveform.
+
+                :param int,tuple src: Source, see info above
+                """
+                src_str = _source(src)
+                self._send_operator("'SQR({})'".format(src_str))
+
+            def square_root(self, src):
+                """
+                Square root of the input waveform.
+
+                :param int,tuple src: Source, see info above
+                """
+                src_str = _source(src)
+                self._send_operator("'SQRT({})'".format(src_str))
+
+            def sum(self, src1, src2):
+                """
+                Product of two sources, `src1`+`src2`.
+
+                :param int,tuple src1: Source 1, see info above
+                :param int,tuple src2: Source 2, see info above
+                """
+                src1_str = _source(src1)
+                src2_str = _source(src2)
+
+                send_str = "'{}+{}'".format(
+                    src1_str,
+                    src2_str
+                )
+
+                self._send_operator(send_str)
+
+            def trend(self, src, vscale=1, center=0, autoscale=True):
+                """
+                Trend of the values of a paramter
+
+                :param float vscale: vertical units to display (V)
+                :param float center: center (V)
+                """
+                src_str = _source(src)
+
+                vscale = assume_units(vscale, u.V).rescale(
+                    u.V
+                ).magnitude
+
+                center = assume_units(center, u.V).rescale(
+                    u.V
+                ).magnitude
+
+                if autoscale:
+                    auto_str = 'ON'
+                else:
+                    auto_str = 'OFF'
+
+                send_str = "'TREND({})',VERSCALE,{},CENTER,{}," \
+                           "AUTOFINDSCALE,{}".format(src_str, vscale,
+                                                     center, auto_str)
+
+                self._send_operator(send_str)
+
+            def roof(self, src, sweeps=1000, limit_sweeps=True):
+                """
+                Highest vertical value at each X value in N sweeps.
+
+                :param int,tuple src: Source, see info above
+                :param int sweeps: Number of sweeps
+                :param bool limit_sweeps: Limit the number of sweeps?
+                """
+                src_str = _source(src)
+                send_str = "'ROOF({})',SWEEPS,{},LIMITNUMSWEEPS,{}".\
+                    format(src_str, sweeps, limit_sweeps)
+                self._send_operator(send_str)
+
+            def _send_operator(self, cmd):
+                """
+                Set the operator in the scope.
+                """
+                self._parent.sendcmd("{},{}".format(
+                    "DEFINE EQN",
+                    cmd))
+
+        # PROPERTIES #
+
+        @property
+        def operator(self):
+            """Get an operator object to set use to do math.
+
+            Example:
+                >>> import instruments as ik
+                >>> import instruments.units as u
+                >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+                >>> channel = inst.channel[0]  # set up channel
+                >>> # set up the first math function
+                >>> function = inst.math[0]
+                >>> function.trace = True  # turn the trace on
+                >>> # set function to average the first oscilloscope channel
+                >>> function.operator.average(0)
+            """
+            return self.Operators(self)
+
+        # METHODS #
+
+        def clear_sweeps(self):
+            """Clear the sweeps in a measurement."""
+            self._parent.clear_sweeps()   # re-implemented because handy
+
+        def sendcmd(self, cmd):
+            """
+            Wraps commands sent from property factories in this class
+            with identifiers for the specified channel.
+
+            :param str cmd: Command to send to the instrument
+            """
+            self._parent.sendcmd("F{}:{}".format(self._idx, cmd))
+
+        def query(self, cmd, size=-1):
+            """
+            Executes the given query. Wraps commands sent from property
+            factories in this class with identifiers for the specified
+            channel.
+
+            :param str cmd: String containing the query to
+                execute.
+            :param int size: Number of bytes to be read. Default is read
+                until termination character is found.
+            :return: The result of the query as returned by the
+                connected instrument.
+            :rtype: `str`
+            """
+            return self._parent.query("F{}:{}".format(self._idx, cmd),
+                                      size=size)
+
+    class Measurement:
+
+        """
+        Class representing a measurement on a MAUI oscilloscope.
+
+        .. warning:: This class should NOT be manually created by the
+            user. It is designed to be initialized by the `MAUI` class.
+        """
+
+        def __init__(self, parent, idx):
+            self._parent = parent
+            self._idx = idx + 1   # 1-based
+
+        # CLASSES #
+
+        class State(Enum):
+            """
+            Enum class for Measurement Parameters. Required to turn it
+            on or off.
+            """
+            statistics = "CUST,STAT"
+            histogram_icon = "CUST,HISTICON"
+            both = "CUST,BOTH"
+            off = "CUST,OFF"
+
+        # PROPERTIES #
+
+        measurement_state = enum_property(
+            command="PARM",
+            enum=State,
+            doc="""
+                Sets / Gets the measurement state. Valid values are
+                'statistics', 'histogram_icon', 'both', 'off'.
+                
+                Example:
+                    >>> import instruments as ik
+                    >>> import instruments.units as u
+                    >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+                    >>> msr1 = inst.measurement[0]  # set up first measurement
+                    >>> msr1.measurement_state = msr1.State.both  # set to `both`
+                """
+        )
+
+        @property
+        def statistics(self):
+            """
+            Gets the statistics for the selected parameter. The scope
+            must be in `My_Measure` mode.
+
+            :return tuple: (average, low, high, sigma, sweeps)
+            :return type: (float, float, float, float, float)
+            """
+            ret_str = self.query("PAST? CUST, P{}".format(self._idx)).\
+                rstrip().split(',')
+            # parse the return string -> put into dictionary:
+            ret_dict = {ret_str[it]: ret_str[it+1] for it in
+                        range(0, len(ret_str), 2)}
+            try:
+                stats = (
+                    float(ret_dict['AVG']),
+                    float(ret_dict['LOW']),
+                    float(ret_dict['HIGH']),
+                    float(ret_dict['SIGMA']),
+                    float(ret_dict['SWEEPS'])
+                )
+            except ValueError:  # some statistics did not return
+                raise ValueError("Some statistics did not return useful "
+                                 "values. The return string is {}. Please "
+                                 "ensure that statistics is properly turned "
+                                 "on.".format(ret_str))
+            return stats
+
+        # METHODS #
+
+        def delete(self):
+            """
+            Deletes the given measurement parameter.
+            """
+            self.sendcmd("PADL {}".format(self._idx))
+
+        def set_parameter(self, param, src):
+            """
+            Sets a given parameter that should be measured on this
+            given channel.
+
+            :param `inst.MeasurementParameters` param: The parameter
+                to set from the given enum list.
+            :param int,tuple src: Source, either as an integer if a
+                channel is requested (e.g., src=0 for Channel 1) or as
+                a tuple in the form, e.g., ('F', 1). Here 'F' refers
+                to a mathematical function and 1 would take the second
+                mathematical function `F2`.
+
+            :raises AttributeError: The chosen parameter is invalid.
+
+            Example:
+                >>> import instruments as ik
+                >>> import instruments.units as u
+                >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+                >>> msr1 = inst.measurement[0]  # set up first measurement
+                >>> # setup to measure the 10 - 90% rise time on first channel
+                >>> msr1.set_parameter(inst.MeasurementParameters.rise_time_10_90, 0)
+            """
+            if not isinstance(param, self._parent.MeasurementParameters):
+                raise AttributeError("Parameter must be selected from {}.".
+                                     format(self._parent.MeasurementParameters)
+                                     )
+
+            send_str = \
+                "PACU {},{},{}".format(
+                    self._idx,
+                    param.value,
+                    _source(src)
+                )
+
+            self.sendcmd(send_str)
+
+        def sendcmd(self, cmd):
+            """
+            Wraps commands sent from property factories in this class
+            with identifiers for the specified channel.
+
+            :param str cmd: Command to send to the instrument
+            """
+            self._parent.sendcmd(cmd)
+
+        def query(self, cmd, size=-1):
+            """
+            Executes the given query. Wraps commands sent from property
+            factories in this class with identifiers for the specified
+            channel.
+
+            :param str cmd: String containing the query to
+                execute.
+            :param int size: Number of bytes to be read. Default is read
+                until termination character is found.
+            :return: The result of the query as returned by the
+                connected instrument.
+            :rtype: `str`
+            """
+            return self._parent.query(cmd,
+                                      size=size)
+
+    # PROPERTIES #
+
+    @property
+    def channel(self):
+        """
+        Gets an iterator or list for easy Pythonic access to the various
+        channel objects on the oscilloscope instrument.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> channel = inst.channel[0]  # get first channel
+        """
+        return ProxyList(self, self.Channel, range(self.number_channels))
+
+    @property
+    def math(self):
+        """
+        Gets an iterator or list for easy Pythonic access to the various
+        math data sources objects on the oscilloscope instrument.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> math = inst.math[0]  # get first math function
+        """
+        return ProxyList(self, self.Math, range(self.number_functions))
+
+    @property
+    def measurement(self):
+        """
+        Gets an iterator or list for easy Pythonic access to the various
+        measurement data sources objects on the oscilloscope instrument.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> msr = inst.measurement[0]  # get first measurement parameter
+        """
+        return ProxyList(self, self.Measurement,
+                         range(self.number_measurements))
+
+    @property
+    def ref(self):
+        raise NotImplementedError
+
+    # PROPERTIES
+
+    @property
+    def number_channels(self):
+        """
+        Sets/Gets the number of channels available on the specific
+        oscilloscope. Defaults to 4.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.number_channel = 2  # for a oscilloscope with 2 channels
+            >>> inst.number_channel
+            2
+        """
+        return self._number_channels
+
+    @number_channels.setter
+    def number_channels(self, newval):
+        self._number_channels = newval
+        # create new trigger source enum
+        self._create_trigger_source_enum()
+
+    @property
+    def number_functions(self):
+        """
+        Sets/Gets the number of functions available on the specific
+        oscilloscope. Defaults to 2.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.number_functions = 4  # for a oscilloscope with 4 math functions
+            >>> inst.number_functions
+            4
+        """
+        return self._number_functions
+
+    @number_functions.setter
+    def number_functions(self, newval):
+        self._number_functions = newval
+
+    @property
+    def number_measurements(self):
+        """
+        Sets/Gets the number of measurements available on the specific
+        oscilloscope. Defaults to 6.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.number_measurements = 4  # for a oscilloscope with 4 measurements
+            >>> inst.number_measurements
+            4
+        """
+        return self._number_measurements
+
+    @number_measurements.setter
+    def number_measurements(self, newval):
+        self._number_measurements = newval
+
+    @property
+    def self_test(self):
+        """
+        Runs an oscilloscope's internal self test and returns the
+        result. The self-test includes testing the hardware of all
+        channels, the timebase and the trigger circuits.
+        Hardware failures are identified by a unique binary code in the
+        returned <status> number. A status of 0 indicates that no
+        failures occurred.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.self_test()
+        """
+        # increase timeout x 10 to allow for enough time to test
+        self.timeout *= 10
+        retval = self.query("*TST?")
+        self.timeout /= 10
+        return retval
+
+    @property
+    def show_id(self):
+        """
+        Gets the scope information and returns it. The response
+        comprises manufacturer, oscilloscope model, serial number,
+        and firmware revision level.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.show_id()
+        """
+        return self.query("*IDN?")
+
+    @property
+    def show_options(self):
+        """
+        Gets and returns oscilloscope options: installed software or
+        hardware that is additional to the standard instrument
+        configuration. The response consists of a series of response
+        fields listing all the installed options.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.show_options()
+        """
+        return self.query("*OPT?")
+
+    @property
+    def time_div(self):
+        """
+        Sets/Gets the time per division, modifies the timebase setting.
+        Unitful.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.time_div = u.Quantity(200, u.ns)
+        """
+        return u.Quantity(
+            float(self.query('TDIV?')), u.s
+        )
+
+    @time_div.setter
+    def time_div(self, newval):
+        newval = assume_units(newval, 's').rescale(u.s).magnitude
+        self.sendcmd('TDIV {}'.format(newval))
+
+    # TRIGGER PROPERTIES
+
+    trigger_state = enum_property(
+        command="TRMD",
+        enum=TriggerState,
+        doc="""
+            Sets / Gets the trigger state. Valid values are are defined
+            in `TriggerState` enum class.
+            
+            Example:
+                >>> import instruments as ik
+                >>> import instruments.units as u
+                >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+                >>> inst.trigger_state = inst.TriggerState.normal
+            """
+    )
+
+    @property
+    def trigger_delay(self):
+        """
+        Sets/Gets the trigger offset with respect to time zero (i.e.,
+        a horizontal shift). Unitful.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.trigger_delay = u.Quantity(60, u.ns)
+
+        """
+        return u.Quantity(
+            float(self.query('TRDL?')), u.s
+        )
+
+    @trigger_delay.setter
+    def trigger_delay(self, newval):
+        newval = assume_units(newval, 's').rescale(u.s).magnitude
+        self.sendcmd('TRDL {}'.format(newval))
+
+    @property
+    def trigger_source(self):
+        """Sets / Gets the trigger source.
+
+        .. note:: The `TriggerSource` class is dynamically generated
+        when the number of channels is switched. The above shown class
+        is only the default! Channels are added and removed, as
+        required.
+
+        .. warning:: If a trigger type is currently set on the
+            oscilloscope that is not implemented in this class,
+            setting the source will fail. The oscilloscope is set up
+            such that the the trigger type and source are set at the
+            same time. However, for convenience, these two properties
+            are split apart here.
+
+        :return: Trigger source.
+        :rtype: Member of `TriggerSource` class.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.trigger_source = inst.TriggerSource.ext  # external trigger
+        """
+        retval = self.query('TRIG_SELECT?').split(',')[2]
+        return self.TriggerSource(retval)
+
+    @trigger_source.setter
+    def trigger_source(self, newval):
+        curr_trig_typ = self.trigger_type
+        cmd = 'TRIG_SELECT {},SR,{}'.format(curr_trig_typ.value,
+                                            newval.value)
+        self.sendcmd(cmd)
+
+    @property
+    def trigger_type(self):
+        """Sets / Gets the trigger type.
+
+        .. warning:: If a trigger source is currently set on the
+            oscilloscope that is not implemented in this class,
+            setting the source will fail. The oscilloscope is set up
+            such that the the trigger type and source are set at the
+            same time. However, for convenience, these two properties
+            are split apart here.
+
+        :return: Trigger type.
+        :rtype: Member of `TriggerType` enum class.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.trigger_type = inst.TriggerType.edge  # trigger on edge
+        """
+        retval = self.query('TRIG_SELECT?').split(',')[0]
+        return self.TriggerType(retval)
+
+    @trigger_type.setter
+    def trigger_type(self, newval):
+        curr_trig_src = self.trigger_source
+        cmd = 'TRIG_SELECT {},SR,{}'.format(newval.value,
+                                            curr_trig_src.value)
+        self.sendcmd(cmd)
+
+    # METHODS #
+
+    def clear_sweeps(self):
+        """Clears the sweeps in a measurement.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.clear_sweeps()
+        """
+        self.sendcmd("CLEAR_SWEEPS")
+
+    def force_trigger(self):
+        """Forces a trigger event to occur on the attached oscilloscope.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.force_trigger()
+        """
+        self.sendcmd("ARM")
+
+    def run(self):
+        """Enables the trigger for the oscilloscope and sets it to auto.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.run()
+        """
+        self.trigger_state = self.TriggerState.auto
+
+    def stop(self):
+        """ Disables the trigger for the oscilloscope.
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.teledyne.MAUI.open_visa("TCPIP0::192.168.0.10::INSTR")
+            >>> inst.stop()
+        """
+        self.sendcmd("STOP")
+
+
+# STATICS #
+
+
+def _source(src):
+    """Stich the source together properly and return it."""
+    if isinstance(src, int):
+        return 'C{}'.format(src + 1)
+    elif isinstance(src, tuple) and len(src) == 2:
+        return '{}{}'.format(src[0].upper(), int(src[1]) + 1)
+    else:
+        raise ValueError('An invalid source was specified. '
+                         'Source must be an integer or a tuple of '
+                         'length 2.')

--- a/instruments/teledyne/maui.py
+++ b/instruments/teledyne/maui.py
@@ -44,7 +44,9 @@ class MAUI(Oscilloscope):
     appropriate send / query commands.
 
     Your scope must be set up to communicate via LXI (VXI11) to be used
-    with pyvisa / pyvisa-py backend.
+    with pyvisa. Make sure that either the pyvisa-py or the NI-VISA
+    backend is installed. Please see the pyvisa documentation for more
+    information.
 
     This class inherits from: `Oscilloscope`
 

--- a/instruments/tests/test_teledyne/test_maui.py
+++ b/instruments/tests/test_teledyne/test_maui.py
@@ -1,0 +1,1099 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the Thorlabs TC200
+"""
+
+# IMPORTS ####################################################################
+
+import numpy as np
+import pytest
+
+import instruments as ik
+import instruments.units as u
+from instruments.tests import expected_protocol
+
+# TESTS ######################################################################
+
+
+# pylint: disable=too-many-lines,redefined-outer-name,protected-access
+
+
+# PYTEST FIXTURES FOR INITIALIZATION #
+
+
+@pytest.fixture
+def init():
+    """Returns the initialization command that is sent to MAUI Scope."""
+    return "COMM_HEADER OFF"
+
+
+# TEST ENUM GENERATION #
+
+def test_create_trigger_source_enum(init):
+    """Generate trigger source enum when number of channels changes."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.number_channels = 42
+
+        # existence of new channels, but not more
+        assert "c41" in osc.TriggerSource.__members__
+        assert "c42" not in osc.TriggerSource.__members__
+
+        # proper name generation
+        assert osc.TriggerSource["c41"].value == "C42"
+
+
+# TEST DATA SOURCE CLASS #
+
+
+def test_maui_data_source_name(init):
+    """Return the name of the channel in the data source."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.math[0].name == 'F1'
+        assert osc.channel[1].name == 'C2'
+
+
+def test_maui_data_source_read_waveform(init):
+    """Return a numpy array of a waveform."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'TRMD?',
+                'TRMD SINGLE',
+                "C1:INSPECT? 'SIMPLE'",
+                "C1:INSPECT? 'HORIZ_OFFSET'",
+                "C1:INSPECT? 'HORIZ_INTERVAL'",
+                'TRMD AUTO'
+            ],
+            [
+                'AUTO',
+                '"  1.   2.   3.   4.  "',
+                "HORIZ_OFFSET       : 0.   ",
+                "HORIZ_INTERVAL     : 2.5        "
+            ],
+            sep="\n"
+    ) as osc:
+        wf = np.array(
+            [
+                [0., 2.5, 5., 7.5],
+                [1., 2., 3., 4.]
+            ]
+        )
+        assert (osc.channel[0].read_waveform() == wf).all()
+
+
+def test_maui_data_source_read_waveform_different_length(init):
+    """BF: Stacking return arrays with different length.
+
+    Depending on rounding issues, time and data arrays can have
+    different lengths. Shorten to the shorter one by cutting the longer
+    one from the end.
+    """
+    faulty_dataset_str = []
+    faulty_dataset_int = []
+    for it in range(402):  # 402 datapoints will make the error
+        faulty_dataset_str.append(str(it))
+        faulty_dataset_int.append(it)
+    return_data_string = '"   ' + '   '.join(faulty_dataset_str) + '   "'
+
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'TRMD?',
+                'TRMD SINGLE',
+                "C1:INSPECT? 'SIMPLE'",
+                "C1:INSPECT? 'HORIZ_OFFSET'",
+                "C1:INSPECT? 'HORIZ_INTERVAL'",
+                'TRMD AUTO'
+            ],
+            [
+                'AUTO',
+                return_data_string,
+                "HORIZ_OFFSET       : 9.8895e-06   ",
+                "HORIZ_INTERVAL     : 5e-10        "
+            ],
+            sep="\n"
+    ) as osc:
+        # create the signal that we want to get returned
+        signal = np.array(faulty_dataset_int)
+        h_offset = 9.8895e-06
+        h_interval = 5e-10
+        timebase = np.arange(
+            h_offset,
+            h_offset + h_interval * (len(signal)),
+            h_interval
+        )
+
+        # now cut timebase to the length of the signal
+        timebase = timebase[0:len(signal)]
+
+        # create return dataset
+        dataset_return = np.stack((timebase, signal))
+        assert (osc.channel[0].read_waveform() == dataset_return).all()
+
+
+def test_maui_data_source_read_waveform_math(init):
+    """Return a numpy array of a waveform for multiple sweeps."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "C1:INSPECT? 'SIMPLE'",
+                "C1:INSPECT? 'HORIZ_OFFSET'",
+                "C1:INSPECT? 'HORIZ_INTERVAL'",
+            ],
+            [
+                '"  1.   2.   3.   4.  "',
+                "HORIZ_OFFSET       : 0.   ",
+                "HORIZ_INTERVAL     : 2.5        "
+            ],
+            sep="\n"
+    ) as osc:
+        wf = np.array(
+            [
+                [0., 2.5, 5., 7.5],
+                [1., 2., 3., 4.]
+            ]
+        )
+        assert (osc.channel[0].read_waveform(single=False) == wf).all()
+
+
+def test_maui_data_source_read_waveform_bin_format(init):
+    """Raise a not implemented error."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        with pytest.raises(NotImplementedError):
+            osc.channel[0].read_waveform(bin_format=True)
+
+
+def test_maui_data_source_trace(init):
+    """Get / Set the on/off status of a trace."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'F1:TRA?',
+                'C1:TRA ON',
+                'C3:TRA OFF'
+            ],
+            [
+                'ON'
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.math[0].trace
+        osc.channel[0].trace = True
+        osc.channel[2].trace = False
+
+
+# TEST CHANNEL CLASS #
+
+
+def test_maui_channel_init(init):
+    """Initialize a MAUI Channel."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.channel[0]._idx == 1
+        assert isinstance(osc.channel[0]._parent, ik.teledyne.MAUI)
+
+
+def test_maui_channel_coupling(init):
+    """Get / Set MAUI Channel coupling."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'C3:CPL?',
+                'C3:CPL A1M'
+            ],
+            [
+                'D50'
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.channel[2].coupling == osc.channel[2].Coupling.dc50
+        osc.channel[2].coupling = osc.channel[2].Coupling.ac1M
+
+
+def test_maui_channel_offset(init):
+    """Get / Set MAUI Channel offset."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'C1:OFST?',
+                'C1:OFST 0.2',
+                'C3:OFST 2'
+            ],
+            [
+                '1'
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.channel[0].offset == u.Quantity(1, u.V)
+        osc.channel[0].offset = u.Quantity(200, u.mV)
+        osc.channel[2].offset = 2
+
+
+def test_maui_channel_scale(init):
+    """Get / Set MAUI Channel scale."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'C2:VDIV?',
+                'C1:VDIV 2.0',
+                'C2:VDIV 0.4'
+            ],
+            [
+                '1'
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.channel[1].scale == u.Quantity(1, u.V)
+        osc.channel[0].scale = u.Quantity(2000, u.mV)
+        osc.channel[1].scale = 0.4
+
+
+# TEST MATH CLASS #
+
+
+def test_maui_math_init(init):
+    """Initialize math channel."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.math[0]._idx == 1
+        assert isinstance(osc.math[0]._parent, ik.teledyne.MAUI)
+
+
+def test_maui_math_clear_sweeps(init):
+    """Clears math channel sweeps."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'CLEAR_SWEEPS'
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].clear_sweeps()
+
+
+# TEST MATH CLASS OPERATORS #
+
+
+def test_maui_math_op_current_settings(init):
+    """Return the current settings as oscilloscope string."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'F1:DEF?'
+            ],
+            [
+                'bla bla bla'  # answer unimportant
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.math[0].operator.current_setting == 'bla bla bla'
+
+
+def test_maui_math_op_absolute(init):
+    """Set math channel, absolute operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'ABS(C1)'"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.absolute(0)
+
+
+def test_maui_math_op_average(init):
+    """Set math channel, average operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'AVG(C1)',AVERAGETYPE,SUMMED,SWEEPS,1000",
+                "F1:DEFINE EQN,'AVG(C2)',AVERAGETYPE,CONTINUOUS,SWEEPS,100"
+
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.average(0)
+        osc.math[0].operator.average(1, average_type='continuous', sweeps=100)
+
+
+def test_maui_math_op_derivative(init):
+    """Set math channel, derivative operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'DERI(C1)',VERSCALE,1000000.0,"
+                "VEROFFSET,0,ENABLEAUTOSCALE,ON",
+                "F1:DEFINE EQN,'DERI(C3)',VERSCALE,5.0,"
+                "VEROFFSET,1.0,ENABLEAUTOSCALE,OFF"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.derivative(0)
+        osc.math[0].operator.derivative(
+            2,
+            vscale=u.Quantity(5000, u.mV / u.s),
+            voffset=u.Quantity(60, u.V / u.min),
+            autoscale=False
+        )
+
+
+def test_maui_math_op_difference(init):
+    """Set math channel, difference operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'C1-C3',VERSCALEVARIABLE,FALSE",
+                "F1:DEFINE EQN,'C1-C3',VERSCALEVARIABLE,TRUE"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.difference(0, 2)
+        osc.math[0].operator.difference(0, 2, vscale_variable=True)
+
+
+def test_maui_math_op_envelope(init):
+    """Set math channel, envelope operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'EXTR(C1)',SWEEPS,1000,LIMITNUMSWEEPS,True",
+                "F1:DEFINE EQN,'EXTR(F2)',SWEEPS,10,LIMITNUMSWEEPS,False"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.envelope(0)
+        osc.math[0].operator.envelope(('f', 1), sweeps=10, limit_sweeps=False)
+
+
+def test_maui_math_op_eres(init):
+    """Set math channel, eres operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'ERES(C1)',BITS,0.5",
+                "F1:DEFINE EQN,'ERES(C1)',BITS,3",
+                "F1:DEFINE EQN,'ERES(C1)',BITS,0.5"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.eres(0)
+        osc.math[0].operator.eres(0, 3)
+        osc.math[0].operator.eres(0, 28)
+
+
+def test_maui_math_op_fft(init):
+    """Set math channel, fft operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'FFT(C1)',TYPE,powerspectrum,"
+                "WINDOW,vonhann,SUPPRESSDC,ON",
+                "F1:DEFINE EQN,'FFT(C1)',TYPE,real,"
+                "WINDOW,flattop,SUPPRESSDC,OFF",
+                "F1:DEFINE EQN,'FFT(C1)',TYPE,powerspectrum,"
+                "WINDOW,vonhann,SUPPRESSDC,ON"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.fft(0)
+        osc.math[0].operator.fft(0, type='real', window='flattop',
+                                 suppress_dc=False)
+        osc.math[0].operator.fft(0, type='inv str', window='inv str',
+                                 suppress_dc=1)
+
+
+def test_maui_math_op_floor(init):
+    """Set math channel, floor operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'FLOOR(C1)',SWEEPS,1000,LIMITNUMSWEEPS,True",
+                "F1:DEFINE EQN,'FLOOR(C1)',SWEEPS,10,LIMITNUMSWEEPS,False"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.floor(0)
+        osc.math[0].operator.floor(0, sweeps=10, limit_sweeps=False)
+
+
+def test_maui_math_op_integral(init):
+    """Set math channel, integral operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'INTG(C1),MULTIPLIER,1,ADDER,0,"
+                "VERSCALE,0.001,VEROFFSET,0",
+                "F1:DEFINE EQN,'INTG(C4),MULTIPLIER,10,ADDER,0.5,"
+                "VERSCALE,1,VEROFFSET,0.001",
+                "F1:DEFINE EQN,'INTG(C4),MULTIPLIER,10,ADDER,0.5,"
+                "VERSCALE,1,VEROFFSET,0.001"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.integral(0)
+        osc.math[0].operator.integral(3, multiplier=10, adder=0.5,
+                                      vscale=u.Quantity(1, u.Wb),
+                                      voffset=u.Quantity(0.001, u.Wb))
+        osc.math[0].operator.integral(3, multiplier=10, adder=0.5,
+                                      vscale=1, voffset=0.001)
+
+
+def test_maui_math_op_invert(init):
+    """Set math channel, invert operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'-C1'"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.invert(0)
+
+
+def test_maui_math_op_product(init):
+    """Set math channel, product operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'C1*C3'"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.product(0, 2)
+
+
+def test_maui_math_op_ratio(init):
+    """Set math channel, ratio operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'C1/C3'"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.ratio(0, 2)
+
+
+def test_maui_math_op_reciprocal(init):
+    """Set math channel, reciprocal operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'1/C3'"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.reciprocal(2)
+
+
+def test_maui_math_op_rescale(init):
+    """Set math channel, rescale operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'RESC(C3)',MULTIPLIER,1,ADDER,0",
+                "F1:DEFINE EQN,'RESC(C3)',MULTIPLIER,10.3,ADDER,1.3"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.rescale(2)
+        osc.math[0].operator.rescale(2, multiplier=10.3, adder=1.3)
+
+
+def test_maui_math_op_sinx(init):
+    """Set math channel, sin(x)/x operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'SINX(C3)'"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.sinx(2)
+
+
+def test_maui_math_op_square(init):
+    """Set math channel, square operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'SQR(C3)'"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.square(2)
+
+
+def test_maui_math_op_square_root(init):
+    """Set math channel, square root operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'SQRT(C3)'"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.square_root(2)
+
+
+def test_maui_math_op_sum(init):
+    """Set math channel, sum operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'C3+C1'"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.sum(2, 0)
+
+
+def test_maui_math_op_trend(init):
+    """Set math channel, trend operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'TREND(C1)',VERSCALE,1,CENTER,0,"
+                "AUTOFINDSCALE,ON",
+                "F1:DEFINE EQN,'TREND(C2)',VERSCALE,2,CENTER,1,"
+                "AUTOFINDSCALE,OFF",
+                "F1:DEFINE EQN,'TREND(C2)',VERSCALE,2,CENTER,1,"
+                "AUTOFINDSCALE,ON"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.trend(0)
+        osc.math[0].operator.trend(1, vscale=u.Quantity(2, u.V),
+                                   center=u.Quantity(1, u.V),
+                                   autoscale=False)
+        osc.math[0].operator.trend(1, vscale=2, center=1, autoscale=True)
+
+
+def test_maui_math_op_roof(init):
+    """Set math channel, roof operator."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "F1:DEFINE EQN,'ROOF(C1)',SWEEPS,1000,LIMITNUMSWEEPS,True",
+                "F1:DEFINE EQN,'ROOF(C1)',SWEEPS,10,LIMITNUMSWEEPS,False"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.math[0].operator.roof(0)
+        osc.math[0].operator.roof(0, sweeps=10, limit_sweeps=False)
+
+
+# TEST MEASUREMENT CLASS #
+
+
+def test_maui_measurement_init(init):
+    """Initialize measurement class."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.measurement[0]._idx == 1
+        assert isinstance(osc.measurement[0]._parent, ik.teledyne.MAUI)
+
+
+def test_maui_measurement_state(init):
+    """Get / Set measurement state."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "PARM?",
+                "PARM CUST,HISTICON"
+            ],
+            [
+                "CUST,OFF"
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.measurement[0].measurement_state == \
+               osc.measurement[0].State.off
+        osc.measurement[0].measurement_state = \
+            osc.measurement[0].State.histogram_icon
+
+
+def test_maui_measurement_statistics_error(init):
+    """Raise ValueError if statistics cannot be gathered."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "PAST? CUST, P1"
+            ],
+            [
+                "CUST,P1,NULL,C3,AVG,UNDEF,HIGH,UNDEF,LAST,UNDEF,LOW,UNDEF,"
+                "SIGMA,UNDEF,SWEEPS,0"
+            ],
+            sep="\n"
+    ) as osc:
+        with pytest.raises(ValueError):
+            print(osc.measurement[0].statistics)
+
+
+def test_maui_measurement_statistics(init):
+    """Get statistics for given measurement."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "PAST? CUST, P1"
+            ],
+            [
+                "CUST,P1,MEAN,C3,AVG,10,HIGH,20,LAST,30,LOW,40,SIGMA,50,"
+                "SWEEPS,42"
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.measurement[0].statistics == (10., 40., 20., 50., 42.)
+
+
+def test_maui_measurement_delete(init):
+    """Delete a given measurement."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "PADL 1"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.measurement[0].delete()
+
+
+def test_maui_measurement_set_parameter(init):
+    """Set a specific parameter."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "PACU 1,AMPL,C3"
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.measurement[0].set_parameter(osc.MeasurementParameters.amplitude,
+                                         2)
+
+
+def test_maui_measurement_set_invalid_parameter(init):
+    """Set a specific parameter."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        with pytest.raises(AttributeError):
+            osc.measurement[0].set_parameter('amplitude', 2)
+
+
+# TEST CLASS PROPERTIES AND METHODS #
+
+
+def test_maui_ref(init):
+    """Reference class in oscillioscope is not implemented."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        with pytest.raises(NotImplementedError):
+            assert osc.ref
+
+
+def test_maui_number_channels(init):
+    """Set / Get number of channels."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.number_channels = 42
+        assert osc.number_channels == 42
+
+
+def test_maui_number_functions(init):
+    """Set / Get number of functions."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.number_functions = 42
+        assert osc.number_functions == 42
+
+
+def test_maui_number_measurements(init):
+    """Set / Get number of measurements."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.number_measurements = 42
+        assert osc.number_measurements == 42
+
+
+def test_maui_self_test(init):
+    """Runs an oscilloscope self test."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "*TST?"
+            ],
+            [
+                "*TST 0"
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.self_test == "*TST 0"  # Status: OK
+
+
+def test_maui_show_id(init):
+    """Displays oscilloscope ID."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "*IDN?"
+            ],
+            [
+                "*IDN LECROY,WAVEMASTER,WM01000,3.3.0"
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.show_id == "*IDN LECROY,WAVEMASTER,WM01000,3.3.0"
+
+
+def test_maui_show_options(init):
+    """Displays oscilloscope options."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                "*OPT?"
+            ],
+            [
+                "*OPT 0"
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.show_options == "*OPT 0"  # no options installed
+
+
+def test_maui_time_div(init):
+    """Get / Set time per division."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'TDIV?',
+                'TDIV 0.001'
+            ],
+            [
+                '1'
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.time_div == u.Quantity(1, u.s)
+        osc.time_div = u.Quantity(1, u.ms)
+
+
+def test_maui_trigger_state(init):
+    """Get / Set trigger state."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'TRMD?',
+                'TRMD SINGLE'
+            ],
+            [
+                'AUTO'
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.trigger_state == osc.TriggerState.auto
+        osc.trigger_state = osc.TriggerState.single
+
+
+def test_maui_trigger_delay(init):
+    """Get / Set trigger delay."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'TRDL?',
+                'TRDL 0.001',
+                'TRDL 1'
+            ],
+            [
+                '0.001'
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.trigger_delay == u.Quantity(1, u.ms)
+        osc.trigger_delay = u.Quantity(1, u.ms)
+        osc.trigger_delay = 1
+
+
+def test_maui_trigger_source(init):
+    """Get / Set trigger source."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'TRIG_SELECT?',
+                'TRIG_SELECT?',
+                'TRIG_SELECT EDGE,SR,EX'
+            ],
+            [
+                'EDGE,SR,C1,HT,OFF',
+                'EDGE,SR,C1,HT,OFF'
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.trigger_source == osc.TriggerSource.c0
+        osc.trigger_source = osc.TriggerSource.ext
+
+
+def test_maui_trigger_type(init):
+    """Get / Set trigger type."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'TRIG_SELECT?',
+                'TRIG_SELECT?',
+                'TRIG_SELECT EDGE,SR,C3'
+            ],
+            [
+                'RUNT,SR,C3,HT,OFF',
+                'EDGE,SR,C3,HT,OFF'
+            ],
+            sep="\n"
+    ) as osc:
+        assert osc.trigger_type == osc.TriggerType.runt
+        osc.trigger_type = osc.TriggerType.edge
+
+
+def test_maui_clear_sweeps(init):
+    """Clear the sweeps."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'CLEAR_SWEEPS'
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.clear_sweeps()
+
+
+def test_maui_force_trigger(init):
+    """Force a trigger."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'ARM'
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.force_trigger()
+
+
+def test_maui_run(init):
+    """Run the measurement in automatic trigger state."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'TRMD AUTO'
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.run()
+
+
+def test_maui_stop(init):
+    """Stop the acquisition."""
+    with expected_protocol(
+            ik.teledyne.MAUI,
+            [
+                init,
+                'STOP'
+            ],
+            [
+            ],
+            sep="\n"
+    ) as osc:
+        osc.stop()
+
+
+# STATIC FUNCTIONS #
+
+
+def test_source_stichting_integer():
+    """Source stiching when an integer is given."""
+    assert ik.teledyne.maui._source(3) == "C4"
+
+
+def test_source_stiching_tuple():
+    """Source stiching when a tuple is given."""
+    assert ik.teledyne.maui._source(('p', 0)) == "P1"
+    assert ik.teledyne.maui._source(('P', 0)) == "P1"
+
+
+def test_source_stiching_value_error():
+    """Raise a value error if anything else."""
+    with pytest.raises(ValueError):
+        ik.teledyne.maui._source(3.14)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 pyserial
 pyvisa>=1.9
-pyvisa-py
 quantities>=0.12.1
 python-vxi11>=0.8
 pyusb

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 pyserial
 pyvisa>=1.9
+pyvisa-py
 quantities>=0.12.1
 python-vxi11>=0.8
 pyusb


### PR DESCRIPTION
Changes:
- maui.py and associated folder structure created
- Communication via pyvisa-py: requirements.txt extended
  - Requires LXI support of oscilloscope
- test suite with full coverage of all new functions
- Inherits from `Oscilloscope`
  - read_waveform has additional argument to allow grabbing math traces
    in a useful way (see docstring)
- Implemented features are:
  - Trigger control: Trigger sources enum class is automatically
    regenerated when user changes number of channel on their specific
    oscilloscope
  - Channel control
  - Math function
  - Measurement control
  - Data Sources subclass
- Extensive doc strings with notes and warnings
  - Not all scopes will have all functions available
  - User needs to insure that functions are available on their MAUI
    oscilloscope
- Updated documentation
- Added a detailed jupyter notebook in examples folder
- tested and linted

To keep in mind:
- `numpy` is currently a requirement -> as in `Oscilloscope` parent class. Could be changed now, however, parent class requires a numpy array to be returned for `read_waveform`.
- `read_waveform` has an additional argument that is not in the parent class. Reasonable default given, see docstring.
- Please check the auto generation of the enum class for the trigger sources. Is this the best way of allowing for dynamically generated class? Reason to implement it this way is to account for differenet numbers of channels.