### PR TITLE
Test suite and BF for Newport's `error.py`

### DIFF
--- a/instruments/newport/errors.py
+++ b/instruments/newport/errors.py
@@ -103,8 +103,7 @@ class NewportError(IOError):
         if timestamp is None:
             self._timestamp = datetime.datetime.now() - NewportError.start_time
         else:
-            self._timestamp = datetime.timedelta(
-                seconds=(timestamp * 400E-6))
+            self._timestamp = datetime.datetime.now() - timestamp
 
         if errcode is not None:
             # Break the error code into an axis number

--- a/instruments/tests/test_newport/test_errors.py
+++ b/instruments/tests/test_newport/test_errors.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for NewportError class
+"""
+
+# IMPORTS ####################################################################
+
+
+import datetime
+
+from instruments.newport.errors import NewportError
+
+
+# TESTS ######################################################################
+
+
+# pylint: disable=protected-access
+
+
+def test_init_none():
+    """Initialized with both arguments as `None`."""
+    cls = NewportError()
+    assert isinstance(cls._timestamp, datetime.timedelta)
+    assert cls._errcode is None
+    assert cls._axis is None
+
+
+def test_init_with_timestamp():
+    """Initialized with a time stamp."""
+    timestamp = datetime.datetime.now()
+    cls = NewportError(timestamp=timestamp)
+    assert isinstance(cls._timestamp, datetime.timedelta)
+
+
+def test_init_with_error_code():
+    """Initialize with non-axis specific error code."""
+    err_code = 7  # parameter out of range
+    cls = NewportError(errcode=err_code)
+    assert cls._axis is None
+    assert cls._errcode == 7
+
+
+def test_init_with_error_code_axis():
+    """Initialize with axis-specific error code."""
+    err_code = 313  # ax 3 not enabled
+    cls = NewportError(errcode=err_code)
+    assert cls._axis == 3
+    assert cls._errcode == 13
+
+
+def test_get_message():
+    """Get the message for a given error code."""
+    err_code = "7"
+    cls = NewportError()
+    assert cls.get_message(err_code) == cls.messageDict[err_code]
+
+
+def test_timestamp():
+    """Get the timestamp for a given error."""
+    cls = NewportError()
+    assert cls.timestamp == cls._timestamp
+
+
+def test_errcode():
+    """Get the error code reported by device."""
+    cls = NewportError(errcode=7)
+    assert cls.errcode == cls._errcode
+
+
+def test_axis():
+    """Get axis for given error code."""
+    cls = NewportError(errcode=313)
+    assert cls.axis == cls._axis


### PR DESCRIPTION
Simple test suite with full coverage. Time stamps are only tested for existence. Further tests are probably not required.
If further tests for timestamps are wanted we might consider to add `pytest-freezegun` to the `dev-requirements.txt` in order to freeze timestamps. (Maybe should include that just for the awesome name :wink:).

**Bug fix:**
The timedelta creation for the timestamp made not much sense to me and resulted in an error, even when just executing it by itself. Creating a timestamp that is as close to the one given if no specific `datetime` is provided.