### PR TITLE
Test suite and BFs for Tektronix TDS224

### DIFF
--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -72,8 +72,7 @@ class _TekTDS224DataSource(OscilloscopeDataSource):
                 # Set the data encoding format to ASCII
                 raw = self._tek.query("CURVE?")
                 raw = raw.split(',')  # Break up comma delimited string
-                raw = map(float, raw)  # Convert each list element to int
-                raw = np.array(raw)  # Convert into numpy array
+                raw = np.array(raw, dtype=np.float)  # Convert to ndarray
             else:
                 self._tek.sendcmd("DAT:ENC RIB")
                 # Set encoding to signed, big-endian
@@ -227,8 +226,7 @@ class TekTDS224(SCPIInstrument, Oscilloscope):
             elif hasattr(newval, "name"):  # Is a datasource with a name.
                 newval = newval.name
         self.sendcmd(f"DAT:SOU {newval}")
-        if not self._testing:
-            time.sleep(0.01)  # Let the instrument catch up.
+        time.sleep(0.01)  # Let the instrument catch up.
 
     @property
     def data_width(self):

--- a/instruments/tests/test_tektronix/test_tektronix_tds224.py
+++ b/instruments/tests/test_tektronix/test_tektronix_tds224.py
@@ -6,16 +6,55 @@ Module containing tests for the Tektronix TDS224
 
 # IMPORTS ####################################################################
 
+from enum import Enum
+import time
+
+from hypothesis import given, strategies as st
 import numpy as np
+import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol, make_name_test
 
 # TESTS ######################################################################
 
-# pylint: disable=protected-access
+# pylint: disable=protected-access,redefined-outer-name
+
+
+# FIXTURES #
+
+
+@pytest.fixture(autouse=True)
+def mock_time(mocker):
+    """Mock time to replace time.sleep."""
+    return mocker.patch.object(time, 'sleep', return_value=None)
+
 
 test_tektds224_name = make_name_test(ik.tektronix.TekTDS224)
+
+
+def test_ref_init():
+    """Initialize a reference channel."""
+    with expected_protocol(
+            ik.tektronix.TekTDS224,
+            [
+            ],
+            [
+            ]
+    ) as tek:
+        assert tek.ref[0]._tek is tek
+
+
+def test_data_source_name():
+    """Get name of data source."""
+    with expected_protocol(
+            ik.tektronix.TekTDS224,
+            [
+            ],
+            [
+            ]
+    ) as tek:
+        assert tek.math.name == "MATH"
 
 
 def test_tektds224_data_width():
@@ -32,18 +71,57 @@ def test_tektds224_data_width():
         tek.data_width = 1
 
 
-def test_tektds224_data_source():
+@given(width=st.integers().filter(lambda x: x > 2 or x < 1))
+def test_tektds224_data_width_value_error(width):
+    """Raise value error if data_width is out of range."""
+    with expected_protocol(
+            ik.tektronix.TekTDS224,
+            [
+            ],
+            [
+            ]
+    ) as tek:
+        with pytest.raises(ValueError) as err_info:
+            tek.data_width = width
+        err_msg = err_info.value.args[0]
+        assert err_msg == "Only one or two byte-width is supported."
+
+
+def test_tektds224_data_source(mock_time):
     with expected_protocol(
             ik.tektronix.TekTDS224,
             [
                 "DAT:SOU?",
+                "DAT:SOU?",
                 "DAT:SOU MATH"
             ], [
+                "MATH",
                 "CH1"
             ]
     ) as tek:
+        assert tek.data_source == tek.math
         assert tek.data_source == ik.tektronix.tektds224._TekTDS224Channel(tek, 0)
         tek.data_source = tek.math
+
+        # assert that time.sleep is called
+        mock_time.assert_called()
+
+
+def test_tektds224_data_source_with_enum():
+    """Set data source from an enum."""
+    class Channel(Enum):
+        """Fake class to init data_source with enum."""
+        channel = "MATH"
+
+    with expected_protocol(
+            ik.tektronix.TekTDS224,
+            [
+                "DAT:SOU MATH"
+            ],
+            [
+            ]
+    ) as tek:
+        tek.data_source = Channel.channel
 
 
 def test_tektds224_channel():
@@ -68,6 +146,23 @@ def test_tektds224_channel_coupling():
     ) as tek:
         assert tek.channel[0].coupling == tek.Coupling.dc
         tek.channel[1].coupling = tek.Coupling.ac
+
+
+def test_tektds224_channel_coupling_type_error():
+    """Raise TypeError if coupling setting is wrong type."""
+    wrong_type = 42
+    with expected_protocol(
+            ik.tektronix.TekTDS224,
+            [
+            ],
+            [
+            ]
+    ) as tek:
+        with pytest.raises(TypeError) as err_info:
+            tek.channel[1].coupling = wrong_type
+        err_msg = err_info.value.args[0]
+        assert err_msg == f"Coupling setting must be a `TekTDS224.Coupling` " \
+                          f"value,got {type(wrong_type)} instead."
 
 
 def test_tektds224_data_source_read_waveform():
@@ -102,3 +197,64 @@ def test_tektds224_data_source_read_waveform():
         (x, y) = tek.channel[1].read_waveform()
         assert (x == data).all()
         assert (y == data).all()
+
+
+@given(values=st.lists(st.floats(allow_infinity=False, allow_nan=False),
+                       min_size=1))
+def test_tektds224_data_source_read_waveform_ascii(values):
+    """Read waveform as ASCII"""
+    # values
+    values_str = ",".join([str(value) for value in values])
+
+    # parameters
+    yoffs = 1
+    ymult = 1
+    yzero = 0
+    xzero = 0
+    xincr = 1
+    ptcnt = len(values)
+
+    with expected_protocol(
+            ik.tektronix.TekTDS224,
+            [
+                "DAT:SOU?",
+                "DAT:SOU CH2",
+                "DAT:ENC ASCI",
+                "CURVE?",
+                "WFMP:CH2:YOF?",
+                "WFMP:CH2:YMU?",
+                "WFMP:CH2:YZE?",
+                "WFMP:XZE?",
+                "WFMP:XIN?",
+                "WFMP:CH2:NR_P?",
+                "DAT:SOU CH1"
+            ], [
+                "CH1",
+                values_str,
+                f"{yoffs}",
+                f"{ymult}",
+                f"{yzero}",
+                f"{xzero}",
+                f"{xincr}",
+                f"{ptcnt}"
+            ]
+    ) as tek:
+        x_expected = np.arange(float(ptcnt)) * float(xincr) + float(xzero)
+        y_expected = ((np.array(values) - float(yoffs)) * float(ymult)) + \
+                     float(yzero)
+        x_read, y_read = tek.channel[1].read_waveform(bin_format=False)
+        np.testing.assert_equal(x_read, x_expected)
+        np.testing.assert_equal(y_read, y_expected)
+
+
+def test_force_trigger():
+    """Raise NotImplementedError when trying to force a trigger."""
+    with expected_protocol(
+            ik.tektronix.TekTDS224,
+            [
+            ],
+            [
+            ]
+    ) as tek:
+        with pytest.raises(NotImplementedError):
+            tek.force_trigger()


### PR DESCRIPTION
Test suite extended for full coverage

**Bug fixes**:
- Using `map` to convert a list from string to floats is Py2 legacy and
  not allowed anymore. Now using `numpy` conversions.
- Remove `if not self._testing` statement to introduce `time.sleep`:
  instead mocking time.sleep in test suite now with an autouse fixture.

(I had a some work stashed away...)