### PR TITLE
Remove numpy as hard requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ jobs:
     env: TOXENV=py38
   - python: 3.9
     env: TOXENV=py39
+  - python: 3.9
+    env: TOXENV=py39-numpy
 before_install:
 - python --version
 - uname -a

--- a/README.rst
+++ b/README.rst
@@ -131,10 +131,8 @@ existing classes which are similar to your work to learn more about the
 structure of this project.
 
 To run the tests against all supported version of Python, you will need to
-have the binary for each installed, as well as any requirements needed to
-install ``numpy`` under each Python version. On Debian/Ubuntu systems this means
-you will need to install the ``python-dev`` package for each version of Python
-supported (``python3.8-dev``, etc).
+have the binary for each installed. The easiest way to accomplish this is
+to use the tool `pyenv<https://github.com/pyenv/pyenv>_`.
 
 With the required system packages installed, all tests can be run with ``tox``:
 

--- a/instruments/__init__.py
+++ b/instruments/__init__.py
@@ -35,9 +35,8 @@ from . import thorlabs
 from . import toptica
 from . import yokogawa
 
-from .units import ureg as units
-
 from .config import load_instruments
+from .units import ureg as units
 
 # VERSION METADATA ###########################################################
 # In keeping with PEP-396, we define a version number of the form

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -20,12 +20,12 @@ import usb
 import usb.core
 import usb.util
 
-from instruments.optional_dep_finder import numpy
 from instruments.abstract_instruments.comm import (
     SocketCommunicator, USBCommunicator, VisaCommunicator, FileCommunicator,
     LoopbackCommunicator, GPIBCommunicator, AbstractCommunicator,
     USBTMCCommunicator, VXI11Communicator, serial_manager
 )
+from instruments.optional_dep_finder import numpy
 from instruments.errors import AcknowledgementError, PromptError
 
 # CONSTANTS ###################################################################

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -15,15 +15,12 @@ import urllib.parse as parse
 
 from serial import SerialException
 from serial.tools.list_ports import comports
-try:
-    import numpy
-except ImportError:
-    numpy = None
 import pyvisa
 import usb
 import usb.core
 import usb.util
 
+from instruments.optional_dep_finder import numpy
 from instruments.abstract_instruments.comm import (
     SocketCommunicator, USBCommunicator, VisaCommunicator, FileCommunicator,
     LoopbackCommunicator, GPIBCommunicator, AbstractCommunicator,

--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -10,11 +10,15 @@ Provides the base Instrument class for all instruments.
 import os
 import collections
 import socket
+import struct
 import urllib.parse as parse
 
 from serial import SerialException
 from serial.tools.list_ports import comports
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 import pyvisa
 import usb
 import usb.core
@@ -285,7 +289,9 @@ class Instrument:
                     raise IOError("Did not read in the required number of bytes"
                                   "during binblock read. Got {}, expected "
                                   "{}".format(len(data), num_of_bytes))
-            return np.frombuffer(data, dtype=fmt)
+            if numpy:
+                return numpy.frombuffer(data, dtype=fmt)
+            return struct.unpack(f"{fmt[0]}{int(len(data)/data_width)}{fmt[-1]}", data)
 
     # CLASS METHODS #
 

--- a/instruments/agilent/agilent34410a.py
+++ b/instruments/agilent/agilent34410a.py
@@ -79,7 +79,8 @@ class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
 
         :param int count: Number of samples to take.
 
-        :rtype: `~pint.Quantity` with `numpy.array`
+        :rtype: `tuple`[`~pint.Quantity`, ...]
+            or if numpy is installed, `~pint.Quantity` with `numpy.array` data
         """
         mode = self.mode
         units = UNITS[mode]
@@ -94,8 +95,7 @@ class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
         data = self.binblockread(8, fmt=">d")
         if numpy:
             return data * units
-        else:
-            return tuple(val * units for val in data)
+        return tuple(val * units for val in data)
 
     # DATA READING METHODS #
 
@@ -111,7 +111,8 @@ class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
         recommended to transfer a large number of
         data points using this method.
 
-        :rtype: `list` of `~pint.Quantity` elements
+        :rtype: `tuple`[`~pint.Quantity`, ...]
+            or if numpy is installed, `~pint.Quantity` with `numpy.array` data
         """
         units = UNITS[self.mode]
         data = list(map(float, self.query('FETC?').split(',')))
@@ -130,7 +131,8 @@ class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
             output buffer. If set to -1, all points in memory will be
             transfered.
 
-        :rtype: `list` of `~pint.Quantity` elements
+        :rtype: `tuple`[`~pint.Quantity`, ...]
+            or if numpy is installed, `~pint.Quantity` with `numpy.array` data
         """
         if not isinstance(sample_count, int):
             raise TypeError('Parameter "sample_count" must be an integer.')
@@ -149,7 +151,8 @@ class Agilent34410a(SCPIMultimeter):  # pylint: disable=abstract-method
         """
         Returns all readings in non-volatile memory (NVMEM).
 
-        :rtype: `list` of `~pint.Quantity` elements
+        :rtype: `tuple`[`~pint.Quantity`, ...]
+            or if numpy is installed, `~pint.Quantity` with `numpy.array` data
         """
         units = UNITS[self.mode]
         data = list(map(float, self.query('DATA:DATA? NVMEM').split(',')))

--- a/instruments/agilent/agilent34410a.py
+++ b/instruments/agilent/agilent34410a.py
@@ -6,12 +6,8 @@ Provides support for the Agilent 34410a digital multimeter.
 
 # IMPORTS #####################################################################
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
 from instruments.generic_scpi import SCPIMultimeter
+from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
 
 # CLASSES #####################################################################

--- a/instruments/hp/hp6624a.py
+++ b/instruments/hp/hp6624a.py
@@ -250,9 +250,9 @@ class HP6624a(PowerSupply):
             of units Volts.
         :type: `list` of `~pint.Quantity` with units Volt
         """
-        return [
+        return tuple([
             self.channel[i].voltage for i in range(self.channel_count)
-        ]
+        ])
 
     @voltage.setter
     def voltage(self, newval):
@@ -276,9 +276,9 @@ class HP6624a(PowerSupply):
             of units Amps.
         :type: `list` of `~pint.Quantity` with units Amp
         """
-        return [
+        return tuple([
             self.channel[i].current for i in range(self.channel_count)
-        ]
+        ])
 
     @current.setter
     def current(self, newval):
@@ -301,7 +301,7 @@ class HP6624a(PowerSupply):
         :units: :math:`\\text{V}` (volts)
         :rtype: `tuple` of `~pint.Quantity`
         """
-        return (
+        return tuple(
             self.channel[i].voltage_sense for i in range(self.channel_count)
         )
 
@@ -313,7 +313,7 @@ class HP6624a(PowerSupply):
         :units: :math:`\\text{A}` (amps)
         :rtype: `tuple` of `~pint.Quantity`
         """
-        return (
+        return tuple(
             self.channel[i].current_sense for i in range(self.channel_count)
         )
 

--- a/instruments/hp/hp6624a.py
+++ b/instruments/hp/hp6624a.py
@@ -248,7 +248,7 @@ class HP6624a(PowerSupply):
 
         :units: As specified (if a `~pint.Quantity`) or assumed to be
             of units Volts.
-        :type: `list` of `~pint.Quantity` with units Volt
+        :type: `tuple`[`~pint.Quantity`, ...] with units Volt
         """
         return tuple([
             self.channel[i].voltage for i in range(self.channel_count)
@@ -274,7 +274,7 @@ class HP6624a(PowerSupply):
 
         :units: As specified (if a `~pint.Quantity`) or assumed to be
             of units Amps.
-        :type: `list` of `~pint.Quantity` with units Amp
+        :type: `tuple`[`~pint.Quantity`, ...] with units Amp
         """
         return tuple([
             self.channel[i].current for i in range(self.channel_count)
@@ -299,7 +299,7 @@ class HP6624a(PowerSupply):
         Gets the actual voltage as measured by the sense wires for all channels.
 
         :units: :math:`\\text{V}` (volts)
-        :rtype: `tuple` of `~pint.Quantity`
+        :rtype: `tuple`[`~pint.Quantity`, ...]
         """
         return tuple(
             self.channel[i].voltage_sense for i in range(self.channel_count)
@@ -311,7 +311,7 @@ class HP6624a(PowerSupply):
         Gets the actual current as measured by the instrument for all channels.
 
         :units: :math:`\\text{A}` (amps)
-        :rtype: `tuple` of `~pint.Quantity`
+        :rtype: `tuple`[`~pint.Quantity`, ...]
         """
         return tuple(
             self.channel[i].current_sense for i in range(self.channel_count)

--- a/instruments/keithley/keithley2182.py
+++ b/instruments/keithley/keithley2182.py
@@ -27,7 +27,7 @@ class Keithley2182(SCPIMultimeter):
 
     >>> import instruments as ik
     >>> meter = ik.keithley.Keithley2182.open_gpibusb("/dev/ttyUSB0", 10)
-    >>> print meter.measure(meter.Mode.voltage_dc)
+    >>> print(meter.measure(meter.Mode.voltage_dc))
 
 
     """
@@ -213,7 +213,8 @@ class Keithley2182(SCPIMultimeter):
         recommended to transfer a large number of data points using GPIB.
 
         :return: Measurement readings from the instrument output buffer.
-        :rtype: `list` of `~pint.Quantity` elements
+        :rtype: `tuple`[`~pint.Quantity`, ...]
+            or if numpy is installed, `~pint.Quantity` with `numpy.array` data
         """
         data = list(map(float, self.query("FETC?").split(",")))
         unit = self.units

--- a/instruments/keithley/keithley2182.py
+++ b/instruments/keithley/keithley2182.py
@@ -8,13 +8,9 @@ Driver for the Keithley 2182 nano-voltmeter
 
 from enum import Enum
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
-from instruments.generic_scpi import SCPIMultimeter
 from instruments.abstract_instruments import Multimeter
+from instruments.generic_scpi import SCPIMultimeter
+from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
 from instruments.util_fns import ProxyList
 

--- a/instruments/keithley/keithley2182.py
+++ b/instruments/keithley/keithley2182.py
@@ -7,10 +7,15 @@ Driver for the Keithley 2182 nano-voltmeter
 # IMPORTS #####################################################################
 
 from enum import Enum
-from instruments.units import ureg as u
+
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 from instruments.generic_scpi import SCPIMultimeter
 from instruments.abstract_instruments import Multimeter
+from instruments.units import ureg as u
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################
@@ -214,7 +219,11 @@ class Keithley2182(SCPIMultimeter):
         :return: Measurement readings from the instrument output buffer.
         :rtype: `list` of `~pint.Quantity` elements
         """
-        return list(map(float, self.query("FETC?").split(","))) * self.units
+        data = list(map(float, self.query("FETC?").split(",")))
+        unit = self.units
+        if numpy:
+            return data * unit
+        return tuple(d * unit for d in data)
 
     def measure(self, mode=None):
         """

--- a/instruments/optional_dep_finder.py
+++ b/instruments/optional_dep_finder.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+"""
+Small module to obtain handles to optional dependencies
+"""
+
+# pylint: disable=unused-import
+try:
+    import numpy
+    _numpy_installed = True
+except ImportError:
+    numpy = None
+    _numpy_installed = False

--- a/instruments/srs/srs830.py
+++ b/instruments/srs/srs830.py
@@ -12,17 +12,13 @@ import time
 import warnings
 from enum import Enum, IntEnum
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
 from instruments.abstract_instruments.comm import (
     GPIBCommunicator,
     SerialCommunicator,
     LoopbackCommunicator
 )
 from instruments.generic_scpi import SCPIInstrument
+from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
 from instruments.util_fns import (
     bool_property, bounded_unitful_property, enum_property, unitful_property

--- a/instruments/srs/srs830.py
+++ b/instruments/srs/srs830.py
@@ -352,7 +352,8 @@ class SRS830(SCPIInstrument):
 
         :param `int` num_samples: Number of samples to take.
 
-        :rtype: `list`
+        :rtype: `tuple`[`tuple`[`float`, ...], `tuple`[`float`, ...]]
+            or if numpy is installed, `numpy.array`[`numpy.array`, `numpy.array`]
         """
         if num_samples > 16383:
             raise ValueError('Number of samples cannot exceed 16383.')
@@ -501,7 +502,7 @@ class SRS830(SCPIInstrument):
             given by {CH1|CH2}.
         :type channel: `SRS830.Mode` or `str`
 
-        :rtype: `list`
+        :rtype: `tuple`[`float`, ...] or if numpy is installed, `numpy.array`
         """
         if isinstance(channel, str):
             channel = channel.lower()

--- a/instruments/srs/srs830.py
+++ b/instruments/srs/srs830.py
@@ -12,7 +12,10 @@ import time
 import warnings
 from enum import Enum, IntEnum
 
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 from instruments.abstract_instruments.comm import (
     GPIBCommunicator,
@@ -380,7 +383,9 @@ class SRS830(SCPIInstrument):
         ch1 = self.read_data_buffer('ch1')
         ch2 = self.read_data_buffer('ch2')
 
-        return np.array([ch1, ch2])
+        if numpy:
+            return numpy.array([ch1, ch2])
+        return ch1, ch2
 
     # OTHER METHODS #
 
@@ -517,10 +522,10 @@ class SRS830(SCPIInstrument):
         # Query device for entire buffer, returning in ASCII, then
         # converting to a list of floats before returning to the
         # calling method
-        return np.fromstring(
-            self.query('TRCA?{},0,{}'.format(channel, N)).strip(),
-            sep=','
-        )
+        data = self.query('TRCA?{},0,{}'.format(channel, N)).strip()
+        if numpy:
+            return numpy.fromstring(data, sep=',')
+        return tuple(map(float, data.split(",")))
 
     def clear_data_buffer(self):
         """

--- a/instruments/srs/srsctc100.py
+++ b/instruments/srs/srsctc100.py
@@ -244,8 +244,9 @@ class SRSCTC100(SCPIInstrument):
 
             :return: Tuple of all the log data points. First value is time,
                 second is the measurement value.
-            :rtype: Tuple of 2x `~pint.Quantity`, each comprised of
-                a numpy array (`numpy.dnarray`).
+            :rtype: If numpy is installed, tuple of 2x `~pint.Quantity`,
+                each comprised of a numpy array (`numpy.dnarray`).
+                Else, `tuple`[`tuple`[`~pint.Quantity`, ...], `tuple`[`~pint.Quantity`, ...]]
             """
             # Remember the current units.
             units = self.units
@@ -273,6 +274,10 @@ class SRSCTC100(SCPIInstrument):
             # Do an actual error check now.
             if self._ctc.error_check_toggle:
                 self._ctc.errcheck()
+
+            if not numpy:
+                ts = tuple(ts)
+                temps = tuple(temps)
 
             return ts, temps
 

--- a/instruments/srs/srsctc100.py
+++ b/instruments/srs/srsctc100.py
@@ -9,7 +9,10 @@ Provides support for the SRS CTC-100 cryogenic temperature controller.
 from contextlib import contextmanager
 from enum import Enum
 
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.units import ureg as u
@@ -257,8 +260,12 @@ class SRSCTC100(SCPIInstrument):
 
             # Make an empty quantity that size for the times and for the channel
             # values.
-            ts = u.Quantity(np.empty((n_points,)), 'ms')
-            temps = u.Quantity(np.empty((n_points,)), units)
+            if numpy:
+                ts = u.Quantity(numpy.empty((n_points,)), u.ms)
+                temps = u.Quantity(numpy.empty((n_points,)), units)
+            else:
+                ts = u.Quantity([0] * n_points, u.ms)
+                temps = u.Quantity([0] * n_points, units)
 
             # Reset the position to the first point, then save it.
             # pylint: disable=protected-access

--- a/instruments/srs/srsctc100.py
+++ b/instruments/srs/srsctc100.py
@@ -9,12 +9,8 @@ Provides support for the SRS CTC-100 cryogenic temperature controller.
 from contextlib import contextmanager
 from enum import Enum
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
 from instruments.generic_scpi import SCPIInstrument
+from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
 from instruments.util_fns import ProxyList
 

--- a/instruments/srs/srsctc100.py
+++ b/instruments/srs/srsctc100.py
@@ -264,8 +264,8 @@ class SRSCTC100(SCPIInstrument):
                 ts = u.Quantity(numpy.empty((n_points,)), u.ms)
                 temps = u.Quantity(numpy.empty((n_points,)), units)
             else:
-                ts = u.Quantity([0] * n_points, u.ms)
-                temps = u.Quantity([0] * n_points, units)
+                ts = [u.Quantity(0, u.ms)] * n_points
+                temps = [u.Quantity(0, units)] * n_points
 
             # Reset the position to the first point, then save it.
             # pylint: disable=protected-access

--- a/instruments/tektronix/tekawg2000.py
+++ b/instruments/tektronix/tekawg2000.py
@@ -8,12 +8,8 @@ Provides support for the Tektronix AWG2000 series arbitrary wave generators.
 
 from enum import Enum
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
 from instruments.generic_scpi import SCPIInstrument
+from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
 from instruments.util_fns import assume_units, ProxyList
 

--- a/instruments/tektronix/tekawg2000.py
+++ b/instruments/tektronix/tekawg2000.py
@@ -8,7 +8,10 @@ Provides support for the Tektronix AWG2000 series arbitrary wave generators.
 
 from enum import Enum
 
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 from instruments.generic_scpi import SCPIInstrument
 from instruments.units import ureg as u
@@ -231,6 +234,10 @@ class TekAWG2000(SCPIInstrument):
             that all absolute values contained within the array should not
             exceed 1.
         """
+        if numpy is None:
+            raise ImportError("Missing optional dependency numpy, which is required"
+                              "for uploading waveforms.")
+
         if not isinstance(yzero, float) and not isinstance(yzero, int):
             raise TypeError("yzero must be specified as a float or int")
 
@@ -240,10 +247,10 @@ class TekAWG2000(SCPIInstrument):
         if not isinstance(xincr, float) and not isinstance(xincr, int):
             raise TypeError("xincr must be specified as a float or int")
 
-        if not isinstance(waveform, np.ndarray):
+        if not isinstance(waveform, numpy.ndarray):
             raise TypeError("waveform must be specified as a numpy array")
 
-        if np.max(np.abs(waveform)) > 1:
+        if numpy.max(numpy.abs(waveform)) > 1:
             raise ValueError("The max value for an element in waveform is 1.")
 
         self.sendcmd("WFMP:YZERO {}".format(yzero))

--- a/instruments/tektronix/tekdpo4104.py
+++ b/instruments/tektronix/tekdpo4104.py
@@ -95,6 +95,8 @@ class _TekDPO4104DataSource(OscilloscopeDataSource):
 
         :param bool bin_format: If `True`, data is transfered
             in a binary format. Otherwise, data is transferred in ASCII.
+        :rtype: `tuple`[`tuple`[`~pint.Quantity`, ...], `tuple`[`~pint.Quantity`, ...]]
+            or if numpy is installed, `tuple` of two `~pint.Quantity` with `numpy.array` data
         """
 
         # Set the acquisition channel

--- a/instruments/tektronix/tekdpo4104.py
+++ b/instruments/tektronix/tekdpo4104.py
@@ -142,8 +142,8 @@ class _TekDPO4104DataSource(OscilloscopeDataSource):
                 x = numpy.arange(float(ptcnt)) * float(xincr) + float(xzero)
                 y = ((raw - yoffs) * float(ymult)) + float(yzero)
             else:
-                x = tuple([float(val) * float(xincr) + float(xzero) for val in range(ptcnt)])
-                y = [((x - yoffs) * float(ymult)) + float(yzero) for x in raw]
+                x = tuple([float(val) * float(xincr) + float(xzero) for val in range(int(ptcnt))])
+                y = tuple(((x - yoffs) * float(ymult)) + float(yzero) for x in raw)
 
             self._tek.sendcmd("DAT:STOP {}".format(old_dat_stop))
 

--- a/instruments/tektronix/tekdpo4104.py
+++ b/instruments/tektronix/tekdpo4104.py
@@ -127,7 +127,8 @@ class _TekDPO4104DataSource(OscilloscopeDataSource):
             ymult = self._tek.query("WFMP:YMU?")  # Retrieve Y multiplier
             yzero = self._tek.query("WFMP:YZE?")  # Retrieve Y zero
 
-            y = ((raw - yoffs) * float(ymult)) + float(yzero)
+            # y = ((raw - yoffs) * float(ymult)) + float(yzero)
+            y = [((x - yoffs) * float(ymult)) + float(yzero) for x in raw]
 
             xzero = self._tek.query("WFMP:XZE?")  # Retrieve X zero
             xincr = self._tek.query("WFMP:XIN?")  # Retrieve X incr

--- a/instruments/tektronix/tekdpo4104.py
+++ b/instruments/tektronix/tekdpo4104.py
@@ -10,16 +10,12 @@ Provides support for the Tektronix DPO 4104 oscilloscope
 from time import sleep
 from enum import Enum
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
 from instruments.abstract_instruments import (
     OscilloscopeChannel,
     OscilloscopeDataSource,
     Oscilloscope,
 )
+from instruments.optional_dep_finder import numpy
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import ProxyList
 

--- a/instruments/tektronix/tekdpo4104.py
+++ b/instruments/tektronix/tekdpo4104.py
@@ -10,7 +10,10 @@ Provides support for the Tektronix DPO 4104 oscilloscope
 from time import sleep
 from enum import Enum
 
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 from instruments.abstract_instruments import (
     OscilloscopeChannel,
@@ -111,7 +114,10 @@ class _TekDPO4104DataSource(OscilloscopeDataSource):
                 sleep(0.02)  # Work around issue with 2.48 firmware.
                 raw = self._tek.query("CURVE?")
                 raw = raw.split(",")  # Break up comma delimited string
-                raw = np.array(raw, dtype=np.float)  # Convert to numpy array
+                if numpy:
+                    raw = numpy.array(raw, dtype=numpy.float)  # Convert to numpy array
+                else:
+                    raw = map(float, raw)
             else:
                 # Set encoding to signed, big-endian
                 self._tek.sendcmd("DAT:ENC RIB")
@@ -127,15 +133,17 @@ class _TekDPO4104DataSource(OscilloscopeDataSource):
             ymult = self._tek.query("WFMP:YMU?")  # Retrieve Y multiplier
             yzero = self._tek.query("WFMP:YZE?")  # Retrieve Y zero
 
-            # y = ((raw - yoffs) * float(ymult)) + float(yzero)
-            y = [((x - yoffs) * float(ymult)) + float(yzero) for x in raw]
-
             xzero = self._tek.query("WFMP:XZE?")  # Retrieve X zero
             xincr = self._tek.query("WFMP:XIN?")  # Retrieve X incr
             # Retrieve number of data points
             ptcnt = self._tek.query("WFMP:NR_P?")
 
-            x = np.arange(float(ptcnt)) * float(xincr) + float(xzero)
+            if numpy:
+                x = numpy.arange(float(ptcnt)) * float(xincr) + float(xzero)
+                y = ((raw - yoffs) * float(ymult)) + float(yzero)
+            else:
+                x = tuple([float(val) * float(xincr) + float(xzero) for val in range(ptcnt)])
+                y = [((x - yoffs) * float(ymult)) + float(yzero) for x in raw]
 
             self._tek.sendcmd("DAT:STOP {}".format(old_dat_stop))
 

--- a/instruments/tektronix/tekdpo70000.py
+++ b/instruments/tektronix/tekdpo70000.py
@@ -27,6 +27,8 @@ from instruments.util_fns import (
 
 # CLASSES #####################################################################
 
+# pylint: disable=too-many-lines
+
 
 class TekDPO70000(SCPIInstrument, Oscilloscope):
 
@@ -485,9 +487,9 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
             # TODO: incorperate the unit_string somehow
             if numpy:
                 return self.scale * (
-                    (TekDPO70000.VERT_DIVS / 2) *
-                    data.astype(float) / (2**15) - self.position
+                    (TekDPO70000.VERT_DIVS / 2) * data.astype(float) / (2**15) - self.position
                 )
+
             scale = self.scale
             position = self.position
             rval = tuple(

--- a/instruments/tektronix/tekdpo70000.py
+++ b/instruments/tektronix/tekdpo70000.py
@@ -10,15 +10,11 @@ import abc
 from enum import Enum
 import time
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
 from instruments.abstract_instruments import (
     Oscilloscope, OscilloscopeChannel, OscilloscopeDataSource
 )
 from instruments.generic_scpi import SCPIInstrument
+from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
 from instruments.util_fns import (
     enum_property, string_property, int_property, unitful_property,

--- a/instruments/tektronix/tekdpo70000.py
+++ b/instruments/tektronix/tekdpo70000.py
@@ -483,10 +483,18 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
         def _scale_raw_data(self, data):
             # TODO: incorperate the unit_string somehow
-            return self.scale * (
-                (TekDPO70000.VERT_DIVS / 2) *
-                data.astype(float) / (2**15) - self.position
+            if numpy:
+                return self.scale * (
+                    (TekDPO70000.VERT_DIVS / 2) *
+                    data.astype(float) / (2**15) - self.position
+                )
+            scale = self.scale
+            position = self.position
+            rval = tuple(
+                scale * ((TekDPO70000.VERT_DIVS / 2) * d / (2 ** 15) - position)
+                for d in map(float, data)
             )
+            return rval
 
     class Channel(DataSource, OscilloscopeChannel):
 
@@ -629,10 +637,10 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
                     data.astype(float) / (2**15) - position
                 ) + offset
 
-            return [
+            return tuple(
                 scale * ((TekDPO70000.VERT_DIVS / 2) * d / (2 ** 15) - position) + offset
                 for d in map(float, data)
-            ]
+            )
 
     # PROPERTIES ##
 

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -10,7 +10,10 @@ import time
 
 from enum import Enum
 
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 from instruments.abstract_instruments import (
     OscilloscopeChannel,
@@ -72,7 +75,10 @@ class _TekTDS224DataSource(OscilloscopeDataSource):
                 # Set the data encoding format to ASCII
                 raw = self._tek.query("CURVE?")
                 raw = raw.split(',')  # Break up comma delimited string
-                raw = np.array(raw, dtype=np.float)  # Convert to ndarray
+                if numpy:
+                    raw = numpy.array(raw, dtype=numpy.float)  # Convert to ndarray
+                else:
+                    raw = tuple(map(float, raw))
             else:
                 self._tek.sendcmd("DAT:ENC RIB")
                 # Set encoding to signed, big-endian
@@ -98,7 +104,10 @@ class _TekTDS224DataSource(OscilloscopeDataSource):
             # of data
             # points
 
-            x = np.arange(float(ptcnt)) * float(xincr) + float(xzero)
+            if numpy:
+                x = numpy.arange(float(ptcnt)) * float(xincr) + float(xzero)
+            else:
+                x = tuple(float(val) * float(xincr) + float(xzero) for val in range(ptcnt))
 
             return x, y
 

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -62,7 +62,8 @@ class _TekTDS224DataSource(OscilloscopeDataSource):
         :param bool bin_format: If `True`, data is transfered
             in a binary format. Otherwise, data is transferred in ASCII.
 
-        :rtype: two item `tuple` of `numpy.ndarray`
+        :rtype: `tuple`[`tuple`[`float`, ...], `tuple`[`float`, ...]]
+            or if numpy is installed, `tuple`[`numpy.array`, `numpy.array`]
         """
         with self:
 

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -10,17 +10,13 @@ import time
 
 from enum import Enum
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
-
 from instruments.abstract_instruments import (
     OscilloscopeChannel,
     OscilloscopeDataSource,
     Oscilloscope,
 )
 from instruments.generic_scpi import SCPIInstrument
+from instruments.optional_dep_finder import numpy
 from instruments.util_fns import ProxyList
 from instruments.units import ureg as u
 

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -89,7 +89,8 @@ class _TekTDS224DataSource(OscilloscopeDataSource):
             ymult = self._tek.query(f"WFMP:{self.name}:YMU?")  # Retrieve Y multiply
             yzero = self._tek.query(f"WFMP:{self.name}:YZE?")  # Retrieve Y zero
 
-            y = ((raw - float(yoffs)) * float(ymult)) + float(yzero)
+            # y = ((raw - float(yoffs)) * float(ymult)) + float(yzero)
+            y = [((x - float(yoffs)) * float(ymult)) + float(yzero) for x in raw]
 
             xzero = self._tek.query("WFMP:XZE?")  # Retrieve X zero
             xincr = self._tek.query("WFMP:XIN?")  # Retrieve X incr

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -95,19 +95,16 @@ class _TekTDS224DataSource(OscilloscopeDataSource):
             ymult = self._tek.query(f"WFMP:{self.name}:YMU?")  # Retrieve Y multiply
             yzero = self._tek.query(f"WFMP:{self.name}:YZE?")  # Retrieve Y zero
 
-            # y = ((raw - float(yoffs)) * float(ymult)) + float(yzero)
-            y = [((x - float(yoffs)) * float(ymult)) + float(yzero) for x in raw]
-
             xzero = self._tek.query("WFMP:XZE?")  # Retrieve X zero
             xincr = self._tek.query("WFMP:XIN?")  # Retrieve X incr
-            ptcnt = self._tek.query(f"WFMP:{self.name}:NR_P?")  # Retrieve number
-            # of data
-            # points
+            ptcnt = self._tek.query(f"WFMP:{self.name}:NR_P?")  # Retrieve number of data points
 
             if numpy:
                 x = numpy.arange(float(ptcnt)) * float(xincr) + float(xzero)
+                y = ((raw - float(yoffs)) * float(ymult)) + float(yzero)
             else:
-                x = tuple(float(val) * float(xincr) + float(xzero) for val in range(ptcnt))
+                x = tuple(float(val) * float(xincr) + float(xzero) for val in range(int(ptcnt)))
+                y = tuple(((x - float(yoffs)) * float(ymult)) + float(yzero) for x in raw)
 
             return x, y
 

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -40,7 +40,10 @@ import operator
 import struct
 import time
 
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 from instruments.abstract_instruments import (
     OscilloscopeChannel,
@@ -125,7 +128,10 @@ class _TekTDS5xxDataSource(OscilloscopeDataSource):
                 self._parent.sendcmd('DAT:ENC ASCI')
                 raw = self._parent.query('CURVE?')
                 raw = raw.split(',')  # Break up comma delimited string
-                raw = np.array(raw, dtype=np.float)  # Convert into numpy array
+                if numpy:
+                    raw = numpy.array(raw, dtype=numpy.float)  # Convert to numpy array
+                else:
+                    raw = map(float, raw)
             else:
                 # Set encoding to signed, big-endian
                 self._parent.sendcmd('DAT:ENC RIB')
@@ -139,23 +145,25 @@ class _TekTDS5xxDataSource(OscilloscopeDataSource):
                 self._parent._file.read_raw(1)
 
             # Retrieve Y offset
-            yoffs = self._parent.query('WFMP:{}:YOF?'.format(self.name))
+            yoffs = float(self._parent.query('WFMP:{}:YOF?'.format(self.name)))
             # Retrieve Y multiply
-            ymult = self._parent.query('WFMP:{}:YMU?'.format(self.name))
+            ymult = float(self._parent.query('WFMP:{}:YMU?'.format(self.name)))
             # Retrieve Y zero
-            yzero = self._parent.query('WFMP:{}:YZE?'.format(self.name))
-
-            # y = ((raw - float(yoffs)) * float(ymult)) + float(yzero)
-            y = [((x - float(yoffs)) * float(ymult)) + float(yzero) for x in raw]
+            yzero = float(self._parent.query('WFMP:{}:YZE?'.format(self.name)))
 
             # Retrieve X incr
-            xincr = self._parent.query('WFMP:{}:XIN?'.format(self.name))
+            xincr = float(self._parent.query('WFMP:{}:XIN?'.format(self.name)))
             # Retrieve number of data points
-            ptcnt = self._parent.query('WFMP:{}:NR_P?'.format(self.name))
+            ptcnt = int(self._parent.query('WFMP:{}:NR_P?'.format(self.name)))
 
-            x = np.arange(float(ptcnt)) * float(xincr)
+            if numpy:
+                x = numpy.arange(float(ptcnt)) * float(xincr)
+                y = ((raw - yoffs) * float(ymult)) + float(yzero)
+            else:
+                x = tuple([float(val) * float(xincr) for val in range(ptcnt)])
+                y = [((x - yoffs) * float(ymult)) + float(yzero) for x in raw]
 
-            return (x, y)
+            return x, y
 
 
 class _TekTDS5xxChannel(_TekTDS5xxDataSource, OscilloscopeChannel):
@@ -401,7 +409,7 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
         :rtype: `list`
         """
         active = []
-        channels = np.array(self.query('SEL?').split(';')[0:11], dtype=np.int)
+        channels = list(map(int, self.query('SEL?').split(';')[0:11]))
         for idx in range(0, 4):
             if channels[idx]:
                 active.append(_TekTDS5xxChannel(self, idx))

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -40,10 +40,6 @@ import operator
 import struct
 import time
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
 
 from instruments.abstract_instruments import (
     OscilloscopeChannel,
@@ -51,6 +47,7 @@ from instruments.abstract_instruments import (
     Oscilloscope,
 )
 from instruments.generic_scpi import SCPIInstrument
+from instruments.optional_dep_finder import numpy
 from instruments.util_fns import ProxyList
 
 # CLASSES #####################################################################

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -116,7 +116,8 @@ class _TekTDS5xxDataSource(OscilloscopeDataSource):
         :param bool bin_format: If `True`, data is transfered
             in a binary format. Otherwise, data is transferred in ASCII.
 
-        :rtype: two item `tuple` of `numpy.ndarray`
+        :rtype: `tuple`[`tuple`[`float`, ...], `tuple`[`float`, ...]]
+            or if numpy is installed, `tuple`[`numpy.array`, `numpy.array`]
         """
         with self:
 
@@ -158,7 +159,7 @@ class _TekTDS5xxDataSource(OscilloscopeDataSource):
                 y = ((raw - yoffs) * float(ymult)) + float(yzero)
             else:
                 x = tuple([float(val) * float(xincr) for val in range(ptcnt)])
-                y = [((x - yoffs) * float(ymult)) + float(yzero) for x in raw]
+                y = tuple(((x - yoffs) * float(ymult)) + float(yzero) for x in raw)
 
             return x, y
 

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -145,7 +145,8 @@ class _TekTDS5xxDataSource(OscilloscopeDataSource):
             # Retrieve Y zero
             yzero = self._parent.query('WFMP:{}:YZE?'.format(self.name))
 
-            y = ((raw - float(yoffs)) * float(ymult)) + float(yzero)
+            # y = ((raw - float(yoffs)) * float(ymult)) + float(yzero)
+            y = [((x - float(yoffs)) * float(ymult)) + float(yzero) for x in raw]
 
             # Retrieve X incr
             xincr = self._parent.query('WFMP:{}:XIN?'.format(self.name))

--- a/instruments/teledyne/maui.py
+++ b/instruments/teledyne/maui.py
@@ -16,7 +16,10 @@ class.
 # IMPORTS #####################################################################
 
 from enum import Enum
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 from instruments.abstract_instruments import (
     Oscilloscope, OscilloscopeChannel, OscilloscopeDataSource
@@ -265,19 +268,25 @@ class MAUI(Oscilloscope):
                 self._parent.trigger_state = trig_state
 
             # format the string to appropriate data
-            dat_val = np.array(retval.replace('"', '').split(),
-                               dtype=np.float)
+            retval = retval.replace('"', '').split()
+            if numpy:
+                dat_val = numpy.array(retval, dtype=numpy.float)  # Convert to ndarray
+            else:
+                dat_val = tuple(map(float, retval))
 
             # format horizontal data into floats
             horiz_off = float(horiz_off.replace('"', '').split(':')[1])
             horiz_int = float(horiz_int.replace('"', '').split(':')[1])
 
             # create time base
-            dat_time = np.arange(
-                horiz_off,
-                horiz_off + horiz_int * (len(dat_val)),
-                horiz_int
-            )
+            if numpy:
+                dat_time = numpy.arange(
+                    horiz_off,
+                    horiz_off + horiz_int * (len(dat_val)),
+                    horiz_int
+                )
+            else:
+                dat_time = tuple(val * horiz_int + horiz_off for val in range(len(dat_val)))
 
             # fix length bug, sometimes dat_time is longer than dat_signal
             if len(dat_time) > len(dat_val):
@@ -285,7 +294,10 @@ class MAUI(Oscilloscope):
             else:  # in case the opposite is the case
                 dat_val = dat_val[0:len(dat_time)]
 
-            return np.stack((dat_time, dat_val))
+            if numpy:
+                return numpy.stack((dat_time, dat_val))
+            else:
+                return dat_time, dat_val
 
         trace = bool_property(
             command="TRA",

--- a/instruments/teledyne/maui.py
+++ b/instruments/teledyne/maui.py
@@ -230,7 +230,8 @@ class MAUI(Oscilloscope):
 
             :return: Data (time, signal) where time is in seconds and
                 signal in V
-            :rtype: ndarray
+            :rtype: `tuple`[`tuple`[`~pint.Quantity`, ...], `tuple`[`~pint.Quantity`, ...]]
+                or if numpy is installed, `tuple`[`numpy.array`, `numpy.array`]
 
             :raises NotImplementedError: Bin format was chosen, but
                 it is not implemented.

--- a/instruments/teledyne/maui.py
+++ b/instruments/teledyne/maui.py
@@ -16,14 +16,11 @@ class.
 # IMPORTS #####################################################################
 
 from enum import Enum
-try:
-    import numpy
-except ImportError:
-    numpy = None
 
 from instruments.abstract_instruments import (
     Oscilloscope, OscilloscopeChannel, OscilloscopeDataSource
 )
+from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
 from instruments.util_fns import (
     assume_units, enum_property, bool_property, ProxyList

--- a/instruments/tests/__init__.py
+++ b/instruments/tests/__init__.py
@@ -15,11 +15,8 @@ from io import BytesIO
 from unittest import mock
 
 import pytest
-try:
-    import numpy
-except ImportError:
-    numpy = None
 
+from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
 
 # FUNCTIONS ##################################################################

--- a/instruments/tests/__init__.py
+++ b/instruments/tests/__init__.py
@@ -20,6 +20,8 @@ try:
 except ImportError:
     numpy = None
 
+from instruments.units import ureg as u
+
 # FUNCTIONS ##################################################################
 
 
@@ -128,5 +130,7 @@ def iterable_eq(a, b):
     """
     if numpy and (isinstance(a, numpy.ndarray) or isinstance(b, numpy.ndarray)):
         assert (a == b).all()
+    elif isinstance(a, u.Quantity) and isinstance(b, u.Quantity):
+        unit_eq(a, b)
     else:
         assert a == b

--- a/instruments/tests/__init__.py
+++ b/instruments/tests/__init__.py
@@ -126,6 +126,9 @@ def iterable_eq(a, b):
     Asserts that the contents of two iterables are the same.
     """
     if numpy and (isinstance(a, numpy.ndarray) or isinstance(b, numpy.ndarray)):
+        # pylint: disable=unidiomatic-typecheck
+        assert type(a) == type(b), f"Expected two numpy arrays, got {type(a)}, {type(b)}"
+        assert len(a) == len(b), f"Length of iterables is not the same, got {len(a)} and {len(b)}"
         assert (a == b).all()
     elif isinstance(a, u.Quantity) and isinstance(b, u.Quantity):
         unit_eq(a, b)

--- a/instruments/tests/__init__.py
+++ b/instruments/tests/__init__.py
@@ -15,6 +15,10 @@ from io import BytesIO
 from unittest import mock
 
 import pytest
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 # FUNCTIONS ##################################################################
 
@@ -116,3 +120,13 @@ def make_name_test(ins_class, name_cmd="*IDN?"):
         with expected_protocol(ins_class, name_cmd + "\n", "NAME\n") as ins:
             assert ins.name == "NAME"
     return test
+
+
+def iterable_eq(a, b):
+    """
+    Asserts that the contents of two iterables are the same.
+    """
+    if numpy and (isinstance(a, numpy.ndarray) or isinstance(b, numpy.ndarray)):
+        assert (a == b).all()
+    else:
+        assert a == b

--- a/instruments/tests/test_agilent/test_agilent_34410a.py
+++ b/instruments/tests/test_agilent/test_agilent_34410a.py
@@ -6,13 +6,10 @@ Module containing tests for Agilent 34410a
 
 # IMPORTS ####################################################################
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
 import pytest
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,

--- a/instruments/tests/test_agilent/test_agilent_34410a.py
+++ b/instruments/tests/test_agilent/test_agilent_34410a.py
@@ -13,7 +13,12 @@ except ImportError:
 import pytest
 
 import instruments as ik
-from instruments.tests import expected_protocol, make_name_test, unit_eq
+from instruments.tests import (
+    expected_protocol,
+    iterable_eq,
+    make_name_test,
+    unit_eq
+)
 from instruments.units import ureg as u
 
 # TESTS ######################################################################
@@ -99,10 +104,11 @@ def test_agilent34410a_r():
                 b"#18" + bytes.fromhex("3FF0000000000000")
             ]
     ) as dmm:
-        expected = [1] * u.volt
+        expected = (u.Quantity(1, u.volt),)
         if numpy:
             expected = numpy.array([1]) * u.volt
-        unit_eq(dmm.r(1), expected)
+        actual = dmm.r(1)
+        iterable_eq(actual, expected)
 
 
 def test_agilent34410a_r_count_zero():
@@ -119,10 +125,11 @@ def test_agilent34410a_r_count_zero():
                 b"#18" + bytes.fromhex("3FF0000000000000")
             ]
     ) as dmm:
-        expected = [1] * u.volt
+        expected = (u.Quantity(1, u.volt),)
         if numpy:
             expected = numpy.array([1]) * u.volt
-        unit_eq(dmm.r(0), expected)
+        actual = dmm.r(0)
+        iterable_eq(actual, expected)
 
 
 def test_agilent34410a_r_type_error():
@@ -154,8 +161,10 @@ def test_agilent34410a_fetch():
             ]
     ) as dmm:
         data = dmm.fetch()
-        unit_eq(data[0], 4.27150000E-03 * u.volt)
-        unit_eq(data[1], 5.27150000E-03 * u.volt)
+        expected = (4.27150000E-03 * u.volt, 5.27150000E-03 * u.volt)
+        if numpy:
+            expected = (4.27150000E-03, 5.27150000E-03) * u.volt
+        iterable_eq(data, expected)
 
 
 def test_agilent34410a_read_data():
@@ -210,6 +219,7 @@ def test_agilent34410a_read_data_type_error():
             dmm.read_data(wrong_type)
         err_msg = err_info.value.args[0]
         assert err_msg == 'Parameter "sample_count" must be an integer.'
+
 
 def test_agilent34410a_read_data_nvmem():
     with expected_protocol(

--- a/instruments/tests/test_agilent/test_agilent_34410a.py
+++ b/instruments/tests/test_agilent/test_agilent_34410a.py
@@ -6,7 +6,10 @@ Module containing tests for Agilent 34410a
 
 # IMPORTS ####################################################################
 
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 import pytest
 
 import instruments as ik
@@ -96,7 +99,10 @@ def test_agilent34410a_r():
                 b"#18" + bytes.fromhex("3FF0000000000000")
             ]
     ) as dmm:
-        unit_eq(dmm.r(1), np.array([1]) * u.volt)
+        expected = [1] * u.volt
+        if numpy:
+            expected = numpy.array([1]) * u.volt
+        unit_eq(dmm.r(1), expected)
 
 
 def test_agilent34410a_r_count_zero():
@@ -113,7 +119,10 @@ def test_agilent34410a_r_count_zero():
                 b"#18" + bytes.fromhex("3FF0000000000000")
             ]
     ) as dmm:
-        unit_eq(dmm.r(0), np.array([1]) * u.volt)
+        expected = [1] * u.volt
+        if numpy:
+            expected = numpy.array([1]) * u.volt
+        unit_eq(dmm.r(0), expected)
 
 
 def test_agilent34410a_r_type_error():

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -13,7 +13,6 @@ import serial
 from serial.tools.list_ports_common import ListPortInfo
 
 import pytest
-import numpy as np
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -24,6 +23,7 @@ from instruments.abstract_instruments.comm import (
     USBTMCCommunicator, VXI11Communicator, serial_manager, SerialCommunicator
 )
 from instruments.errors import AcknowledgementError, PromptError
+from instruments.tests import iterable_eq
 
 from . import mock
 
@@ -43,7 +43,8 @@ def test_instrument_binblockread():
             ],
             sep="\n"
     ) as inst:
-        np.testing.assert_array_equal(inst.binblockread(2), [0, 1, 2, 3, 4])
+        actual_data = inst.binblockread(2)
+        iterable_eq(actual_data, (0, 1, 2, 3, 4))
 
 
 def test_instrument_binblockread_two_reads():
@@ -53,11 +54,11 @@ def test_instrument_binblockread_two_reads():
         side_effect=[b"#", b"2", b"10", data[:6], data[6:]]
     )
 
-    np.testing.assert_array_equal(inst.binblockread(2), [0, 1, 2, 3, 4])
+    iterable_eq(inst.binblockread(2), (0, 1, 2, 3, 4))
 
     calls_expected = [1, 1, 2, 10, 4]
     calls_actual = [call[0][0] for call in inst._file.read_raw.call_args_list]
-    np.testing.assert_array_equal(calls_expected, calls_actual)
+    iterable_eq(calls_actual, calls_expected)
 
 
 def test_instrument_binblockread_too_many_reads():

--- a/instruments/tests/test_base_instrument.py
+++ b/instruments/tests/test_base_instrument.py
@@ -15,6 +15,7 @@ from serial.tools.list_ports_common import ListPortInfo
 import pytest
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import expected_protocol
 # pylint: disable=unused-import
 from instruments.abstract_instruments.comm import (
@@ -44,7 +45,10 @@ def test_instrument_binblockread():
             sep="\n"
     ) as inst:
         actual_data = inst.binblockread(2)
-        iterable_eq(actual_data, (0, 1, 2, 3, 4))
+        expected = (0, 1, 2, 3, 4)
+        if numpy:
+            expected = numpy.array(expected)
+        iterable_eq(actual_data, expected)
 
 
 def test_instrument_binblockread_two_reads():
@@ -54,7 +58,10 @@ def test_instrument_binblockread_two_reads():
         side_effect=[b"#", b"2", b"10", data[:6], data[6:]]
     )
 
-    iterable_eq(inst.binblockread(2), (0, 1, 2, 3, 4))
+    expected = (0, 1, 2, 3, 4)
+    if numpy:
+        expected = numpy.array((0, 1, 2, 3, 4))
+    iterable_eq(inst.binblockread(2), expected)
 
     calls_expected = [1, 1, 2, 10, 4]
     calls_actual = [call[0][0] for call in inst._file.read_raw.call_args_list]

--- a/instruments/tests/test_comm/test_usbtmc.py
+++ b/instruments/tests/test_comm/test_usbtmc.py
@@ -9,8 +9,6 @@ Unit tests for the USBTMC communication layer
 
 import pytest
 
-from numpy import array
-
 from instruments.abstract_instruments.comm import USBTMCCommunicator
 from instruments.tests import unit_eq
 from instruments.units import ureg as u
@@ -73,10 +71,10 @@ def test_usbtmccomm_timeout(mock_usbtmc):
     timeout.assert_called_with()
 
     comm.timeout = 10
-    timeout.assert_called_with(array(10.0))
+    timeout.assert_called_with(10.0)
 
     comm.timeout = 1000 * u.millisecond
-    timeout.assert_called_with(array(1.0))
+    timeout.assert_called_with(1.0)
 
 
 @mock.patch(patch_path)

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -6,11 +6,17 @@ Unit tests for the HP 6624a power supply
 
 # IMPORTS #####################################################################
 
-
+try:
+    import numpy
+except ImportError:
+    numpy = None
 import pytest
 
 import instruments as ik
-from instruments.tests import expected_protocol
+from instruments.tests import (
+    expected_protocol,
+    iterable_eq,
+)
 from instruments.units import ureg as u
 from .. import mock
 
@@ -200,7 +206,8 @@ def test_all_voltage():
             ],
             sep="\n"
     ) as hp:
-        assert sorted(hp.voltage) == sorted((2, 3, 4, 5) * u.V)
+        expected = (2 * u.V, 3 * u.V, 4 * u.V, 5 * u.V)
+        iterable_eq(hp.voltage, expected)
         hp.voltage = 5 * u.V
         hp.voltage = (1 * u.V, 2 * u.V, 3 * u.V, 4 * u.V)
 
@@ -242,7 +249,8 @@ def test_all_current():
             ],
             sep="\n"
     ) as hp:
-        assert sorted(hp.current) == sorted((2, 3, 4, 5) * u.A)
+        expected = (2 * u.A, 3 * u.A, 4 * u.A, 5 * u.A)
+        iterable_eq(hp.current, expected)
         hp.current = 5 * u.A
         hp.current = (1 * u.A, 2 * u.A, 3 * u.A, 4 * u.A)
 
@@ -274,7 +282,8 @@ def test_all_voltage_sense():
             ],
             sep="\n"
     ) as hp:
-        assert sorted(hp.voltage_sense) == sorted((2, 3, 4, 5) * u.V)
+        expected = (2 * u.V, 3 * u.V, 4 * u.V, 5 * u.V)
+        iterable_eq(hp.voltage_sense, expected)
 
 
 def test_all_current_sense():
@@ -294,7 +303,8 @@ def test_all_current_sense():
             ],
             sep="\n"
     ) as hp:
-        assert sorted(hp.current_sense) == sorted((2, 3, 4, 5) * u.A)
+        expected = (2 * u.A, 3 * u.A, 4 * u.A, 5 * u.A)
+        iterable_eq(hp.current_sense, expected)
 
 
 def test_clear():

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -6,10 +6,6 @@ Unit tests for the HP 6624a power supply
 
 # IMPORTS #####################################################################
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
 import pytest
 
 import instruments as ik

--- a/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/tests/test_keithley/test_keithley2182.py
@@ -8,6 +8,10 @@ Unit tests for the Keithley 2182 nano-voltmeter
 
 
 import pytest
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 import instruments as ik
 from instruments.tests import (
@@ -139,7 +143,11 @@ def test_fetch():
             ]
     ) as inst:
         data = inst.fetch()
-        iterable_eq(data, [1.234, 1, 5.678] * u.volt)
+        vals = [1.234, 1, 5.678]
+        expected_data = tuple(v * u.volt for v in vals)
+        if numpy:
+            expected_data = vals * u.volt
+        iterable_eq(data, expected_data)
 
 
 def test_measure():

--- a/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/tests/test_keithley/test_keithley2182.py
@@ -8,12 +8,9 @@ Unit tests for the Keithley 2182 nano-voltmeter
 
 
 import pytest
-try:
-    import numpy
-except ImportError:
-    numpy = None
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,

--- a/instruments/tests/test_keithley/test_keithley2182.py
+++ b/instruments/tests/test_keithley/test_keithley2182.py
@@ -7,11 +7,13 @@ Unit tests for the Keithley 2182 nano-voltmeter
 # IMPORTS #####################################################################
 
 
-import numpy as np
 import pytest
 
 import instruments as ik
-from instruments.tests import expected_protocol
+from instruments.tests import (
+    expected_protocol,
+    iterable_eq,
+)
 from instruments.units import ureg as u
 
 # TESTS #######################################################################
@@ -136,9 +138,8 @@ def test_fetch():
                 "VOLT",
             ]
     ) as inst:
-        np.testing.assert_array_equal(
-            inst.fetch(), [1.234, 1, 5.678] * u.volt
-        )
+        data = inst.fetch()
+        iterable_eq(data, [1.234, 1, 5.678] * u.volt)
 
 
 def test_measure():

--- a/instruments/tests/test_rigol/test_rigolds1000.py
+++ b/instruments/tests/test_rigol/test_rigolds1000.py
@@ -9,6 +9,7 @@ Module containing tests for the Rigol DS1000
 import pytest
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,
@@ -159,7 +160,10 @@ def test_channel_read_waveform():
                 b"#210" + bytes.fromhex("00000001000200030004") + b"0"
             ]
     ) as osc:
-        iterable_eq(osc.channel[1].read_waveform(), (0, 1, 2, 3, 4))
+        expected = (0, 1, 2, 3, 4)
+        if numpy:
+            expected = numpy.array(expected)
+        iterable_eq(osc.channel[1].read_waveform(), expected)
 
 
 # TEST MATH #
@@ -188,7 +192,10 @@ def test_math_read_waveform():
                 b"#210" + bytes.fromhex("00000001000200030004") + b"0"
             ]
     ) as osc:
-        iterable_eq(osc.math.read_waveform(), (0, 1, 2, 3, 4))
+        expected = (0, 1, 2, 3, 4)
+        if numpy:
+            expected = numpy.array(expected)
+        iterable_eq(osc.math.read_waveform(), expected)
 
 
 # TEST REF DATASOURCE #

--- a/instruments/tests/test_rigol/test_rigolds1000.py
+++ b/instruments/tests/test_rigol/test_rigolds1000.py
@@ -6,11 +6,14 @@ Module containing tests for the Rigol DS1000
 
 # IMPORTS ####################################################################
 
-import numpy as np
 import pytest
 
 import instruments as ik
-from instruments.tests import expected_protocol, make_name_test
+from instruments.tests import (
+    expected_protocol,
+    iterable_eq,
+    make_name_test,
+)
 
 # TESTS ######################################################################
 
@@ -156,10 +159,7 @@ def test_channel_read_waveform():
                 b"#210" + bytes.fromhex("00000001000200030004") + b"0"
             ]
     ) as osc:
-        np.testing.assert_array_equal(
-            osc.channel[1].read_waveform(),
-            [0, 1, 2, 3, 4]
-        )
+        iterable_eq(osc.channel[1].read_waveform(), (0, 1, 2, 3, 4))
 
 
 # TEST MATH #
@@ -188,10 +188,7 @@ def test_math_read_waveform():
                 b"#210" + bytes.fromhex("00000001000200030004") + b"0"
             ]
     ) as osc:
-        np.testing.assert_array_equal(
-            osc.math.read_waveform(),
-            [0, 1, 2, 3, 4]
-        )
+        iterable_eq(osc.math.read_waveform(), (0, 1, 2, 3, 4))
 
 
 # TEST REF DATASOURCE #

--- a/instruments/tests/test_srs/test_srs345.py
+++ b/instruments/tests/test_srs/test_srs345.py
@@ -7,10 +7,11 @@ Unit tests for the SRS 345 function generator
 # IMPORTS #####################################################################
 
 
-import numpy as np
-
 import instruments as ik
-from instruments.tests import expected_protocol
+from instruments.tests import (
+    expected_protocol,
+    iterable_eq,
+)
 from instruments.units import ureg as u
 
 # TESTS #######################################################################
@@ -28,9 +29,7 @@ def test_amplitude():
                 "1.234VP",
             ]
     ) as inst:
-        np.testing.assert_array_equal(
-            inst.amplitude, (1.234 * u.V, inst.VoltageMode.peak_to_peak)
-        )
+        iterable_eq(inst.amplitude, (1.234 * u.V, inst.VoltageMode.peak_to_peak))
         inst.amplitude = 0.1 * u.V
         inst.amplitude = (0.1 * u.V, inst.VoltageMode.rms)
 

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -266,7 +266,7 @@ def test_take_measurement():
             ]
     ) as inst:
         resp = inst.take_measurement(sample_rate=1, num_samples=2)
-        iterable_eq(resp, [[1.234, 5.678], [0.456, 5.321]])
+        iterable_eq(resp, ((1.234, 5.678), (0.456, 5.321)))
 
 
 def test_take_measurement_invalid_num_samples():
@@ -437,7 +437,7 @@ def test_read_data_buffer():
             ]
     ) as inst:
         data = inst.read_data_buffer(channel=inst.Mode.ch1)
-        expected = [1.234, 9.876]
+        expected = (1.234, 9.876)
         iterable_eq(data, expected)
 
 
@@ -454,7 +454,7 @@ def test_read_data_buffer_mode_as_str():
             ]
     ) as inst:
         data = inst.read_data_buffer(channel="ch1")
-        expected = [1.234, 9.876]
+        expected = (1.234, 9.876)
         iterable_eq(data, expected)
 
 

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -12,8 +12,13 @@ import pytest
 import serial
 
 import instruments as ik
-from instruments.abstract_instruments.comm import GPIBCommunicator, \
-    LoopbackCommunicator, SerialCommunicator, USBCommunicator
+from instruments.abstract_instruments.comm import (
+    GPIBCommunicator,
+    LoopbackCommunicator,
+    SerialCommunicator,
+    USBCommunicator
+)
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,
@@ -327,7 +332,10 @@ def test_take_measurement():
             ]
     ) as inst:
         resp = inst.take_measurement(sample_rate=1, num_samples=2)
-        iterable_eq(resp, ((1.234, 5.678), (0.456, 5.321)))
+        expected = ((1.234, 5.678), (0.456, 5.321))
+        if numpy:
+            expected = numpy.array(expected)
+        iterable_eq(resp, expected)
 
 
 def test_take_measurement_num_dat_points_fails():
@@ -364,7 +372,10 @@ def test_take_measurement_num_dat_points_fails():
             ]
     ) as inst:
         resp = inst.take_measurement(sample_rate=1, num_samples=2)
-        iterable_eq(resp, ((1.234, 5.678), (0.456, 5.321)))
+        expected = ((1.234, 5.678), (0.456, 5.321))
+        if numpy:
+            expected = numpy.array(expected)
+        iterable_eq(resp, expected)
 
 
 def test_take_measurement_invalid_num_samples():
@@ -536,6 +547,8 @@ def test_read_data_buffer():
     ) as inst:
         data = inst.read_data_buffer(channel=inst.Mode.ch1)
         expected = (1.234, 9.876)
+        if numpy:
+            expected = numpy.array(expected)
         iterable_eq(data, expected)
 
 
@@ -553,6 +566,8 @@ def test_read_data_buffer_mode_as_str():
     ) as inst:
         data = inst.read_data_buffer(channel="ch1")
         expected = (1.234, 9.876)
+        if numpy:
+            expected = numpy.array(expected)
         iterable_eq(data, expected)
 
 

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -7,11 +7,13 @@ Unit tests for the SRS 830 lock-in amplifier
 # IMPORTS #####################################################################
 
 
-import numpy as np
 import pytest
 
 import instruments as ik
-from instruments.tests import expected_protocol
+from instruments.tests import (
+    expected_protocol,
+    iterable_eq,
+)
 from instruments.units import ureg as u
 
 # TESTS #######################################################################
@@ -264,7 +266,7 @@ def test_take_measurement():
             ]
     ) as inst:
         resp = inst.take_measurement(sample_rate=1, num_samples=2)
-        np.testing.assert_array_equal(resp, [[1.234, 5.678], [0.456, 5.321]])
+        iterable_eq(resp, [[1.234, 5.678], [0.456, 5.321]])
 
 
 def test_take_measurement_invalid_num_samples():
@@ -377,7 +379,7 @@ def test_data_snap():
     ) as inst:
         data = inst.data_snap(mode1=inst.Mode.x, mode2=inst.Mode.y)
         expected = [1.234, 9.876]
-        np.testing.assert_array_equal(data, expected)
+        iterable_eq(data, expected)
 
 
 def test_data_snap_mode_as_str():
@@ -392,7 +394,7 @@ def test_data_snap_mode_as_str():
     ) as inst:
         data = inst.data_snap(mode1='x', mode2='y')
         expected = [1.234, 9.876]
-        np.testing.assert_array_equal(data, expected)
+        iterable_eq(data, expected)
 
 
 def test_data_snap_invalid_snap_mode1():
@@ -436,7 +438,7 @@ def test_read_data_buffer():
     ) as inst:
         data = inst.read_data_buffer(channel=inst.Mode.ch1)
         expected = [1.234, 9.876]
-        np.testing.assert_array_equal(data, expected)
+        iterable_eq(data, expected)
 
 
 def test_read_data_buffer_mode_as_str():
@@ -453,7 +455,7 @@ def test_read_data_buffer_mode_as_str():
     ) as inst:
         data = inst.read_data_buffer(channel="ch1")
         expected = [1.234, 9.876]
-        np.testing.assert_array_equal(data, expected)
+        iterable_eq(data, expected)
 
 
 def test_read_data_buffer_invalid_mode():

--- a/instruments/tests/test_srs/test_srsctc100.py
+++ b/instruments/tests/test_srs/test_srsctc100.py
@@ -376,8 +376,8 @@ def test_channel_get_log(channel):
         ts = u.Quantity(numpy.empty((n_points,)), u.ms)
         temps = u.Quantity(numpy.empty((n_points,)), units)
     else:
-        ts = u.Quantity([0] * n_points, u.ms)
-        temps = u.Quantity([0] * n_points, units)
+        ts = [u.Quantity(0, u.ms)] * n_points
+        temps = [u.Quantity(0, units)] * n_points
     for it, time in enumerate(times):
         ts[it] = u.Quantity(time, u.ms)
         temps[it] = u.Quantity(values[it], units)

--- a/instruments/tests/test_srs/test_srsctc100.py
+++ b/instruments/tests/test_srs/test_srsctc100.py
@@ -11,12 +11,9 @@ from hypothesis import (
     strategies as st,
 )
 import pytest
-try:
-    import numpy
-except ImportError:
-    numpy = None
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,

--- a/instruments/tests/test_srs/test_srsctc100.py
+++ b/instruments/tests/test_srs/test_srsctc100.py
@@ -379,6 +379,10 @@ def test_channel_get_log(channel):
         ts[it] = u.Quantity(time, u.ms)
         temps[it] = u.Quantity(values[it], units)
 
+    if not numpy:
+        ts = tuple(ts)
+        temps = tuple(temps)
+
     with expected_protocol(
             ik.srs.SRSCTC100,
             [

--- a/instruments/tests/test_tektronix/test_tekawg2000.py
+++ b/instruments/tests/test_tektronix/test_tekawg2000.py
@@ -10,7 +10,10 @@ from hypothesis import (
     given,
     strategies as st,
 )
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 import pytest
 
 from instruments.units import ureg as u
@@ -241,6 +244,7 @@ def test_waveform_name_type_mismatch():
         assert exc_msg == "Waveform name must be specified as a string."
 
 
+@pytest.mark.skipif(numpy is None, reason="Numpy required for this test")
 @given(yzero=st.floats(min_value=-5, max_value=5),
        ymult=st.floats(min_value=0.00001),
        xincr=st.floats(min_value=5e-8, max_value=1e-1),
@@ -248,7 +252,7 @@ def test_waveform_name_type_mismatch():
 def test_upload_waveform(yzero, ymult, xincr, waveform):
     """Upload a waveform from the PC to the instrument."""
     # prep waveform
-    waveform = np.array(waveform)
+    waveform = numpy.array(waveform)
     waveform_send = waveform * (2**12 - 1)
     waveform_send = waveform_send.astype("<u2").tobytes()
     wfm_header_2 = str(len(waveform_send))
@@ -268,6 +272,7 @@ def test_upload_waveform(yzero, ymult, xincr, waveform):
         inst.upload_waveform(yzero, ymult, xincr, waveform)
 
 
+@pytest.mark.skipif(numpy is None, reason="Numpy required for this test")
 @given(yzero=st.floats(min_value=-5, max_value=5),
        ymult=st.floats(min_value=0.00001),
        xincr=st.floats(min_value=5e-8, max_value=1e-1),
@@ -277,7 +282,7 @@ def test_upload_waveform_type_mismatch(yzero, ymult, xincr, waveform):
     wrong_type_yzero = "42"
     wrong_type_ymult = "42"
     wrong_type_xincr = "42"
-    waveform_ndarray = np.array(waveform)
+    waveform_ndarray = numpy.array(waveform)
     with expected_protocol(
             ik.tektronix.TekAWG2000,
             [
@@ -310,13 +315,14 @@ def test_upload_waveform_type_mismatch(yzero, ymult, xincr, waveform):
         assert exc_msg == "waveform must be specified as a numpy array"
 
 
+@pytest.mark.skipif(numpy is None, reason="Numpy required for this test")
 @given(yzero=st.floats(min_value=-5, max_value=5),
        ymult=st.floats(min_value=0.00001),
        xincr=st.floats(min_value=5e-8, max_value=1e-1),
        waveform=st.lists(st.floats(min_value=0, max_value=1), min_size=1))
 def test_upload_waveform_wrong_max(yzero, ymult, xincr, waveform):
     """Raise ValueError when waveform maximum is too large."""
-    waveform_wrong_max = np.array(waveform)
+    waveform_wrong_max = numpy.array(waveform)
     waveform_wrong_max[0] = 42.
     with expected_protocol(
             ik.tektronix.TekAWG2000,

--- a/instruments/tests/test_tektronix/test_tekawg2000.py
+++ b/instruments/tests/test_tektronix/test_tekawg2000.py
@@ -332,3 +332,12 @@ def test_upload_waveform_wrong_max(yzero, ymult, xincr, waveform):
             inst.upload_waveform(yzero, ymult, xincr, waveform_wrong_max)
         exc_msg = exc_info.value.args[0]
         assert exc_msg == "The max value for an element in waveform is 1."
+
+
+@pytest.mark.skipif(numpy is not None, reason="Numpy missing is required for this test")
+def test_upload_waveform_missing_numpy_raises_exception():
+    with expected_protocol(
+            ik.tektronix.TekAWG2000, [], []
+    ) as inst:
+        with pytest.raises(ImportError):
+            inst.upload_waveform(0, 0, 0, [0])

--- a/instruments/tests/test_tektronix/test_tekawg2000.py
+++ b/instruments/tests/test_tektronix/test_tekawg2000.py
@@ -10,15 +10,12 @@ from hypothesis import (
     given,
     strategies as st,
 )
-try:
-    import numpy
-except ImportError:
-    numpy = None
 import pytest
 
-from instruments.units import ureg as u
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import expected_protocol, make_name_test
+from instruments.units import ureg as u
 
 
 # TESTS #######################################################################

--- a/instruments/tests/test_tektronix/test_tekdpo4104.py
+++ b/instruments/tests/test_tektronix/test_tekdpo4104.py
@@ -377,8 +377,8 @@ def test_data_source_read_waveform_bin(values, ymult, yzero, xzero, xincr):
         x_read, y_read = inst.channel[channel].read_waveform()
         x_calc = np.arange(ptcnt) * xincr + xzero
         y_calc = ((np.array(values) - yoffs) * ymult) + yzero
-        np.testing.assert_equal(x_read, x_calc)
-        np.testing.assert_equal(y_read, y_calc)
+        assert (x_read == x_calc).all()
+        assert (y_read == y_calc).all()
 
 
 @given(values=st.lists(st.integers(min_value=-32768, max_value=32767),

--- a/instruments/tests/test_tektronix/test_tekdpo4104.py
+++ b/instruments/tests/test_tektronix/test_tekdpo4104.py
@@ -13,11 +13,18 @@ from hypothesis import (
     given,
     strategies as st,
 )
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 import pytest
 
 import instruments as ik
-from instruments.tests import expected_protocol, make_name_test
+from instruments.tests import (
+    expected_protocol,
+    iterable_eq,
+    make_name_test,
+)
 
 
 # TESTS #######################################################################
@@ -375,10 +382,14 @@ def test_data_source_read_waveform_bin(values, ymult, yzero, xzero, xincr):
             ],
     ) as inst:
         x_read, y_read = inst.channel[channel].read_waveform()
-        x_calc = np.arange(ptcnt) * xincr + xzero
-        y_calc = ((np.array(values) - yoffs) * ymult) + yzero
-        assert (x_read == x_calc).all()
-        assert (y_read == y_calc).all()
+        if numpy:
+            x_calc = numpy.arange(ptcnt) * xincr + xzero
+            y_calc = ((numpy.array(values) - yoffs) * ymult) + yzero
+        else:
+            x_calc = tuple([float(val) * xincr + xzero for val in range(ptcnt)])
+            y_calc = tuple([((float(val) - yoffs) * ymult) + yzero for val in values])
+        iterable_eq(x_read, x_calc)
+        iterable_eq(y_read, y_calc)
 
 
 @given(values=st.lists(st.integers(min_value=-32768, max_value=32767),
@@ -431,13 +442,19 @@ def test_data_source_read_waveform_ascii(values, ymult, yzero, xzero, xincr):
     ) as inst:
         # get the values from the instrument
         x_read, y_read = inst.channel[channel].read_waveform(bin_format=False)
+        
         # manually calculate the values
-        raw = np.array(values_str.split(","), dtype=np.float)
-        y_calc = (raw - yoffs) * ymult + yzero
-        x_calc = np.arange(ptcnt) * xincr + xzero
+        if numpy:
+            raw = numpy.array(values_str.split(","), dtype=numpy.float)
+            x_calc = numpy.arange(ptcnt) * xincr + xzero
+            y_calc = (raw - yoffs) * ymult + yzero
+        else:
+            x_calc = tuple([float(val) * xincr + xzero for val in range(ptcnt)])
+            y_calc = tuple([((float(val) - yoffs) * ymult) + yzero for val in values])
+        
         # assert arrays are equal
-        np.testing.assert_almost_equal(x_read, x_calc)
-        np.testing.assert_almost_equal(y_read, y_calc)
+        iterable_eq(x_read, x_calc)
+        iterable_eq(y_read, y_calc)
 
 
 @given(offset=st.floats(min_value=-100, max_value=100))

--- a/instruments/tests/test_tektronix/test_tekdpo4104.py
+++ b/instruments/tests/test_tektronix/test_tekdpo4104.py
@@ -442,7 +442,7 @@ def test_data_source_read_waveform_ascii(values, ymult, yzero, xzero, xincr):
     ) as inst:
         # get the values from the instrument
         x_read, y_read = inst.channel[channel].read_waveform(bin_format=False)
-        
+
         # manually calculate the values
         if numpy:
             raw = numpy.array(values_str.split(","), dtype=numpy.float)
@@ -451,7 +451,7 @@ def test_data_source_read_waveform_ascii(values, ymult, yzero, xzero, xincr):
         else:
             x_calc = tuple([float(val) * xincr + xzero for val in range(ptcnt)])
             y_calc = tuple([((float(val) - yoffs) * ymult) + yzero for val in values])
-        
+
         # assert arrays are equal
         iterable_eq(x_read, x_calc)
         iterable_eq(y_read, y_calc)

--- a/instruments/tests/test_tektronix/test_tekdpo4104.py
+++ b/instruments/tests/test_tektronix/test_tekdpo4104.py
@@ -13,13 +13,10 @@ from hypothesis import (
     given,
     strategies as st,
 )
-try:
-    import numpy
-except ImportError:
-    numpy = None
 import pytest
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,

--- a/instruments/tests/test_tektronix/test_tekdpo70000.py
+++ b/instruments/tests/test_tektronix/test_tekdpo70000.py
@@ -1073,7 +1073,7 @@ def test_channel_scale(value):
 
 
 @given(values=st.lists(st.floats(min_value=-2147483648, max_value=2147483647),
-                      min_size=1))
+                       min_size=1))
 def test_channel_scale_raw_data(values):
     """Return scaled raw data according to current settings."""
     channel = 0

--- a/instruments/tests/test_tektronix/test_tekdpo70000.py
+++ b/instruments/tests/test_tektronix/test_tekdpo70000.py
@@ -13,13 +13,10 @@ from hypothesis import (
     given,
     strategies as st,
 )
-try:
-    import numpy
-except ImportError:
-    numpy = None
 import pytest
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,

--- a/instruments/tests/test_tektronix/test_tektronix_tds224.py
+++ b/instruments/tests/test_tektronix/test_tektronix_tds224.py
@@ -10,13 +10,10 @@ from enum import Enum
 import time
 
 from hypothesis import given, strategies as st
-try:
-    import numpy
-except ImportError:
-    numpy = None
 import pytest
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,

--- a/instruments/tests/test_tektronix/test_tktds5xx.py
+++ b/instruments/tests/test_tektronix/test_tktds5xx.py
@@ -20,7 +20,11 @@ import numpy as np
 import pytest
 
 import instruments as ik
-from instruments.tests import expected_protocol, make_name_test
+from instruments.tests import (
+    expected_protocol,
+    iterable_eq,
+    make_name_test,
+)
 
 
 # TESTS #######################################################################
@@ -160,8 +164,8 @@ def test_data_source_read_waveform_binary(values):
     ) as inst:
         channel = inst.channel[channel_no]
         x_read, y_read = channel.read_waveform(bin_format=True)
-        np.testing.assert_equal(x_read, x_calc)
-        np.testing.assert_equal(y_read, y_calc)
+        iterable_eq(x_read, x_calc)
+        iterable_eq(y_read, y_calc)
 
 
 @given(values=st.lists(st.floats(min_value=0), min_size=1))

--- a/instruments/tests/test_tektronix/test_tktds5xx.py
+++ b/instruments/tests/test_tektronix/test_tktds5xx.py
@@ -141,7 +141,7 @@ def test_data_source_read_waveform_binary(values):
         y_calc = ((values_arr - yoffs) * ymult) + yzero
     else:
         x_calc = tuple([float(val) * float(xincr) for val in range(ptcnt)])
-        y_calc = [((val - yoffs) * float(ymult)) + float(yzero) for val in values]
+        y_calc = tuple(((val - yoffs) * float(ymult)) + float(yzero) for val in values)
 
     with expected_protocol(
             ik.tektronix.TekTDS5xx,
@@ -196,7 +196,7 @@ def test_data_source_read_waveform_ascii(values):
         y_calc = ((values_arr - yoffs) * ymult) + yzero
     else:
         x_calc = tuple([float(val) * float(xincr) for val in range(ptcnt)])
-        y_calc = [((val - yoffs) * float(ymult)) + float(yzero) for val in values]
+        y_calc = tuple(((val - yoffs) * float(ymult)) + float(yzero) for val in values)
 
     with expected_protocol(
             ik.tektronix.TekTDS5xx,

--- a/instruments/tests/test_tektronix/test_tktds5xx.py
+++ b/instruments/tests/test_tektronix/test_tktds5xx.py
@@ -16,13 +16,10 @@ from hypothesis import (
     given,
     strategies as st,
 )
-try:
-    import numpy
-except ImportError:
-    numpy = None
 import pytest
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,

--- a/instruments/tests/test_teledyne/test_maui.py
+++ b/instruments/tests/test_teledyne/test_maui.py
@@ -6,18 +6,15 @@ Module containing tests for the Thorlabs TC200
 
 # IMPORTS ####################################################################
 
-try:
-    import numpy
-except ImportError:
-    numpy = None
 import pytest
 
 import instruments as ik
-from instruments.units import ureg as u
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,
 )
+from instruments.units import ureg as u
 
 # TESTS ######################################################################
 

--- a/instruments/tests/test_test_utils.py
+++ b/instruments/tests/test_test_utils.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+
+"""
+Module containing tests for test-related utility functions
+"""
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+import pytest
+
+from instruments.optional_dep_finder import numpy
+from instruments.tests import (
+    iterable_eq
+)
+from instruments.units import ureg as u
+
+
+# TESTS #######################################################################
+
+@given(a=st.lists(st.floats()))
+def test_iterable_eq_passes_basic(a):
+    """
+    Test that two identical lists and tuples always pass
+    """
+    b = a[:]
+    iterable_eq(a, b)
+    iterable_eq(tuple(a), tuple(b))
+
+
+@pytest.mark.parametrize("b", [(0, 1, 2), (0,)])
+def test_iterable_eq_fails(b):
+    """
+    Test failure on equal and mismatched lengths
+    """
+    a = (1, 2, 3)
+    with pytest.raises(AssertionError):
+        iterable_eq(a, b)
+
+
+def test_iterable_eq_fails_type_mismatch():
+    """
+    Test failure on type mismatch
+    """
+    a = [1, 2, 3]
+    with pytest.raises(AssertionError):
+        iterable_eq(a, tuple(a))
+
+
+def test_iterable_eq_passes_sequence_quantity():
+    """
+    Test passes on equal sequences with unitful values
+    """
+    a = (1*u.V, 2*u.A)
+    iterable_eq(a, a[:])
+
+
+def test_iterable_eq_fails_sequence_quantity():
+    """
+    Test failure on unitful sequences with wrong units, and wrong magnitudes
+    """
+    a = (1*u.V, 2*u.A)
+    b = (1*u.A, 2*u.A)  # Different units
+    with pytest.raises(AssertionError):
+        iterable_eq(a, b)
+
+    b = (1 * u.V, 3 * u.A)  # Different magnitude
+    with pytest.raises(AssertionError):
+        iterable_eq(a, b)
+
+
+def test_iterable_eq_passes_singular_quantity():
+    """
+    Test passes on singular unitful quantity
+    """
+    iterable_eq(1*u.V, 1*u.V)
+
+
+def test_iterable_eq_fails_singular_quantity():
+    """
+    Test failure on singular unitful quantity with wrong units
+    """
+    a = 1*u.V
+    b = 1*u.A
+    with pytest.raises(AssertionError):
+        iterable_eq(a, b)
+
+
+@pytest.mark.skipif(numpy is None, reason="Only run if numpy installed")
+def test_iterable_eq_passes_two_numpy_array():
+    """
+    Test pases for two identical numpy arrays
+    """
+    a = numpy.array([1, 2, 3])
+    iterable_eq(a, a.copy())
+
+
+@pytest.mark.skipif(numpy is None, reason="Only run if numpy installed")
+def test_iterable_eq_fails_one_numpy_array_equal_values():
+    """
+    Test failure for one is numpy array, other is not
+    """
+    a = numpy.array([1, 2, 3])
+    b = (1, 2, 3)
+    with pytest.raises(AssertionError):
+        iterable_eq(a, b)
+
+
+@pytest.mark.skipif(numpy is None, reason="Only run if numpy installed")
+@pytest.mark.parametrize("b", [(1, 6, 3), (1, 2)])
+def test_iterable_eq_fails_one_numpy_array(b):
+    """
+    Test that different value and different length
+    comparisons against numpy arrays fail
+    """
+    a = numpy.array([1, 2, 3])
+    with pytest.raises(AssertionError):
+        iterable_eq(a, b)
+
+
+@pytest.mark.skipif(numpy is None, reason="Only run if numpy installed")
+@pytest.mark.parametrize("b", [(1, 6, 3), (1, 2)])
+def test_iterable_eq_fails_two_numpy_array(b):
+    """
+    Test that different value and different length
+    comparisons against numpy arrays fail
+    """
+    a = numpy.array([1, 2, 3])
+    b = numpy.array(b)
+    with pytest.raises(AssertionError):
+        iterable_eq(a, b)
+
+
+@pytest.mark.skipif(numpy is None, reason="Only run if numpy installed")
+def test_iterable_eq_passes_two_numpy_array_quantities():
+    """
+    Test that two unitful quantities with numpy array data
+    will equal data will pass
+    """
+    values = [1, 2, 3]
+    a = numpy.array(values) * u.V
+    b = numpy.array(a) * u.V
+    iterable_eq(a, b)

--- a/instruments/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/instruments/tests/test_yokogawa/test_yokogawa_6370.py
@@ -45,7 +45,7 @@ def test_init():
         pass
 
 
-@given(values=st.lists(st.decimals(allow_infinity=False, allow_nan=False), min_size=1),
+@given(values=st.lists(st.floats(allow_infinity=False, allow_nan=False), min_size=1),
        channel=st.sampled_from(ik.yokogawa.Yokogawa6370.Traces))
 def test_channel_data(values, channel):
     values_packed = b"".join(struct.pack("<d", value) for value in values)
@@ -61,12 +61,13 @@ def test_channel_data(values, channel):
                 b"#" + values_len_of_len + values_len + values_packed
             ]
     ) as inst:
+        values = tuple(values)
         if numpy:
             values = numpy.array(values, dtype="<d")
         iterable_eq(inst.channel[channel].data(), values)
 
 
-@given(values=st.lists(st.decimals(allow_infinity=False, allow_nan=False), min_size=1),
+@given(values=st.lists(st.floats(allow_infinity=False, allow_nan=False), min_size=1),
        channel=st.sampled_from(ik.yokogawa.Yokogawa6370.Traces))
 def test_channel_wavelength(values, channel):
     values_packed = b"".join(struct.pack("<d", value) for value in values)
@@ -82,6 +83,7 @@ def test_channel_wavelength(values, channel):
                 b"#" + values_len_of_len + values_len + values_packed
             ]
     ) as inst:
+        values = tuple(values)
         if numpy:
             values = numpy.array(values, dtype="<d")
         iterable_eq(inst.channel[channel].wavelength(), values)

--- a/instruments/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/instruments/tests/test_yokogawa/test_yokogawa_6370.py
@@ -13,17 +13,14 @@ from hypothesis import (
     given,
     strategies as st,
 )
-try:
-    import numpy
-except ImportError:
-    numpy = None
-from instruments.units import ureg as u
 
 import instruments as ik
+from instruments.optional_dep_finder import numpy
 from instruments.tests import (
     expected_protocol,
     iterable_eq,
 )
+from instruments.units import ureg as u
 
 
 # TESTS #######################################################################

--- a/instruments/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/instruments/tests/test_yokogawa/test_yokogawa_6370.py
@@ -13,7 +13,10 @@ from hypothesis import (
     given,
     strategies as st,
 )
-import numpy as np
+try:
+    import numpy
+except ImportError:
+    numpy = None
 from instruments.units import ureg as u
 
 import instruments as ik
@@ -58,7 +61,9 @@ def test_channel_data(values, channel):
                 b"#" + values_len_of_len + values_len + values_packed
             ]
     ) as inst:
-        iterable_eq(inst.channel[channel].data(), np.array(values, dtype="<d"))
+        if numpy:
+            values = numpy.array(values, dtype="<d")
+        iterable_eq(inst.channel[channel].data(), values)
 
 
 @given(values=st.lists(st.decimals(allow_infinity=False, allow_nan=False), min_size=1),
@@ -77,10 +82,9 @@ def test_channel_wavelength(values, channel):
                 b"#" + values_len_of_len + values_len + values_packed
             ]
     ) as inst:
-        iterable_eq(
-            inst.channel[channel].wavelength(),
-            np.array(values, dtype="<d")
-        )
+        if numpy:
+            values = numpy.array(values, dtype="<d")
+        iterable_eq(inst.channel[channel].wavelength(), values)
 
 
 @given(value=st.floats(min_value=600e-9, max_value=1700e-9))

--- a/instruments/tests/test_yokogawa/test_yokogawa_6370.py
+++ b/instruments/tests/test_yokogawa/test_yokogawa_6370.py
@@ -17,7 +17,10 @@ import numpy as np
 from instruments.units import ureg as u
 
 import instruments as ik
-from instruments.tests import expected_protocol
+from instruments.tests import (
+    expected_protocol,
+    iterable_eq,
+)
 
 
 # TESTS #######################################################################
@@ -55,7 +58,7 @@ def test_channel_data(values, channel):
                 b"#" + values_len_of_len + values_len + values_packed
             ]
     ) as inst:
-        np.testing.assert_array_equal(inst.channel[channel].data(), np.array(values, dtype="<d"))
+        iterable_eq(inst.channel[channel].data(), np.array(values, dtype="<d"))
 
 
 @given(values=st.lists(st.decimals(allow_infinity=False, allow_nan=False), min_size=1),
@@ -74,7 +77,7 @@ def test_channel_wavelength(values, channel):
                 b"#" + values_len_of_len + values_len + values_packed
             ]
     ) as inst:
-        np.testing.assert_array_equal(
+        iterable_eq(
             inst.channel[channel].wavelength(),
             np.array(values, dtype="<d")
         )
@@ -252,7 +255,7 @@ def test_data_active_trace(values):
         data_call_by_trace = inst.channel[channel].data()
         # call active trace data
         data_active_trace = inst.data()
-        assert (data_call_by_trace == data_active_trace).all()
+        iterable_eq(data_call_by_trace, data_active_trace)
 
 
 @given(values=st.lists(st.decimals(allow_infinity=False, allow_nan=False),
@@ -281,7 +284,7 @@ def test_wavelength_active_trace(values):
         data_call_by_trace = inst.channel[channel].wavelength()
         # call active trace data
         data_active_trace = inst.wavelength()
-        assert (data_call_by_trace == data_active_trace).all()
+        iterable_eq(data_call_by_trace, data_active_trace)
 
 
 def test_start_sweep():

--- a/instruments/yokogawa/yokogawa6370.py
+++ b/instruments/yokogawa/yokogawa6370.py
@@ -62,14 +62,14 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
         def data(self, bin_format=True):
             cmd = ":TRAC:Y? {0}".format(self._name)
             self._parent.sendcmd(cmd)
-            data = self._parent.binblockread(data_width=4, fmt="<d")
+            data = self._parent.binblockread(data_width=8, fmt="<d")
             self._parent._file.read_raw(1)  # pylint: disable=protected-access
             return data
 
         def wavelength(self, bin_format=True):
             cmd = ":TRAC:X? {0}".format(self._name)
             self._parent.sendcmd(cmd)
-            data = self._parent.binblockread(data_width=4, fmt="<d")
+            data = self._parent.binblockread(data_width=8, fmt="<d")
             self._parent._file.read_raw(1)  # pylint: disable=protected-access
             return data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy
 pyserial
 pyvisa>=1.9
 python-vxi11>=0.8

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,13 @@ INSTALL_REQUIRES = [
     "ruamel.yaml~=0.15.37",
     "pint>=0.16.1"
 ]
+TEST_REQUIRES = [
+    'pytest >= 6.1.1',
+    'hypothesis'
+]
+EXTRA_REQUIRES = {
+    "numpy": ["numpy"]
+}
 
 
 # HELPER FUNCTONS ############################################################
@@ -87,10 +94,8 @@ setup(
     author_email=find_meta("email"),
     packages=PACKAGES,
     install_requires=INSTALL_REQUIRES,
-    tests_require=[
-        'pytest >= 2.9.1',
-        'hypothesis'
-    ],
+    tests_require=TEST_REQUIRES,
+    extras_require=EXTRA_REQUIRES,
     description=find_meta("description"),
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries"
 ]
 INSTALL_REQUIRES = [
-    "numpy",
     "pyserial>=3.3",
     "pyvisa>=1.9",
     "python-vxi11>=0.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py{36,37,38,39},py{36,37,38,39}-numpy
 [testenv]
-deps = -rdev-requirements.txt
+deps =
+    -rdev-requirements.txt
+    numpy: numpy
 commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,5 @@ envlist = py{36,37,38,39},py{36,37,38,39}-numpy
 deps =
     -rdev-requirements.txt
     numpy: numpy
-commands = pytest
+commands = pytest {toxinidir}/instruments/tests/ {posargs:}
+changedir = {toxworkdir}


### PR DESCRIPTION
Finally! We are now at the point where numpy can be removed as a hard dependency and instead can just be an optional one. The approach taken is to introduce a new tool `optional_dep_finder` that just contains a try except block for importing numpy. This way we completely remove all the repetition in the code base of trying to import it. Anything that previously returned a numpy array still does if numpy is installed. If absent, then a tuple of appropriate values is returned in its place.

See #91 

TODO

- [x] Remove repetitive `try: import numpy` blocks
- [x] Update docstrings
- [x] Improve return type consistency
- [x] Add additional tox environments for tests with & without numpy
- [x] Add addtional travis environments for testing with & without numpy
- [x] Add unit tests for new tools