### PR TITLE
Gentec-eo Blu support and test suite

### DIFF
--- a/doc/source/apiref/gentec-eo.rst
+++ b/doc/source/apiref/gentec-eo.rst
@@ -1,0 +1,12 @@
+.. currentmodule:: instruments.gentec_eo
+
+=========
+Gentec-EO
+=========
+
+:class:`Blu` Power Meter
+=======================================
+
+.. autoclass:: Blu
+    :members:
+    :undoc-members:

--- a/doc/source/apiref/index.rst
+++ b/doc/source/apiref/index.rst
@@ -15,6 +15,7 @@ Contents:
     generic_scpi
     agilent
     fluke
+    gentec-eo
     glassman
     holzworth
     hp

--- a/instruments/__init__.py
+++ b/instruments/__init__.py
@@ -13,6 +13,7 @@ from .abstract_instruments import Instrument
 from . import agilent
 from . import generic_scpi
 from . import fluke
+from . import gentec_eo
 from . import glassman
 from . import holzworth
 from . import hp

--- a/instruments/gentec_eo/__init__.py
+++ b/instruments/gentec_eo/__init__.py
@@ -1,0 +1,3 @@
+"""Module containing Gentec-eo instruments."""
+
+from .blu import Blu

--- a/instruments/gentec_eo/blu.py
+++ b/instruments/gentec_eo/blu.py
@@ -1,0 +1,647 @@
+"""Support for Gentec-EO Blu devices."""
+
+
+# IMPORTS #####################################################################
+
+from enum import Enum
+from time import sleep
+
+from instruments.abstract_instruments import Instrument
+import instruments.units as u
+from instruments.util_fns import assume_units
+
+# CLASSES #####################################################################
+
+
+class Blu(Instrument):
+    """Communicate with Gentec-eo BLU power / energy meter interfaces.
+
+    These instruments communicate via USB or via bluetooth. The
+    bluetooth sender / receiver that is provided with the instrument is
+    simply emulating a COM port. This routine cannot pair the device
+    with bluetooth, but once it is paired, it can communicate with the
+    port. Alternatively, you can plug the device into the computer using
+    a USB cable.
+
+    .. warning:: If commands are issued too fast, the device will not
+        answer. Experimentally, a 1 ms delay should be enough to get the
+        device into answering mode. Keep this in mind when issuing many
+        commands at once. No wait time included in this class.
+
+    .. note:: The instrument also has a possiblity to read a continuous
+        data stream. This is currently not implemented here since it
+        would have to be threaded out.
+
+    Example:
+        >>> import instruments as ik
+        >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+        >>> inst.current_value
+        3.004 W
+    """
+
+    def __init__(self, filelike):
+        super(Blu, self).__init__(filelike)
+
+        # use a terminator for blu, even though none required
+        self.terminator = "\r\n"
+
+        # define the power mode
+        self._power_mode = None
+
+        # acknowledgement message
+        self._ack_message = "ACK"
+
+    def _ack_expected(self, msg=""):
+        """Set up acknowledgement checking."""
+        return self._ack_message
+
+    # ENUMS #
+
+    class Scale(Enum):
+        """Available scales for Blu devices.
+
+        The following list maps available scales of the Blu devices
+        to the respective indexes. All scales are either in watts or
+        joules, depending if power or energy mode is activated.
+        Furthermore, the maximum value that can be measured determines
+        the name of the scale to be set. Prefixes are given in the
+        `enum` class while the unit is omitted since it depends on the
+        mode the head is in.
+        """
+        max1pico = "00"
+        max3pico = "01"
+        max10pico = "02"
+        max30pico = "03"
+        max100pico = "04"
+        max300pico = "05"
+        max1nano = "06"
+        max3nano = "07"
+        max10nano = "08"
+        max30nano = "09"
+        max100nano = "10"
+        max300nano = "11"
+        max1micro = "12"
+        max3micro = "13"
+        max10micro = "14"
+        max30micro = "15"
+        max100micro = "16"
+        max300micro = "17"
+        max1milli = "18"
+        max3milli = "19"
+        max10milli = "20"
+        max30milli = "21"
+        max100milli = "22"
+        max300milli = "23"
+        max1 = "24"
+        max3 = "25"
+        max10 = "26"
+        max30 = "27"
+        max100 = "28"
+        max300 = "29"
+        max1kilo = "30"
+        max3kilo = "31"
+        max10kilo = "32"
+        max30kilo = "33"
+        max100kilo = "34"
+        max300kilo = "35"
+        max1Mega = "36"
+        max3Mega = "37"
+        max10Mega = "38"
+        max30Mega = "39"
+        max100Mega = "40"
+        max300Mega = "41"
+
+    # PROPERTIES #
+
+    @property
+    def anticipation(self):
+        """Get / Set anticipation.
+
+        This command is used to enable or disable the anticipation
+        processing when the device is reading from a wattmeter. The
+        anticipation is a software-based acceleration algorithm that
+        provides faster readings using the detector’s calibration.
+
+        :return: Is anticipation enabled or not.
+        :rtype: bool
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.anticipation
+            True
+            >>> inst.anticipation = False
+        """
+        return self._value_query("*GAN", tp=int) == 1
+
+    @anticipation.setter
+    def anticipation(self, newval):
+        sendval = 1 if newval else 0
+        self.sendcmd("*ANT{}".format(sendval))
+
+    @property
+    def auto_scale(self):
+        """Get / Set auto scale on the device.
+
+        :return: Status of auto scale enabled feature.
+        :rtype: bool
+
+        :raises ValueError: The command was not acknowledged by the
+            device.
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.auto_scale
+            True
+            >>> inst.auto_scale = False
+        """
+        resp = self._value_query("*GAS", tp=int)
+        return resp == 1
+
+    @auto_scale.setter
+    def auto_scale(self, newval):
+        sendval = 1 if newval else 0
+        self.sendcmd("*SAS{}".format(sendval))
+
+    @property
+    def available_scales(self):
+        """Get available scales from connected device.
+
+        :return: Scales currently available on device.
+        :rtype: :class:`Blu.Scale`
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.available_scales
+            [<Scale.max100milli: '22'>, <Scale.max300milli: '23'>,
+            <Scale.max1: '24'>, <Scale.max3: '25'>, <Scale.max10: '26'>,
+            <Scale.max30: '27'>, <Scale.max100: '28'>]
+        """
+        # set no terminator and a 1 second timeout
+        _terminator = self.terminator
+        self.terminator = ""
+        _timeout = self.timeout
+        self.timeout = u.Quantity(1, u.s)
+
+        # get the response
+        resp = self._no_ack_query("*DVS").split('\r\n')
+
+        # set back terminator and 3 second timeout
+        self.terminator = _terminator
+        self.timeout = _timeout
+
+        # prepare return
+        retlist = []  # init return list of enums
+        for line in resp:
+            if len(line) > 0:  # account for empty lines
+                index = line[line.find("[")+1:line.find("]")]
+                retlist.append(self.Scale(index))
+        return retlist
+
+    @property
+    def battery_state(self):
+        """Get the charge state of the battery.
+
+        :return: Charge state of battery
+        :rtype: u.percent
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.battery_state
+            array(100.) * %
+        """
+        resp = self._no_ack_query("*QSO").rstrip()
+        resp = float(resp[resp.find("=")+1:len(resp)])
+        return u.Quantity(resp, u.percent)
+
+    @property
+    def current_value(self):
+        """Get the currently measured value (unitful).
+
+        :return: Currently measured value
+        :rtype: u.Quantity
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.current_value
+            3.004 W
+        """
+        if self._power_mode is None:
+            _ = self.measure_mode  # determine the power mode
+            sleep(0.01)
+
+        unit = u.W if self._power_mode else u.J
+        return u.Quantity(float(self._no_ack_query("*CVU")), unit)
+
+    @property
+    def head_type(self):
+        """Get the head type information.
+
+        :return: Type of instrument head.
+        :rtype: str
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.head_type
+            'NIG : 104552, Wattmeter, V1.95'
+        """
+        return self._no_ack_query("*GFW")
+
+    @property
+    def measure_mode(self):
+        """Get the current measurement mode.
+
+        Potential return values are 'power', which inidcates power mode
+        in W and 'sse', indicating single shot energy mode in J.
+
+        :return: 'power' if in power mode, 'sse' if in single shot
+            energy mode.
+        :rtype: str
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.measure_mode
+            'power'
+        """
+        resp = self._value_query("*GMD", tp=int)
+        if resp == 0:
+            self._power_mode = True
+            return 'power'
+        else:
+            self._power_mode = False
+            return 'sse'
+
+    @property
+    def new_value_ready(self):
+        """Get status if a new value is ready.
+
+        This command is used to check whether a new value is available
+        from the device. Though optional, its use is recommended when
+        used with single pulse operation.
+
+        :return: Is a new value ready?
+        :rtype: bool
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.new_value_ready
+            False
+        """
+        resp = self._no_ack_query("*NVU")
+        return False if resp.find("Not") > -1 else True
+
+    @property
+    def scale(self):
+        """Get / Set measurement scale.
+
+        The measurement scales are chosen from the the `Scale` enum
+        class. Scales are either in watts or joules, depending on what
+        state the power meter is currently in.
+
+        .. note:: Setting a scale manually will automatically turn of
+            auto scale.
+
+        :return: Scale that is currently set.
+        :rtype: :class:`Blu.Scale`
+
+        :raises ValueError: The command was not acknowledged by the
+            device. A scale that is not available might have been
+            selected. Use `available_scales` to display scales that
+            are possible on your device.
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.scale = inst.Scale.max3
+            >>> inst.scale
+            <Scale.max3: '25'>
+        """
+        return self.Scale(self._value_query("*GCR"))
+
+    @scale.setter
+    def scale(self, newval):
+        self.sendcmd("*SCS{}".format(newval.value))
+
+    @property
+    def single_shot_energy_mode(self):
+        """ Get / Set single shot energy mode.
+
+        :return: Is single shot energy mode turned on?
+        :rtype: bool
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.single_shot_energy_mode
+            False
+            >>> inst.single_shot_energy_mode = True
+        """
+        val = self._value_query("*GSE", tp=int) == 1
+        self._power_mode = False if val else True
+        return val
+
+    @single_shot_energy_mode.setter
+    def single_shot_energy_mode(self, newval):
+        sendval = 1 if newval else 0  # set send value
+        self._power_mode = False if newval else True  # set power mode
+        self.sendcmd("*SSE{}".format(sendval))
+
+    @property
+    def trigger_level(self):
+        """Get / Set trigger level when in energy mode.
+
+        The trigger level must be between 0.001 and 0.998.
+
+        :return: Trigger level (absolute) with respect to the currently
+            set scale
+        :rtype: float
+
+        :raise ValueError: Trigger level out of range.
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.trigger_level = 0.153
+            >>> inst.trigger_level
+            0.153
+
+        """
+        level = self._no_ack_query("*GTL")
+        # get the percent
+        retval = float(level[level.find(":")+1:level.find("%")]) / 100
+        return retval
+
+    @trigger_level.setter
+    def trigger_level(self, newval):
+        if newval < 0.001 or newval > 0.99:
+            raise ValueError("Trigger level {} is out of range. It must be "
+                             "between 0.001 and 0.998.".format(newval))
+
+        newval = newval * 100.
+        if newval >= 10:
+            newval = str(round(newval, 1)).zfill(4)
+        else:
+            newval = str(round(newval, 2)).zfill(4)
+
+        self.sendcmd("*STL{}".format(newval))
+
+    @property
+    def usb_state(self):
+        """Get status if USB cable is connected.
+
+        :return: Is a USB cable connected?
+        :rtype: bool
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.usb_state
+            True
+        """
+        return self._value_query("*USB", tp=int) == 1
+
+    @property
+    def user_multiplier(self):
+        """Get / Set user multiplier.
+
+        :return: User multiplier
+        :rtype: u.Quantity
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.user_multiplier = 10
+            >>> inst.user_multiplier
+            10.0
+        """
+        return self._value_query("*GUM", tp=float)
+
+    @user_multiplier.setter
+    def user_multiplier(self, newval):
+        sendval = _format_eight(newval)  # sendval: 8 characters long
+        self.sendcmd("*MUL{}".format(sendval))
+
+    @property
+    def user_offset(self):
+        """Get / Set user offset.
+
+        The user offset can be set unitful in watts or joules and set
+        to the device.
+
+        :return: User offset
+        :rtype: u.Quantity
+
+        :raises ValueError: Unit not supported or value for offset is
+            out of range.
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.user_offset = 10
+            >>> inst.user_offset
+            array(10.) * W
+        """
+        if self._power_mode is None:
+            _ = self.measure_mode  # determine the power mode
+            sleep(0.01)
+
+        if self._power_mode:
+            return assume_units(self._value_query("*GUO", tp=float), u.W)
+        else:
+            return assume_units(self._value_query("*GUO", tp=float), u.J)
+
+    @user_offset.setter
+    def user_offset(self, newval):
+        # if unitful, try to rescale and grab magnitude
+        if isinstance(newval, u.Quantity):
+            try:
+                newval = newval.rescale(u.W).magnitude
+            except ValueError:  # so it's not in W
+                try:
+                    newval = newval.rescale(u.J).magnitude
+                except ValueError:  # invalid unit
+                    raise ValueError("Value must be given in watts, "
+                                     "joules, or unitless.")
+        sendval = _format_eight(newval)  # sendval: 8 characters long
+        self.sendcmd("*OFF{}".format(sendval))
+
+    @property
+    def version(self):
+        """Get device information.
+
+        :return: Version and device type
+        :rtype: str
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.version
+            'Blu firmware Version 1.95'
+        """
+        return self._no_ack_query("*VER")
+
+    @property
+    def wavelength(self):
+        """Get / Set the wavelength.
+
+        The wavelength can be set unitful. Specifying zero as a
+        wavelength or providing an out-of-bound value as a parameter
+        restores the default settings, typically 1064nm. If no units
+        are provided, nm are assumed.
+
+        :return: Wavelength in nm
+        :rtype: u.Quantity
+
+        Example:
+            >>> import instruments as ik
+            >>> import instruments.units as u
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.wavelength = u.Quantity(527, u.nm)
+            >>> inst.wavelength
+            array(527) * nm
+        """
+        return u.Quantity(self._value_query("*GWL", tp=int), u.nm)
+
+    @wavelength.setter
+    def wavelength(self, newval):
+        val = assume_units(newval, u.nm).rescale(u.nm).magnitude.round(0)
+        if val >= 1000000 or val < 0:  # can only send 5 digits
+            val = 0  # out of bound anyway
+        val = str(int(val)).zfill(5)
+        self.sendcmd("*PWC{}".format(val))
+
+    @property
+    def zero_offset(self):
+        """Get / Set zero offset.
+
+        Gets the status if zero offset is enabled. When set to `True`,
+        the device will read the current level immediately for around
+        three seconds and then set the baseline to the averaged value.
+        If activated and set to `True` again, a new value for the
+        baseline will be established.
+
+        :return: Is zero offset enabled?
+        :rtype: bool
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.zero_offset
+            True
+            >>> inst.zero_offset = False
+        """
+        return self._value_query("*GZO", tp=int) == 1
+
+    @zero_offset.setter
+    def zero_offset(self, newval):
+        if newval:
+            self.sendcmd("*SOU")
+        else:
+            self.sendcmd("*COU")
+
+    # METHODS #
+
+    def confirm_connection(self):
+        """Confirm a connection to the device.
+
+        Turns of bluetooth searching by confirming a connection.
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.confirm_connection()
+        """
+        self.sendcmd("*RDY")
+
+    def disconnect(self):
+        """Disconnect the device.
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.disconnect()
+        """
+        self.sendcmd("*BTD")
+
+    def scale_down(self):
+        """Set scale to next lower level.
+
+        Sets the power meter to the next lower scale. If already at
+        the lowest possible scale, no change will be made.
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.scale_down()
+        """
+        self.sendcmd("*SSD")
+
+    def scale_up(self):
+        """Set scale to next higher level.
+
+        Sets the power meter to the next higher scale. If already at
+        the highest possible scale, no change will be made.
+
+        Example:
+            >>> import instruments as ik
+            >>> inst = ik.gentec_eo.Blu.open_serial('/dev/ttyACM0')
+            >>> inst.scale_up()
+        """
+        self.sendcmd("*SSU")
+
+    # PRIVATE METHODS #
+
+    def _no_ack_query(self, cmd, size=-1):
+        """Query a value and don't expect an ACK message."""
+        self._ack_message = None
+        value = self.query(cmd, size=size)
+        self._ack_message = "ACK"
+        return value
+
+    def _value_query(self, cmd, tp=str):
+        """Query one specific value and return it.
+
+        :param cmd: Command to send to self._no_ack_query.
+        :type cmd: str
+        :param tp: Type of the value to be returned, default: str
+        :type tp: type
+
+        :return: Single value of query.
+        :rtype: tp (selected type)
+
+        :raises ValueError: Conversion of response into given type was
+            unsuccessful.
+        """
+        resp = self._no_ack_query(cmd).rstrip()  # strip \r\n
+        resp = resp.split(":")[1]  # strip header off
+        resp = resp.replace(" ", "")  # strip white space
+        if isinstance(resp, tp):
+            return resp
+        else:
+            return tp(resp)
+
+
+def _format_eight(value):
+    """Formats a value to eight characters total.
+
+    :param value: value to be formatted, > -1e100 and < 1e100
+    :type value: int,float
+
+    :return: Value formatted to 8 characters
+    :rtype: str
+    """
+    if len(str(value)) > 8:
+        if value < 0:
+            value = "{0:.2g}".format(value).zfill(8)  # make space for -
+        else:
+            value = "{0:.3g}".format(value).zfill(8)
+    else:
+        value = str(value).zfill(8)
+    return value

--- a/instruments/gentec_eo/blu.py
+++ b/instruments/gentec_eo/blu.py
@@ -185,12 +185,13 @@ class Blu(Instrument):
         _timeout = self.timeout
         self.timeout = u.Quantity(1, u.s)
 
-        # get the response
-        resp = self._no_ack_query("*DVS").split('\r\n')
-
-        # set back terminator and 3 second timeout
-        self.terminator = _terminator
-        self.timeout = _timeout
+        try:
+            # get the response
+            resp = self._no_ack_query("*DVS").split('\r\n')
+        finally:
+            # set back terminator and 3 second timeout
+            self.terminator = _terminator
+            self.timeout = _timeout
 
         # prepare return
         retlist = []  # init return list of enums
@@ -601,8 +602,10 @@ class Blu(Instrument):
     def _no_ack_query(self, cmd, size=-1):
         """Query a value and don't expect an ACK message."""
         self._ack_message = None
-        value = self.query(cmd, size=size)
-        self._ack_message = "ACK"
+        try:
+            value = self.query(cmd, size=size)
+        finally:
+            self._ack_message = "ACK"
         return value
 
     def _value_query(self, cmd, tp=str):

--- a/instruments/tests/test_gentec_eo/test_blu.py
+++ b/instruments/tests/test_gentec_eo/test_blu.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the Gentec-eo Blu
+"""
+
+# IMPORTS ####################################################################
+
+from hypothesis import given, strategies as st
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol
+import instruments.units as u
+
+# TESTS ######################################################################
+
+# pylint: disable=protected-access
+
+
+# TESTS FOR Blu #
+
+
+def test_blu_initialization():
+    """Initialize the device."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+            ],
+            [
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.terminator == "\r\n"
+        assert blu._power_mode is None
+
+
+# TEST PROPERTIES #
+
+
+def test_blu_anticipation():
+    """Get / Set the instrument into anticipation mode."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GAN",
+                "*ANT0"
+            ],
+            [
+                "Anticipation: 1",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.anticipation
+        blu.anticipation = False
+
+
+def test_blu_auto_scale():
+    """Get / Set the instrument into automatic scaling mode."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GAS",
+                "*SAS0"
+            ],
+            [
+                "Autoscale: 1",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.auto_scale
+        blu.auto_scale = False
+
+
+def test_blu_available_scales():
+    """Get the available scales that are on teh blue device.
+
+    Note that the routine tested here will temporarily overwrite the
+    terminator and the timeout. The function here is special in the
+    sense that it returns a list of parameters, all individual entries
+    are separated by the terminator. There is no clear end to when this
+    should be finished. It is assumed that 1 second is enough time to
+    send all the data.
+    """
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*DVS"
+            ],
+            [
+                "[22]: 100.0 m\r\n"
+                "[23]: 300.0 m\r\n"
+                "[24]: 1.000\r\n"
+                "[25]: 3.000\r\n"
+                "[26]: 10.00\r\n"
+                "[27]: 30.00\r\n"
+                "[28]: 100.0\r\n"
+            ],
+            sep="",
+    ) as blu:
+        ret_scale = [
+            blu.Scale.max100milli,
+            blu.Scale.max300milli,
+            blu.Scale.max1,
+            blu.Scale.max3,
+            blu.Scale.max10,
+            blu.Scale.max30,
+            blu.Scale.max100
+        ]
+        assert blu.available_scales == ret_scale
+
+
+def test_blu_battery_state():
+    """Get the battery state of the instrument in percent."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*QSO"
+            ],
+            [
+                "98"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.battery_state == u.Quantity(98, u.percent)
+
+
+def test_blu_current_value_watts():
+    """Get the current value in Watt mode."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GMD",
+                "*CVU"
+            ],
+            [
+                "Mode: 0",
+                "42"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.current_value == u.Quantity(42, u.W)
+
+
+def test_blu_current_value_joules():
+    """Get the current value in Watt mode."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GMD",
+                "*CVU"
+            ],
+            [
+                "Mode: 2",
+                "42"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.current_value == u.Quantity(42, u.J)
+
+
+def test_blu_head_type():
+    """Get information on the connected power meter head.
+
+    Here, an example head is returned.
+    """
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GFW"
+            ],
+            [
+                "NIG : 104552, Wattmeter, V1.95"
+            ],
+            sep="\r\n",
+    ) as blu:
+        example_head = "NIG : 104552, Wattmeter, V1.95"
+        assert blu.head_type == example_head
+
+
+def test_blu_measure_mode():
+    """Get the measure mode the head is in.
+
+    This routine is also run when a unitful response is returned from
+    another routine and the measurement mode has not been determined
+    before.
+    """
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GMD",
+                "*GMD"
+            ],
+            [
+                "Mode: 0",
+                "Mode: 2"
+            ],
+            sep="\r\n",
+    ) as blu:
+        # power mode
+        assert blu.measure_mode == "power"
+        assert blu._power_mode
+
+        # single shot energy mode (J)
+        assert blu.measure_mode == "sse"
+        assert not blu._power_mode
+
+
+def test_blu_new_value_ready():
+    """Query if a new value is ready for reading."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*NVU",
+                "*NVU"
+            ],
+            [
+                "New Data Not Available",
+                "New Data Available"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert not blu.new_value_ready
+        assert blu.new_value_ready
+
+
+@pytest.mark.parametrize("scale", ik.gentec_eo.Blu.Scale)
+def test_blu_scale(scale):
+    """Get / set the instrument scale manually."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                f"*SCS{scale.value}",
+                "*GCR"
+            ],
+            [
+                "ACK",
+                f"Range: {scale.value}"
+            ],
+            sep="\r\n",
+    ) as blu:
+        blu.scale = scale
+        assert blu.scale == scale
+
+
+def test_blu_single_shot_energy_mode():
+    """Get / set the single shot energy mode."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GSE",
+                "*SSE1"
+            ],
+            [
+                "SSE: 0",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert not blu.single_shot_energy_mode
+        assert blu._power_mode
+        blu.single_shot_energy_mode = True
+        assert not blu._power_mode
+
+
+def test_blu_trigger_level():
+    """Get / set the trigger level."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GTL",
+                "*STL53.4",
+                "*STL01.2",
+                "*STL1.23"
+            ],
+            [
+                "Trigger level: 15.4% (4.6 Watts) of max power: 30 Watts",
+                "ACK",
+                "ACK",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.trigger_level == 0.154
+        blu.trigger_level = 0.534
+        blu.trigger_level = 0.012
+        blu.trigger_level = 0.0123
+
+
+def test_blu_trigger_level_invalid_value():
+    """Raise error when trigger level value set is out of bound."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+            ],
+            [
+            ],
+            sep="\r\n",
+    ) as blu:
+        with pytest.raises(ValueError):
+            blu.trigger_level = -0.3
+        with pytest.raises(ValueError):
+            blu.trigger_level = 1.1
+
+
+def test_blu_usb_state():
+    """Get the status if USB cable is plugged in."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*USB"
+            ],
+            [
+                "USB: 1"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.usb_state
+
+
+def test_blu_user_multiplier():
+    """Get / set user multiplier."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GUM",
+                "*MUL435.6666"
+            ],
+            [
+                "User Multiplier: 3.3000000e+01",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.user_multiplier == 33.
+        blu.user_multiplier = 435.6666
+
+
+def test_blu_user_offset_watts():
+    """Get / set user offset in watts."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GMD",  # get power mode
+                "*GUO",
+                "*OFF000042.0"
+
+            ],
+            [
+                "Mode: 0",  # power mode watts
+                "User Offset : 1.500e-3",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.user_offset == u.Quantity(1.5, u.mW)
+        blu.user_offset = u.Quantity(42.0, u.W)
+
+
+def test_blu_user_offset_joules():
+    """Get / set user offset in joules."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GMD",  # get power mode
+                "*GUO",
+                "*OFF000042.0"
+
+            ],
+            [
+                "Mode: 2",  # power mode watts
+                "User Offset : 1.500e-3",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.user_offset == u.Quantity(0.0015, u.J)
+        blu.user_offset = u.Quantity(42.0, u.J)
+
+
+def test_blu_user_offset_unitless():
+    """Set user offset unitless."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*OFF000042.0"
+
+            ],
+            [
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        blu.user_offset = 42.0
+
+
+def test_blu_user_offset_unit_error():
+    """Raise ValueError if unit is invalid."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+            ],
+            [
+            ],
+            sep="\r\n",
+    ) as blu:
+        with pytest.raises(ValueError):
+            blu.user_offset = u.Quantity(42, u.mm)
+
+
+def test_blu_version():
+    """Query version of device."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*VER"
+            ],
+            [
+                "Blu firmware Version 1.95"
+            ],
+            sep="\r\n",
+    ) as blu:
+        version = "Blu firmware Version 1.95"
+        assert blu.version == version
+
+
+def test_blu_wavelength():
+    """Get / set the wavelength."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GWL",
+                "*PWC00527",
+                "*PWC00527"
+            ],
+            [
+                "PWC: 1064",
+                "ACK",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.wavelength == u.Quantity(1064, u.nm)
+        blu.wavelength = u.Quantity(0.527, u.um)
+        blu.wavelength = 527
+
+
+def test_blu_wavelength_out_of_bound():
+    """Get / set the wavelength when value is out of bound."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*PWC00000",
+                "*PWC00000"
+            ],
+            [
+                "ACK",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        blu.wavelength = u.Quantity(1000, u.um)
+        blu.wavelength = -3
+
+
+def test_blu_zero_offset():
+    """Get / set the zero offset."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*GZO",
+                "*SOU",
+                "*COU"
+            ],
+            [
+                "Zero: 1",
+                "ACK",
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        assert blu.zero_offset
+        blu.zero_offset = True
+        blu.zero_offset = False
+
+
+# TEST METHODS #
+
+
+def test_blu_confirm_connection():
+    """Confirm a bluetooth connection."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*RDY"
+            ],
+            [
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        blu.confirm_connection()
+
+
+def test_blu_disconnect():
+    """Disconnect bluetooth connection."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*BTD"
+            ],
+            [
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        blu.disconnect()
+
+
+def test_blu_scale_down():
+    """Set the scale one level lower."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*SSD"
+            ],
+            [
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        blu.scale_down()
+
+
+def test_blu_scale_up():
+    """Set the scale one level higher."""
+    with expected_protocol(
+            ik.gentec_eo.Blu,
+            [
+                "*SSU"
+            ],
+            [
+                "ACK"
+            ],
+            sep="\r\n",
+    ) as blu:
+        blu.scale_up()
+
+
+# NON-Blu ROUTINES #
+
+
+def test_format_eight_type():
+    """Ensure type returned is string."""
+    assert isinstance(ik.gentec_eo.blu._format_eight(3.), str)
+
+
+@given(value=st.floats(min_value=-1e100, max_value=1e100,
+                       exclude_min=True, exclude_max=True))
+def test_format_eight_length_values(value):
+    """Ensure format eight routine works.
+
+    This is a helper routine for the blu device to cut any number to
+    eight characters. Make sure this is the case with various numbers
+    and that it is correct to 1% with given number.
+    """
+    value_read = ik.gentec_eo.blu._format_eight(value)
+    assert value == pytest.approx(float(value_read), abs(value) / 100.)
+    assert len(value_read) == 8


### PR DESCRIPTION
To mix it up... here's a new instrument instead of a test

Added support for gentec-eo's Blu series power meters. These power
meters connect via bluetooth, the bluetooth dongle showsvup as a regular
serial port. In addition, they can be plugged into a USB port and vshow up
as a regular serial interface as well.

Full test suite added as well.

All routines have example doc strings with detailed examples.

Added to docs.