### PR TITLE
BF: Adjust `pytest.approx` statement such that Keithley580 tests pass

### DIFF
--- a/instruments/tests/test_keithley/test_keithley580.py
+++ b/instruments/tests/test_keithley/test_keithley580.py
@@ -761,7 +761,7 @@ def test_measure(init, create_measurement, resistance):
             sep="\n"
     ) as inst:
         read_value = inst.measure()
-        assert read_value.magnitude == pytest.approx(resistance)
+        assert read_value.magnitude == pytest.approx(resistance, rel=1e-6)
         assert read_value.units == u.ohm
 
 


### PR DESCRIPTION
The test now passes. Set the relative deviation allowed to 1e-6. 
The funky thing is: according to the pytest documentation [here](https://docs.pytest.org/en/5.4.1/reference.html#pytest-approx), this should have been the default setting already. 
My local `tox` with all fresh environments passes now. Let's see what Travis says...

See discussion in PR #270 