### PR TITLE
Use tox in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,26 +6,41 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
+stages:
+- prechecks
+- tests-cpython
+jobs:
+  include:
+  - stage: prechecks
+    python: 3.6
+    env: TOXENV=pylint
+  - stage: tests-cpython
+    python: 3.6
+    env: TOXENV=py36
+  - python: 3.7
+    env: TOXENV=py37
+  - python: 3.8
+    env: TOXENV=py38
+  - python: 3.9
+    env: TOXENV=py39
+before_install:
+- python --version
+- uname -a
+- lsb_release -a
 install:
-  - "pip install -r requirements.txt"
-  - "pip install -r dev-requirements.txt"
-  - pip install coveralls
-  - pip install coverage
-  - pip install pytest-cov
+  - pip install -U setuptools
+  - pip install tox coverage coveralls
 before_script:
   # We use before_script to report version and path information in a way
   # that can be easily hidden by Travis' log folding. Moreover, a nonzero
   # exit code from this block kills the entire job, meaning that if we can't
   # even sensibly get version information, we correctly abort.
-  - which python
-  - python --version
-  - which pytest
-  - pytest --version
-  - which pylint
-  - pylint --version
+  - virtualenv --version
+  - pip --version
+  - tox --version
+  - coverage --version
 script:
-  - pytest --cov=instruments
-  - if [[ $TRAVIS_PYTHON_VERSION != 3.9 ]]; then pylint --disable=I,R instruments; fi
+  - tox
 after_success:
   - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 dist: xenial
 sudo: false
 language: python
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
-  - "3.9"
 stages:
 - prechecks
 - tests-cpython

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ basepython = python3
 deps =
     -rdev-requirements.txt
 commands =
-    pylint --disable=I,R {toxinidir}/instruments
+    pylint -j 0 --disable=I,R {toxinidir}/instruments

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,16 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py36,py37,py38,py39,pylint
+
 [testenv]
-deps = -rdev-requirements.txt
-commands = pytest
+deps =
+    -rdev-requirements.txt
+    pytest-cov
+    coverage
+commands = pytest --cov=instruments {toxinidir}/instruments/tests/ {posargs:}
+
+[testenv:pylint]
+basepython = python3
+deps =
+    -rdev-requirements.txt
+commands =
+    pylint --disable=I,R {toxinidir}/instruments

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ envlist = py36,py37,py38,py39,pylint
 deps =
     -rdev-requirements.txt
     pytest-cov
+    pytest-xdist
     coverage
-commands = pytest --cov=instruments {toxinidir}/instruments/tests/ {posargs:}
+commands = pytest -n auto --cov=instruments {toxinidir}/instruments/tests/ {posargs:}
 
 [testenv:pylint]
 basepython = python3


### PR DESCRIPTION
This PR changes how we do testing in CI, and by extension, what we consider a passing build.

The core of this is to use `tox` as the venv manager in order to create known environments for the tests to execute against. In addition, it allows developers to run tests in the same fashion as they would be run in CI.

While we are [not using a `src` folder](https://blog.ionelmc.ro/2014/05/25/python-packaging/) (although funny enough, IK did have one several years ago), moving to `tox` as the center focus for creating and deploying our test environments will help fix a number of issues. 

#288 