### PR TITLE
Enhancements to SRS DG645 test suite and class

### DIFF
--- a/instruments/srs/srsdg645.py
+++ b/instruments/srs/srsdg645.py
@@ -56,12 +56,15 @@ class _SRSDG645Channel:
         Formatted as a two-tuple of the reference and the delay time.
         For example, ``(SRSDG645.Channels.A, u.Quantity(10, "ps"))``
         indicates a delay of 10 picoseconds from delay channel A.
+
+        :units: Assume seconds if no units given.
         """
         resp = self._ddg.query("DLAY?{}".format(int(self._chan))).split(",")
         return SRSDG645.Channels(int(resp[0])), u.Quantity(float(resp[1]), "s")
 
     @delay.setter
     def delay(self, newval):
+        newval = (newval[0], assume_units(newval[1], u.s))
         self._ddg.sendcmd("DLAY {},{},{}".format(
             int(self._chan),
             int(newval[0].idx),
@@ -331,6 +334,7 @@ class SRSDG645(SCPIInstrument):
 
     @holdoff.setter
     def holdoff(self, newval):
+        newval = assume_units(newval, u.s)
         self.sendcmd("HOLD {}".format(newval.rescale(u.s).magnitude))
 
     @property
@@ -381,11 +385,14 @@ class SRSDG645(SCPIInstrument):
         Gets/sets the burst period. The burst period sets the time
         between delay cycles during a burst. The burst period may
         range from 100 ns to 2000 – 10 ns in 10 ns steps.
+
+        :units: Assume seconds if no units given.
         """
         return u.Quantity(float(self.query("BURP?")), u.s)
 
     @burst_period.setter
     def burst_period(self, newval):
+        newval = assume_units(newval, u.s)
         self.sendcmd("BURP {}".format(newval.rescale(u.s).magnitude))
 
     @property
@@ -395,9 +402,12 @@ class SRSDG645(SCPIInstrument):
         delays the first burst pulse relative to the trigger by the
         burst delay. The burst delay may range from 0 ps to < 2000 s
         with a resolution of 5 ps.
+
+        :units: Assume seconds if no units given.
         """
         return u.Quantity(float(self.query("BURD?")), u.s)
 
     @burst_delay.setter
     def burst_delay(self, newval):
+        newval = assume_units(newval, u.s)
         self.sendcmd("BURD {}".format(newval.rescale(u.s).magnitude))

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -15,6 +15,8 @@ from instruments.tests import expected_protocol, make_name_test, unit_eq
 
 # TESTS ######################################################################
 
+# pylint: disable=protected-access
+
 test_srsdg645_name = make_name_test(ik.srs.SRSDG645)
 
 
@@ -30,6 +32,16 @@ def test_srsdg645_channel_init():
         ik.srs.srsdg645._SRSDG645Channel(42, 0)
 
 
+def test_srsdg645_channel_init_channel_value():
+    """
+    _SRSDG645Channel: Ensure the correct channel value is used when
+    passing on a SRSDG645.Channels instance as the `chan` value.
+    """
+    ddg = ik.srs.SRSDG645.open_test()  # test connection
+    chan = ik.srs.srsdg645.SRSDG645.Channels.B  # select a channel manually
+    assert ik.srs.srsdg645._SRSDG645Channel(ddg, chan)._chan == 3
+
+
 def test_srsdg645_channel_delay():
     """
     SRSDG645: Get / set delay.
@@ -42,7 +54,7 @@ def test_srsdg645_channel_delay():
                 "DLAY 5,4,10"
             ],
             [
-            "0,42"
+                "0,42"
             ],
     ) as ddg:
         ref, t = ddg.channel["A"].delay


### PR DESCRIPTION
Trying to put some code where my mouth is :wink: (#246): With the hardware present I went through the `srsdg645.py` file and extended the test suite to increase the coverage. Every routine now has a test. The only uncovered line is 96-97:

```python
if isinstance(filelike, GPIBCommunicator):
    filelike.strip = 2
``` 

While going through the class I noticed a few inconsistencies. Several routines ha no `assume_units()` call included, while some others did. I extended all of those routines (and the respective tests) to contain an `assume_units` call, defaulting to SI units when none were given. Details on which routines in commit message below.

One test was renamed and restructured, since it didn't test at all what it was named after... Now it does, and is formatted like every other test.