### PR TITLE
Tests that proprety factories invoke host classes `query` and `sendcmd` methods

### DIFF
--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -14,12 +14,66 @@ import instruments.units as u
 from instruments.util_fns import (
     ProxyList,
     assume_units, convert_temperature,
-    setattr_expression
+    setattr_expression,
+    bool_property, enum_property, unitless_property, int_property,
+    unitful_property, string_property
 )
+
+
+# FIXTURES ###################################################################
+
+
+@pytest.fixture
+def mock_inst(mocker):
+    """Intialize a mock instrument to test property factories.
+
+    Include a call to each property factory to be tested. The command
+    given to the property factory must be a valid argument returned by
+    query. This argument can be asserted later. Also set up are mocker
+    spies to assert `query` and `sendcmd` have actually been called.
+
+    :return: Fake instrument class.
+    """
+    class Inst:
+        """Mock instrument class."""
+        def __init__(self):
+            """Set up the mocker spies and send command placeholder."""
+            # spies
+            self.spy_query = mocker.spy(self, 'query')
+            self.spy_sendcmd = mocker.spy(self, 'sendcmd')
+
+            # variable to set with send command
+            self._sendcmd = None
+
+        def query(self, cmd):
+            """Return the command minus the ? which is sent along."""
+            return f"{cmd[:-1]}"
+
+        def sendcmd(self, cmd):
+            """Sets the command to `self._sendcmd`."""
+            self._sendcmd = cmd
+
+        class SomeEnum(Enum):
+            test = "enum"
+
+        bool_property = bool_property("ON")  # return True
+
+        enum_property = enum_property("enum", SomeEnum)
+
+        unitless_property = unitless_property("42")
+
+        int_property = int_property("42")
+
+        unitful_property = unitful_property("42", u.K)
+
+        string_property = string_property("'STRING'")
+
+    return Inst()
+
 
 # TEST CASES #################################################################
 
-# pylint: disable=protected-access,missing-docstring
+# pylint: disable=protected-access,missing-docstring,redefined-outer-name
 
 
 def test_ProxyList_basics():
@@ -209,3 +263,73 @@ def test_setattr_expression_both():
     a = A()
     setattr_expression(a, 'b[0].x', 'foo')
     assert a.b[0].x == 'foo'
+
+
+def test_bool_property_sendcmd_query(mock_inst):
+    """Assert that bool_property calls sendcmd, query of parent class."""
+    # fixture query should return "On" -> True
+    assert mock_inst.bool_property
+    mock_inst.spy_query.assert_called()
+    # setter
+    mock_inst.bool_property = True
+    assert mock_inst._sendcmd == "ON ON"
+    mock_inst.spy_sendcmd.assert_called()
+
+
+def test_enum_property_sendcmd_query(mock_inst):
+    """Assert that enum_property calls sendcmd, query of parent class."""
+    # test getter
+    assert mock_inst.enum_property == mock_inst.SomeEnum.test
+    mock_inst.spy_query.assert_called()
+    # setter
+    mock_inst.enum_property = mock_inst.SomeEnum.test
+    assert mock_inst._sendcmd == "enum enum"
+    mock_inst.spy_sendcmd.assert_called()
+
+
+def test_unitless_property_sendcmd_query(mock_inst):
+    """Assert that unitless_property calls sendcmd, query of parent class."""
+    # getter
+    assert mock_inst.unitless_property == 42
+    mock_inst.spy_query.assert_called()
+    # setter
+    value = 13
+    mock_inst.unitless_property = value
+    assert mock_inst._sendcmd == f"42 {value:e}"
+    mock_inst.spy_sendcmd.assert_called()
+
+
+def test_int_property_sendcmd_query(mock_inst):
+    """Assert that int_property calls sendcmd, query of parent class."""
+    # getter
+    assert mock_inst.int_property == 42
+    mock_inst.spy_query.assert_called()
+    # setter
+    value = 13
+    mock_inst.int_property = value
+    assert mock_inst._sendcmd == f"42 {value}"
+    mock_inst.spy_sendcmd.assert_called()
+
+
+def test_unitful_property_sendcmd_query(mock_inst):
+    """Assert that unitful_property calls sendcmd, query of parent class."""
+    # getter
+    assert mock_inst.unitful_property == u.Quantity(42, u.K)
+    mock_inst.spy_query.assert_called()
+    # setter
+    value = 13
+    mock_inst.unitful_property = u.Quantity(value, u.K)
+    assert mock_inst._sendcmd == f"42 {value:e}"
+    mock_inst.spy_sendcmd.assert_called()
+
+
+def test_string_property_sendcmd_query(mock_inst):
+    """Assert that string_property calls sendcmd, query of parent class."""
+    # getter
+    assert mock_inst.string_property == "STRING"
+    mock_inst.spy_query.assert_called()
+    # setter
+    value = "forty-two"
+    mock_inst.string_property = value
+    assert mock_inst._sendcmd == f"'STRING' \"{value}\""
+    mock_inst.spy_sendcmd.assert_called()

--- a/instruments/tests/test_util_fns.py
+++ b/instruments/tests/test_util_fns.py
@@ -12,11 +12,16 @@ import pytest
 
 import instruments.units as u
 from instruments.util_fns import (
+    assume_units,
+    bool_property,
+    convert_temperature,
+    enum_property,
+    int_property,
     ProxyList,
-    assume_units, convert_temperature,
     setattr_expression,
-    bool_property, enum_property, unitless_property, int_property,
-    unitful_property, string_property
+    string_property,
+    unitful_property,
+    unitless_property
 )
 
 


### PR DESCRIPTION
Test for property factories were extended to test the following:

- Setter and getter work according to the expected format.
- Assert that the property getter calls its host classes `query` method
- Assert that the property setter calls its host classes `sendcmd`
  method

A test class is set up using a fixture. `query` and `sendcmd` are implemented in a simple way such that we can assert easily that they are called using mocker spies. After getting / setting values, the spies are used to assert that the call has taken place, as discussed in issue #258.