### PR TITLE
Tests and some BFs for HP devices

### DIFF
--- a/instruments/hp/hp3456a.py
+++ b/instruments/hp/hp3456a.py
@@ -574,8 +574,7 @@ class HP3456a(Multimeter):
                             "HP3456a.Register, got {} "
                             "instead.".format(name))
         self.sendcmd("RE{}".format(name.value))
-        if not self._testing:  # pragma: no cover
-            time.sleep(.1)
+        time.sleep(.1)
         return float(self.query("", size=-1))
 
     def _register_write(self, name, value):
@@ -601,8 +600,7 @@ class HP3456a(Multimeter):
         ]:
             raise ValueError("register {} is read only".format(name))
         self.sendcmd("W{}ST{}".format(value, name.value))
-        if not self._testing:  # pragma: no cover
-            time.sleep(.1)
+        time.sleep(.1)
 
     def trigger(self):
         """

--- a/instruments/hp/hpe3631a.py
+++ b/instruments/hp/hpe3631a.py
@@ -141,7 +141,7 @@ class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
         is lower than I. If the load is smaller than V/I, the set current
         I acts as a current limiter and the voltage is lower than V.
         """
-        return AttributeError("The `HPe3631a` sets its mode automatically")
+        raise AttributeError("The `HPe3631a` sets its mode automatically")
 
     channelid = int_property(
         "INST:NSEL",

--- a/instruments/tests/test_hp/test_hp3456a.py
+++ b/instruments/tests/test_hp/test_hp3456a.py
@@ -6,6 +6,7 @@ Unit tests for the HP 3456a digital voltmeter
 
 # IMPORTS #####################################################################
 
+import time
 
 import pytest
 
@@ -16,6 +17,12 @@ from instruments.units import ureg as u
 # TESTS #######################################################################
 
 # pylint: disable=protected-access
+
+
+@pytest.fixture(autouse=True)
+def time_mock(mocker):
+    """Mock out time to speed up."""
+    return mocker.patch.object(time, 'sleep', return_value=None)
 
 
 def test_hp3456a_trigger_mode():
@@ -338,6 +345,8 @@ def test_hp3456a_input_range():
     ) as dmm:
         dmm.input_range = 10 ** -1 * u.volt
         dmm.input_range = 1e3 * u.ohm
+        with pytest.raises(NotImplementedError):
+            _ = dmm.input_range
 
 
 def test_hp3456a_input_range_invalid_str():

--- a/instruments/tests/test_hp/test_hp6624a.py
+++ b/instruments/tests/test_hp/test_hp6624a.py
@@ -57,6 +57,21 @@ def test_channel_query():
     assert value == "FOO"
 
 
+def test_mode():
+    """Raise NotImplementedError when mode is called."""
+    with expected_protocol(
+            ik.hp.HP6624a,
+            [],
+            [],
+            sep="\n"
+    ) as hp:
+        channel = hp.channel[0]
+        with pytest.raises(NotImplementedError):
+            _ = channel.mode
+        with pytest.raises(NotImplementedError):
+            channel.mode = 42
+
+
 def test_channel_voltage():
     with expected_protocol(
             ik.hp.HP6624a,

--- a/instruments/tests/test_hp/test_hp6632b.py
+++ b/instruments/tests/test_hp/test_hp6632b.py
@@ -6,6 +6,7 @@ Unit tests for the HP 6632b power supply
 
 # IMPORTS #####################################################################
 
+import pytest
 
 from instruments.units import ureg as u
 
@@ -324,6 +325,45 @@ def test_hp6632b_abort_output_trigger():
             []
     ) as psu:
         psu.abort_output_trigger()
+
+
+def test_line_frequency():
+    """Raise NotImplemented error when called."""
+    with expected_protocol(
+            ik.hp.HP6632b,
+            [],
+            []
+    ) as psu:
+        with pytest.raises(NotImplementedError):
+            psu.line_frequency = 42
+        with pytest.raises(NotImplementedError):
+            _ = psu.line_frequency
+
+
+def test_display_brightness():
+    """Raise NotImplemented error when called."""
+    with expected_protocol(
+            ik.hp.HP6632b,
+            [],
+            []
+    ) as psu:
+        with pytest.raises(NotImplementedError):
+            psu.display_brightness = 42
+        with pytest.raises(NotImplementedError):
+            _ = psu.display_brightness
+
+
+def test_display_contrast():
+    """Raise NotImplemented error when called."""
+    with expected_protocol(
+            ik.hp.HP6632b,
+            [],
+            []
+    ) as psu:
+        with pytest.raises(NotImplementedError):
+            psu.display_contrast = 42
+        with pytest.raises(NotImplementedError):
+            _ = psu.display_contrast
 
 
 def test_hp6632b_check_error_queue():

--- a/instruments/tests/test_hp/test_hp6652a.py
+++ b/instruments/tests/test_hp/test_hp6652a.py
@@ -6,6 +6,7 @@ Unit tests for the HP 6652a single output power supply
 
 # IMPORTS #####################################################################
 
+import pytest
 
 import instruments as ik
 from instruments.tests import expected_protocol
@@ -26,6 +27,21 @@ def test_name():
     ) as hp:
         assert hp.name == "FOO BAR"
 
+
+def test_mode():
+    """Raise NotImplementedError when called."""
+    with expected_protocol(
+            ik.hp.HP6652a,
+            [
+            ],
+            [
+            ],
+            sep="\n"
+    ) as hp:
+        with pytest.raises(NotImplementedError):
+            _ = hp.mode
+        with pytest.raises(NotImplementedError):
+            hp.mode = 42
 
 def test_reset():
     with expected_protocol(


### PR DESCRIPTION
Full cov test suites for:
- HP3456a
- HP6624a
- HP6632b
- HP6652a
- HPe3631a

Bug fix:
- HPe3631a: Raise an error that was previously returned

Changes:
- HP3456a: Remove `if self._testing` statement to not do `time.sleep`
  during tests. Instead use an automatically used pytest fixture to
  mock out `time.sleep`.