### PR TITLE
Tests and BFs for Thorlabs `_abstract` and `_packets` helper classes

### DIFF
--- a/instruments/tests/test_thorlabs/test_abstract.py
+++ b/instruments/tests/test_thorlabs/test_abstract.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the abstract ThorlabsInstrument class.
+"""
+
+# IMPORTS ####################################################################
+
+
+import struct
+import time
+
+import pytest
+
+import instruments as ik
+from instruments.thorlabs import _packets
+from instruments.tests import expected_protocol
+
+
+# TESTS ######################################################################
+
+
+example_packet = _packets.ThorLabsPacket(
+    message_id=0x0000,
+    param1=0x00,
+    param2=0x00,
+    dest=0x50,
+    source=0x01,
+    data=None
+)
+
+
+example_packet_with_data = _packets.ThorLabsPacket(
+    message_id=0x0000,
+    param1=None,
+    param2=None,
+    dest=0x50,
+    source=0x01,
+    data=struct.pack('<HH', 0, 1)
+)
+
+
+# pylint: disable=protected-access
+
+
+def test_init():
+    """Initialize the instrument and set terminator."""
+    with expected_protocol(
+            ik.thorlabs._abstract.ThorLabsInstrument,
+            [
+            ],
+            [
+            ],
+            sep=""
+    ) as inst:
+        assert inst.terminator == ""
+
+
+def test_send_packet():
+    """Send a packet using write_raw."""
+    with expected_protocol(
+            ik.thorlabs._abstract.ThorLabsInstrument,
+            [
+                example_packet.pack()
+            ],
+            [
+            ],
+            sep=""
+    ) as inst:
+        inst.sendpacket(example_packet)
+
+
+def test_query_packet(mocker):
+    """Query the simple example packet without data.
+
+    For simplicity, the query and response packet are the same.
+    """
+    with expected_protocol(
+            ik.thorlabs._abstract.ThorLabsInstrument,
+            [
+                example_packet.pack()
+            ],
+            [
+                example_packet.pack()
+            ],
+            sep=""
+    ) as inst:
+        read_raw_spy = mocker.spy(inst._file, 'read_raw')
+        packet_return = inst.querypacket(example_packet)
+        assert packet_return.message_id == example_packet.message_id
+        assert packet_return.parameters == example_packet.parameters
+        assert packet_return.destination == example_packet.destination
+        assert packet_return.source == example_packet.source
+        assert packet_return.data == example_packet.data
+        # assert read_raw is called with proper length
+        read_raw_spy.assert_called_with(6)
+
+
+def test_query_packet_with_data(mocker):
+    """Query the simple example packet with data."""
+    data_length = 4
+    with expected_protocol(
+            ik.thorlabs._abstract.ThorLabsInstrument,
+            [
+                example_packet.pack()
+            ],
+            [
+                example_packet_with_data.pack()
+            ],
+            sep=""
+    ) as inst:
+        read_raw_spy = mocker.spy(inst._file, 'read_raw')
+        packet_return = inst.querypacket(example_packet,
+                                         expect_data_len=data_length)
+        assert packet_return.data == example_packet_with_data.data
+        # assert read_raw is called with proper length
+        read_raw_spy.assert_called_with(data_length + 6)
+
+
+def test_query_packet_expect_none_no_respnse():
+    """Query a packet but no response, none expected."""
+    with expected_protocol(
+            ik.thorlabs._abstract.ThorLabsInstrument,
+            [
+                example_packet.pack()
+            ],
+            [
+            ],
+            sep=""
+    ) as inst:
+        assert inst.querypacket(example_packet, expect=None) is None
+
+
+def test_query_packet_expect_but_no_respnse():
+    """Raise IO error when expecting a package but none returned."""
+    expect = 0x0000
+    with expected_protocol(
+            ik.thorlabs._abstract.ThorLabsInstrument,
+            [
+                example_packet.pack()
+            ],
+            [
+            ],
+            sep=""
+    ) as inst:
+        with pytest.raises(IOError) as err_info:
+            inst.querypacket(example_packet, expect=expect)
+        err_msg = err_info.value.args[0]
+        assert err_msg == f"Expected packet {expect}, got nothing instead."
+
+
+def test_query_packet_wrong_package_received():
+    """Raise IOError if an unexpected package is received."""
+    expect = 0x002A
+    with expected_protocol(
+            ik.thorlabs._abstract.ThorLabsInstrument,
+            [
+                example_packet.pack()
+            ],
+            [
+                example_packet.pack()
+            ],
+            sep=""
+    ) as inst:
+        with pytest.raises(IOError) as err_info:
+            inst.querypacket(example_packet, expect=expect)
+        err_msg = err_info.value.args[0]
+        assert err_msg == f"APT returned message ID " \
+                          f"{example_packet.message_id}, expected {expect}"
+
+
+def test_query_packet_no_response_with_timeout(mocker):
+    """Query a packet but no response, timeout is set."""
+    with expected_protocol(
+            ik.thorlabs._abstract.ThorLabsInstrument,
+            [
+                example_packet.pack()
+            ],
+            [
+            ],
+            sep=""
+    ) as inst:
+        time_spy = mocker.spy(time, 'time')
+        assert inst.querypacket(example_packet, timeout=0) is None
+        # timeout set to zero, assert `time.time()`  called twice
+        assert time_spy.call_count == 2

--- a/instruments/tests/test_thorlabs/test_packets.py
+++ b/instruments/tests/test_thorlabs/test_packets.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the ThorLabsPacket class.
+"""
+
+# IMPORTS ####################################################################
+
+
+import struct
+
+import pytest
+
+from instruments.thorlabs import _packets
+
+
+# TESTS ######################################################################
+
+
+# pylint: disable=protected-access,redefined-outer-name
+
+
+# variable to parametrize parameters or data: param1, param2, data, has_data
+params_or_data = (
+    (0x00, 0x00, None, False),
+    (None, None, struct.pack("<HH", 0x00, 0x01), True)
+)
+
+
+@pytest.mark.parametrize("params_or_data", params_or_data)
+def test_init(params_or_data):
+    """Initialize a Thorlabs packet without data."""
+    message_id = 0x0000
+    param1 = params_or_data[0]
+    param2 = params_or_data[1]
+    dest = 0x50
+    source = 0x01
+    data = params_or_data[2]
+    pkt = _packets.ThorLabsPacket(
+        message_id=message_id,
+        param1=param1,
+        param2=param2,
+        dest=dest,
+        source=source,
+        data=data,
+    )
+    # assert that variables are set correctly
+    assert pkt._message_id == message_id
+    assert pkt._param1 == param1
+    assert pkt._param2 == param2
+    assert pkt._data == data
+    assert pkt._dest == dest
+    assert pkt._source == source
+    assert pkt._has_data is params_or_data[3]
+
+
+def test_init_no_params_no_data():
+    """Raise ValueError if package initialized without parameters or data."""
+    message_id = 0x0000
+    param1 = None
+    param2 = None
+    dest = 0x50
+    source = 0x01
+    data = None
+    with pytest.raises(ValueError) as err_info:
+        _ = _packets.ThorLabsPacket(
+            message_id=message_id,
+            param1=param1,
+            param2=param2,
+            dest=dest,
+            source=source,
+            data=data,
+        )
+    err_msg = err_info.value.args[0]
+    assert err_msg == "Must specify either parameters or data."
+
+
+def test_init_params_and_data():
+    """Raise ValueError if package initialized with parameters and data."""
+    message_id = 0x0000
+    param1 = 0x00
+    param2 = 0x00
+    dest = 0x50
+    source = 0x01
+    data = struct.pack("<HH", 0x00, 0x01)
+    with pytest.raises(ValueError) as err_info:
+        _ = _packets.ThorLabsPacket(
+            message_id=message_id,
+            param1=param1,
+            param2=param2,
+            dest=dest,
+            source=source,
+            data=data,
+        )
+    err_msg = err_info.value.args[0]
+    assert err_msg == "A ThorLabs packet can either have parameters or " \
+                      "data, but not both."
+
+
+@pytest.mark.parametrize("params_or_data", params_or_data)
+def test_string(params_or_data):
+    """Return a string of the class."""
+    message_id = 0x0000
+    param1 = params_or_data[0]
+    param2 = params_or_data[1]
+    dest = 0x50
+    source = 0x01
+    data = params_or_data[2]
+    pkt = _packets.ThorLabsPacket(
+        message_id=message_id,
+        param1=param1,
+        param2=param2,
+        dest=dest,
+        source=source,
+        data=data,
+    )
+    string_expected = """
+ThorLabs APT packet:
+    Message ID      {0}
+    Parameter 1     {1}
+    Parameter 2     {2}
+    Destination     {3}
+    Source          {4}
+    Data            {5}
+""".format(
+    f"0x{message_id:x}",
+    f"0x{param1:x}" if not params_or_data[3] else "None",
+    f"0x{param2:x}" if not params_or_data[3] else "None",
+    f"0x{dest:x}",
+    f"0x{source:x}",
+    f"{data}" if params_or_data[3] else "None"
+)
+    assert pkt.__str__() == string_expected
+
+
+def test_message_id():
+    """Get / set message ID."""
+    pkt = _packets.ThorLabsPacket(
+        message_id=0x000,
+        param1=0x01,
+        param2=0x02,
+        dest=0x50,
+        source=0x01,
+        data=None
+    )
+    pkt.message_id = 0x002A
+    assert pkt.message_id == 0x002A
+
+
+def test_parameters():
+    """Get / set both parameters."""
+    pkt = _packets.ThorLabsPacket(
+        message_id=0x000,
+        param1=0x01,
+        param2=0x02,
+        dest=0x50,
+        source=0x01,
+        data=None
+    )
+    pkt.parameters = (0x0D, 0x2A)
+    assert pkt.parameters == (0x0D, 0x2A)
+
+
+def test_destination():
+    """Get / set destination."""
+    pkt = _packets.ThorLabsPacket(
+        message_id=0x000,
+        param1=0x01,
+        param2=0x02,
+        dest=0x50,
+        source=0x01,
+        data=None
+    )
+    pkt.destination = 0x2A
+    assert pkt.destination == 0x2A
+
+
+def test_source():
+    """Get / set source."""
+    pkt = _packets.ThorLabsPacket(
+        message_id=0x000,
+        param1=0x01,
+        param2=0x02,
+        dest=0x50,
+        source=0x01,
+        data=None
+    )
+    pkt.source = 0x2A
+    assert pkt.source == 0x2A
+
+
+def test_data():
+    """Get / set data."""
+    pkt = _packets.ThorLabsPacket(
+        message_id=0x000,
+        param1=None,
+        param2=None,
+        dest=0x50,
+        source=0x01,
+        data=0x00
+    )
+    data = struct.pack("<H", 0x2A)
+    pkt.data = data
+    assert pkt.data == data
+
+
+@pytest.mark.parametrize("params_or_data", params_or_data)
+def test_pack_with_data(params_or_data):
+    """Pack a package with data."""
+    message_id = 0x0000
+    param1 = params_or_data[0]
+    param2 = params_or_data[1]
+    dest = 0x50
+    source = 0x01
+    data = params_or_data[2]
+    pkt = _packets.ThorLabsPacket(
+        message_id=message_id,
+        param1=param1,
+        param2=param2,
+        dest=dest,
+        source=source,
+        data=data,
+    )
+
+    if params_or_data[3]:
+        message_header = struct.Struct("<HHBB")
+        pkt_expected = message_header.pack(
+            message_id, len(data), 0x80 | dest, source
+        ) + data
+    else:
+        message_header = struct.Struct("<HBBBB")
+        pkt_expected = message_header.pack(
+            message_id, param1, param2, dest, source
+        )
+    assert pkt.pack() == pkt_expected
+
+
+@pytest.mark.parametrize("params_or_data", params_or_data)
+def test_unpack(params_or_data):
+    """Unpack data - the reverse operation of packing it!"""
+    message_id = 0x0000
+    param1 = params_or_data[0]
+    param2 = params_or_data[1]
+    dest = 0x50
+    source = 0x01
+    data = params_or_data[2]
+    pkt = _packets.ThorLabsPacket(
+        message_id=message_id,
+        param1=param1,
+        param2=param2,
+        dest=dest,
+        source=source,
+        data=data,
+    )
+    packed_package = pkt.pack()
+    unpacked_package = pkt.unpack(packed_package)
+    assert unpacked_package.message_id == message_id
+    assert unpacked_package.parameters == (param1, param2)
+    assert unpacked_package.data == data
+    assert unpacked_package.destination == dest
+    assert unpacked_package.source == source
+
+
+def test_unpack_empty_packet():
+    """Raise ValueError if trying to unpack empty string."""
+    pkt = _packets.ThorLabsPacket(
+        message_id=0x000,
+        param1=0x01,
+        param2=0x02,
+        dest=0x50,
+        source=0x01,
+        data=None
+    )
+    with pytest.raises(ValueError) as err_info:
+        pkt.unpack("")
+    err_msg = err_info.value.args[0]
+    assert err_msg == "Expected a packet, got an empty string instead."
+
+
+def test_unpack_too_short():
+    """Raise ValueError if trying to unpack to short value."""
+    pkt = _packets.ThorLabsPacket(
+        message_id=0x000,
+        param1=0x01,
+        param2=0x02,
+        dest=0x50,
+        source=0x01,
+        data=None
+    )
+    too_short_package = struct.pack("<HH", 0x01, 0x02)
+    with pytest.raises(ValueError) as err_info:
+        pkt.unpack(too_short_package)
+    err_msg = err_info.value.args[0]
+    assert err_msg == "Packet must be at least 6 bytes long."

--- a/instruments/thorlabs/_abstract.py
+++ b/instruments/thorlabs/_abstract.py
@@ -72,7 +72,7 @@ class ThorLabsInstrument(Instrument):
         """
         t_start = time.time()
 
-        if timeout:
+        if timeout is not None:
             timeout = assume_units(timeout, second).rescale('second').magnitude
 
         while True:

--- a/instruments/thorlabs/_packets.py
+++ b/instruments/thorlabs/_packets.py
@@ -51,8 +51,6 @@ class ThorLabsPacket:
         if not has_data and (data is not None):
             raise ValueError("A ThorLabs packet can either have parameters "
                              "or data, but not both.")
-        if param1 is None and param2 is None and data is None:
-            raise ValueError("You must specify either data or parameters.")
 
         self._message_id = message_id
         self._param1 = param1
@@ -66,12 +64,17 @@ class ThorLabsPacket:
         return """
 ThorLabs APT packet:
     Message ID      0x{0._message_id:x}
-    Parameter 1     0x{0._param1:x}
-    Parameter 2     0x{0._param2:x}
+    Parameter 1     {1}
+    Parameter 2     {2}
     Destination     0x{0._dest:x}
     Source          0x{0._source:x}
-    Data            {1}
-""".format(self, "{:x}".format(self._data) if self._has_data else "None")
+    Data            {3}
+""".format(
+    self,
+    "0x{:x}".format(self._param1) if not self._has_data else "None",
+    "0x{:x}".format(self._param2) if not self._has_data else "None",
+    "{}".format(self._data) if self._has_data else "None"
+)
 
     @property
     def message_id(self):
@@ -97,7 +100,7 @@ ThorLabs APT packet:
 
     @parameters.setter
     def parameters(self, newval):
-        self._message_id = newval
+        self._param1, self._param2 = newval
 
     @property
     def destination(self):


### PR DESCRIPTION
Test suites for both thorlabs helper classes with full coverage. Mainly (only?) used by ThorlabsAPT.

Bug fixes for `_abstract.py`:
- Re-stated `if timeout` to `if timeout is not None` to avoid
  ambivalence if a timeout of zero is specified (as done in the test to
  speed things up). By default, `timeout` is set to `None`.

Bug fixes for `_packets.py`:
- Removed inaccessible code.
- `__str__` had several errors in it and couldn't print when given
  variables were `None` (which some of them always have to be)
- `parameters` setter previously set `message_id` instead of parameters.