### PR TITLE
Rename visa to pyvisa

### DIFF
--- a/instruments/abstract_instruments/comm/visa_communicator.py
+++ b/instruments/abstract_instruments/comm/visa_communicator.py
@@ -10,7 +10,7 @@ library.
 
 import io
 
-import visa
+import pyvisa
 
 from instruments.abstract_instruments.comm import AbstractCommunicator
 from instruments.util_fns import assume_units
@@ -29,13 +29,13 @@ class VisaCommunicator(io.IOBase, AbstractCommunicator):
     def __init__(self, conn):
         super(VisaCommunicator, self).__init__(self)
 
-        if visa is None:
+        if pyvisa is None:
             raise ImportError("PyVISA required for accessing VISA instruments.")
 
-        version = int(visa.__version__.replace(".", "").ljust(3, "0"))
+        version = int(pyvisa.__version__.replace(".", "").ljust(3, "0"))
         # pylint: disable=no-member
-        if (version < 160 and isinstance(conn, visa.Instrument)) or \
-                (version >= 160 and isinstance(conn, visa.Resource)):
+        if (version < 160 and isinstance(conn, pyvisa.Instrument)) or \
+                (version >= 160 and isinstance(conn, pyvisa.Resource)):
             self._conn = conn
             self._terminator = "\n"
         else:

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -15,7 +15,7 @@ import urllib.parse as parse
 from serial import SerialException
 from serial.tools.list_ports import comports
 import numpy as np
-import visa
+import pyvisa
 import usb
 import usb.core
 import usb.util
@@ -581,16 +581,16 @@ class Instrument:
 
         .. _PyVISA: http://pyvisa.sourceforge.net/
         """
-        if visa is None:
+        if pyvisa is None:
             raise ImportError("PyVISA is required for loading VISA "
                               "instruments.")
-        version = list(map(int, visa.__version__.split(".")))
+        version = list(map(int, pyvisa.__version__.split(".")))
         while len(version) < 3:
             version += [0]
         if version[0] >= 1 and version[1] >= 6:
-            ins = visa.ResourceManager().open_resource(resource_name)
+            ins = pyvisa.ResourceManager().open_resource(resource_name)
         else:
-            ins = visa.instrument(resource_name)  #pylint: disable=no-member
+            ins = pyvisa.instrument(resource_name)  #pylint: disable=no-member
         return cls(VisaCommunicator(ins))
 
     @classmethod

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -272,14 +272,14 @@ def test_instrument_open_gpibusb(mock_serial_manager, mock_gpib_comm):
     )
 
 
-@mock.patch("instruments.abstract_instruments.instrument.visa", new=None)
+@mock.patch("instruments.abstract_instruments.instrument.pyvisa", new=None)
 def test_instrument_open_visa_import_error():
     with pytest.raises(ImportError):
         _ = ik.Instrument.open_visa("abc123")
 
 
 @mock.patch("instruments.abstract_instruments.instrument.VisaCommunicator")
-@mock.patch("instruments.abstract_instruments.instrument.visa")
+@mock.patch("instruments.abstract_instruments.instrument.pyvisa")
 def test_instrument_open_visa_new_version(mock_visa, mock_visa_comm):
     mock_visa_comm.return_value.__class__ = VisaCommunicator
     mock_visa.__version__ = "1.8"
@@ -294,7 +294,7 @@ def test_instrument_open_visa_new_version(mock_visa, mock_visa_comm):
 
 
 @mock.patch("instruments.abstract_instruments.instrument.VisaCommunicator")
-@mock.patch("instruments.abstract_instruments.instrument.visa")
+@mock.patch("instruments.abstract_instruments.instrument.pyvisa")
 def test_instrument_open_visa_old_version(mock_visa, mock_visa_comm):
     mock_visa_comm.return_value.__class__ = VisaCommunicator
     mock_visa.__version__ = "1.5"


### PR DESCRIPTION
Switch `import visa` and dependent statements to `import pyvisa`.
Takes care of depreciation warning to avoid further conflicts with other
package. See issue #273 

@scasagrande Was indeed fairly minimal