### PR TITLE
Tests rigolds1000

### DIFF
--- a/instruments/rigol/rigolds1000.py
+++ b/instruments/rigol/rigolds1000.py
@@ -109,19 +109,19 @@ class RigolDS1000Series(SCPIInstrument, Oscilloscope):
 
         coupling = enum_property("COUP", lambda: RigolDS1000Series.Coupling)
 
-        bw_limit = bool_property("BWL", "ON", "OFF")
-        display = bool_property("DISP", "ON", "OFF")
-        invert = bool_property("INV", "ON", "OFF")
+        bw_limit = bool_property("BWL", inst_true="ON", inst_false="OFF")
+        display = bool_property("DISP", inst_true="ON", inst_false="OFF")
+        invert = bool_property("INV", inst_true="ON", inst_false="OFF")
 
         # TODO: :CHAN<n>:OFFset
         # TODO: :CHAN<n>:PROBe
         # TODO: :CHAN<n>:SCALe
 
-        filter = bool_property("FILT", "ON", "OFF")
+        filter = bool_property("FILT", inst_true="ON", inst_false="OFF")
 
         # TODO: :CHAN<n>:MEMoryDepth
 
-        vernier = bool_property("VERN", "ON", "OFF")
+        vernier = bool_property("VERN", inst_true="ON", inst_false="OFF")
 
     # PROPERTIES #
 
@@ -193,7 +193,9 @@ class RigolDS1000Series(SCPIInstrument, Oscilloscope):
     #
     # Many of the :KEY: commands are not yet implemented as methods.
 
-    panel_locked = bool_property(":KEY:LOCK", "ON", "OFF")
+    # FIXME: According to the manual, the next should be "ENAB" and "DIS"
+    # instead of "ON" and "OFF"
+    panel_locked = bool_property(":KEY:LOCK", inst_true="ON", inst_false="OFF")
 
     def release_panel(self):
         # TODO: better name?

--- a/instruments/rigol/rigolds1000.py
+++ b/instruments/rigol/rigolds1000.py
@@ -37,14 +37,6 @@ class RigolDS1000Series(SCPIInstrument, Oscilloscope):
         average = "AVER"
         peak_detect = "PEAK"
 
-    class Coupling(Enum):
-        """
-        Enum containing valid coupling modes for the Rigol DS1000
-        """
-        ac = "AC"
-        dc = "DC"
-        ground = "GND"
-
     # INNER CLASSES #
 
     class DataSource(OscilloscopeDataSource):
@@ -79,6 +71,15 @@ class RigolDS1000Series(SCPIInstrument, Oscilloscope):
         .. warning:: This class should NOT be manually created by the user. It
             is designed to be initialized by the `RigolDS1000Series` class.
         """
+
+        class Coupling(Enum):
+            """
+            Enum containing valid coupling modes for the Rigol DS1000
+            """
+            ac = "AC"
+            dc = "DC"
+            ground = "GND"
+
         def __init__(self, parent, idx):
             self._parent = parent
             self._idx = idx + 1  # Rigols are 1-based.
@@ -107,7 +108,7 @@ class RigolDS1000Series(SCPIInstrument, Oscilloscope):
             """
             return self._parent.query(":CHAN{}:{}".format(self._idx, cmd))
 
-        coupling = enum_property("COUP", lambda: RigolDS1000Series.Coupling)
+        coupling = enum_property("COUP", Coupling)
 
         bw_limit = bool_property("BWL", inst_true="ON", inst_false="OFF")
         display = bool_property("DISP", inst_true="ON", inst_false="OFF")

--- a/instruments/rigol/rigolds1000.py
+++ b/instruments/rigol/rigolds1000.py
@@ -194,9 +194,8 @@ class RigolDS1000Series(SCPIInstrument, Oscilloscope):
     #
     # Many of the :KEY: commands are not yet implemented as methods.
 
-    # FIXME: According to the manual, the next should be "ENAB" and "DIS"
-    # instead of "ON" and "OFF"
-    panel_locked = bool_property(":KEY:LOCK", inst_true="ON", inst_false="OFF")
+    panel_locked = bool_property(":KEY:LOCK", inst_true="ENAB",
+                                 inst_false="DIS")
 
     def release_panel(self):
         # TODO: better name?

--- a/instruments/tests/test_rigol/test_rigolds1000.py
+++ b/instruments/tests/test_rigol/test_rigolds1000.py
@@ -323,10 +323,10 @@ def test_panel_locked():
             ik.rigol.RigolDS1000Series,
             [
                 ":KEY:LOCK?",
-                ":KEY:LOCK OFF"
+                ":KEY:LOCK DIS"
             ],
             [
-                "ON"
+                "ENAB"
             ]
     ) as osc:
         assert osc.panel_locked

--- a/instruments/tests/test_rigol/test_rigolds1000.py
+++ b/instruments/tests/test_rigol/test_rigolds1000.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the Rigol DS1000
+"""
+
+# IMPORTS ####################################################################
+
+import numpy as np
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol, make_name_test
+
+# TESTS ######################################################################
+
+# pylint: disable=protected-access
+
+
+test_rigolds1000_name = make_name_test(ik.rigol.RigolDS1000Series)
+
+
+# TEST CHANNEL #
+
+
+def test_channel_initialization():
+    """Ensure correct initialization of channel object."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+            ],
+            [
+            ]
+    ) as osc:
+        channel = osc.channel[0]
+        assert channel._parent is osc
+        assert channel._idx == 1
+
+
+def test_channel_coupling():
+    """Get / set channel coupling."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":CHAN1:COUP?",
+                ":CHAN2:COUP DC"
+            ],
+            [
+                "AC"
+            ]
+    ) as osc:
+        assert osc.channel[0].coupling == osc.Coupling.ac
+        osc.channel[1].coupling = osc.Coupling.dc
+
+
+def test_channel_bw_limit():
+    """Get / set instrument bw limit."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":CHAN2:BWL?",
+                ":CHAN1:BWL ON"
+            ],
+            [
+                "OFF"
+            ]
+    ) as osc:
+        assert not osc.channel[1].bw_limit
+        osc.channel[0].bw_limit = True
+
+
+def test_channel_display():
+    """Get / set instrument display."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":CHAN2:DISP?",
+                ":CHAN1:DISP ON"
+            ],
+            [
+                "OFF"
+            ]
+    ) as osc:
+        assert not osc.channel[1].display
+        osc.channel[0].display = True
+
+
+def test_channel_invert():
+    """Get / set instrument invert."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":CHAN2:INV?",
+                ":CHAN1:INV ON"
+            ],
+            [
+                "OFF"
+            ]
+    ) as osc:
+        assert not osc.channel[1].invert
+        osc.channel[0].invert = True
+
+
+def test_channel_filter():
+    """Get / set instrument filter."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":CHAN2:FILT?",
+                ":CHAN1:FILT ON"
+            ],
+            [
+                "OFF"
+            ]
+    ) as osc:
+        assert not osc.channel[1].filter
+        osc.channel[0].filter = True
+
+
+def test_channel_vernier():
+    """Get / set instrument vernier."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":CHAN2:VERN?",
+                ":CHAN1:VERN ON"
+            ],
+            [
+                "OFF"
+            ]
+    ) as osc:
+        assert not osc.channel[1].vernier
+        osc.channel[0].vernier = True
+
+
+def test_channel_name():
+    """Get channel name - DataSource property."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+            ],
+            [
+            ]
+    ) as osc:
+        assert osc.channel[0].name == "CHAN1"
+
+
+def test_channel_read_waveform():
+    """Read waveform of channel object."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":WAV:DATA? CHAN2"
+            ],
+            [
+                b"#210" + bytes.fromhex("00000001000200030004") + b"0"
+            ]
+    ) as osc:
+        np.testing.assert_array_equal(
+            osc.channel[1].read_waveform(),
+            [0, 1, 2, 3, 4]
+        )
+
+
+# TEST MATH #
+
+
+def test_math_name():
+    """Ensure correct naming of math object."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+            ],
+            [
+            ]
+    ) as osc:
+        assert osc.math.name == "MATH"
+
+
+def test_math_read_waveform():
+    """Read waveform of of math object."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":WAV:DATA? MATH"
+            ],
+            [
+                b"#210" + bytes.fromhex("00000001000200030004") + b"0"
+            ]
+    ) as osc:
+        np.testing.assert_array_equal(
+            osc.math.read_waveform(),
+            [0, 1, 2, 3, 4]
+        )
+
+
+# TEST REF DATASOURCE #
+
+
+def test_ref_name():
+    """Ensure correct naming of ref object."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+            ],
+            [
+            ]
+    ) as osc:
+        assert osc.ref.name == "REF"
+
+
+def test_ref_read_waveform_raises_error():
+    """Ensure error raising when reading waveform of REF channel."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+            ],
+            [
+            ]
+    ) as osc:
+        with pytest.raises(NotImplementedError):
+            osc.ref.read_waveform()
+
+
+# TEST FURTHER PROPERTIES AND METHODS #
+
+
+def test_acquire_type():
+    """Get / Set acquire type."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":ACQ:TYPE?",
+                ":ACQ:TYPE PEAK"
+            ],
+            [
+                "NORM"
+            ]
+    ) as osc:
+        assert osc.acquire_type == osc.AcquisitionType.normal
+        osc.acquire_type = osc.AcquisitionType.peak_detect
+
+
+def test_acquire_averages():
+    """Get / Set acquire averages."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":ACQ:AVER?",
+                ":ACQ:AVER 128"
+            ],
+            [
+                "16"
+            ]
+    ) as osc:
+        assert osc.acquire_averages == 16
+        osc.acquire_averages = 128
+
+
+def test_acquire_averages_bad_values():
+    """Raise error when bad values encountered."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+            ],
+            [
+            ]
+    ) as osc:
+        with pytest.raises(ValueError):
+            osc.acquire_averages = 0
+        with pytest.raises(ValueError):
+            osc.acquire_averages = 1
+        with pytest.raises(ValueError):
+            osc.acquire_averages = 42
+        with pytest.raises(ValueError):
+            osc.acquire_averages = 257
+        with pytest.raises(ValueError):
+            osc.acquire_averages = 512
+
+
+def test_force_trigger():
+    """Force a trigger."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":FORC"
+            ],
+            [
+            ]
+    ) as osc:
+        osc.force_trigger()
+
+
+def test_run():
+    """Run the instrument."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":RUN"
+            ],
+            [
+            ]
+    ) as osc:
+        osc.run()
+
+
+def test_stop():
+    """Stop the instrument."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":STOP"
+            ],
+            [
+            ]
+    ) as osc:
+        osc.stop()
+
+
+def test_panel_locked():
+    """Get / set the panel_locked bool property."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":KEY:LOCK?",
+                ":KEY:LOCK OFF"
+            ],
+            [
+                "ON"
+            ]
+    ) as osc:
+        assert osc.panel_locked
+        osc.panel_locked = False
+
+
+def test_release_panel():
+    """Get / set the panel_locked bool property."""
+    with expected_protocol(
+            ik.rigol.RigolDS1000Series,
+            [
+                ":KEY:FORC"
+            ],
+            [
+            ]
+    ) as osc:
+        osc.release_panel()

--- a/instruments/tests/test_rigol/test_rigolds1000.py
+++ b/instruments/tests/test_rigol/test_rigolds1000.py
@@ -49,8 +49,8 @@ def test_channel_coupling():
                 "AC"
             ]
     ) as osc:
-        assert osc.channel[0].coupling == osc.Coupling.ac
-        osc.channel[1].coupling = osc.Coupling.dc
+        assert osc.channel[0].coupling == osc.channel[0].Coupling.ac
+        osc.channel[1].coupling = osc.channel[1].Coupling.dc
 
 
 def test_channel_bw_limit():


### PR DESCRIPTION
**Test suite**
Created tests for Rigol DS1000.

**Bug fixes for `rigolds1000.py`**

- For the channel couplings of this oscilloscope, the test was implemented according to the manual, however failed. I believe that this was due to an error in the `RigolDS1000Series` class, `rigolds1000.py` file line 110. My proposed fix is attached to the commit [1d54486](https://github.com/Galvant/InstrumentKit/commit/1d544862935a3af934d65a262aaaefabde7500e8) in this PR: I moved the `Couplings` enum from the main class into the `Channel` inner class. This makes sense, since only channels have these couplings, and is analogue to other oscilloscopes, e.g., Tektronix DPO70000.
- In `bool_properties` calls, named arguments were not appropriately
  named for `inst_true` and `inst_false`. Corrected.
- All bug fixes cross checked with instrument manual.

**Issue (?)**
The function `panel_lock` in the `RigolDS1000Series` sends the commands with `bool_properties` `"ON"` and `"OFF"` for `inst_true` and `inst_false`, respectively. The [manual](https://www.rigolna.com/products/digital-oscilloscopes/1000/) states when this keyword is described that "ENAB" and "DIS" should be used to enable or disable, e.g.:

> Command Format:
> :KEY:LOCK {ENABle|DISable}
> :KEY:LOCK?

In the introduction of the manual on boolean parameter types however, the following is stated:

> Boolean
> The parameter should be “OFF” or “ON”, for example:
> :MEASure:TOTal {ON|OFF}
> Thereinto, “ON” denotes trun on (enable) this function and “OFF” denoets turn
> off (disable).

I added a `#FIXME` tag in front of the code in question. Seems difficult to decide what to do otherwise without the hardware available. Ideas?