### PR TITLE
Update pytest to version 6.1.1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 mock
-pytest
+pytest==6.1.1
 pytest-mock
 hypothesis==4.28.2
 pylint==2.4.4


### PR DESCRIPTION
Hopefully this fixes the pytest version mismatch we are seeing in our travis runs, which is causing 1 of our unit tests to fail due to, what appears to be, a bug in pytest 5.2.1

@trappitsch 