### PR TITLE
Tests for SRS DG645 and 830

### DIFF
--- a/instruments/srs/srs830.py
+++ b/instruments/srs/srs830.py
@@ -47,7 +47,7 @@ class SRS830(SCPIInstrument):
     >>> data = srs.take_measurement(1, 10) # 1Hz sample rate, 10 samples total
     """
 
-    def __init__(self, filelike, outx_mode=None):  # pragma: no cover
+    def __init__(self, filelike, outx_mode=None):
         """
         Class initialization method.
 
@@ -70,7 +70,7 @@ class SRS830(SCPIInstrument):
                 pass
             else:
                 warnings.warn("OUTX command has not been set. Instrument "
-                              "behavour is unknown.", UserWarning)
+                              "behaviour is unknown.", UserWarning)
     # ENUMS #
 
     class FreqSource(IntEnum):
@@ -251,7 +251,7 @@ class SRS830(SCPIInstrument):
         while not resp and i < 10:
             resp = self.query('SPTS?').strip()
             i += 1
-        if not resp:  # pragma: no cover
+        if not resp:
             raise IOError(
                 "Expected integer response from instrument, got {}".format(
                     repr(resp))
@@ -363,8 +363,7 @@ class SRS830(SCPIInstrument):
         self.init(sample_rate, SRS830.BufferMode['one_shot'])
         self.start_data_transfer()
 
-        if not self._testing:
-            time.sleep(sample_time + 0.1)
+        time.sleep(sample_time + 0.1)
 
         self.pause()
 
@@ -374,7 +373,7 @@ class SRS830(SCPIInstrument):
         # in future versions.
         try:
             self.num_data_points
-        except IOError:  # pragma: no cover
+        except IOError:
             pass
 
         ch1 = self.read_data_buffer('ch1')

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -6,15 +6,61 @@ Unit tests for the SRS 830 lock-in amplifier
 
 # IMPORTS #####################################################################
 
+import time
 
 import numpy as np
 import pytest
+import serial
 
 import instruments as ik
+from instruments.abstract_instruments.comm import GPIBCommunicator, \
+    LoopbackCommunicator, SerialCommunicator, USBCommunicator
 from instruments.tests import expected_protocol
 from instruments.units import ureg as u
 
 # TESTS #######################################################################
+
+
+@pytest.fixture(autouse=True)
+def time_mock(mocker):
+    """Mock out sleep such that test runs fast."""
+    return mocker.patch.object(time, 'sleep', return_value=None)
+
+
+@pytest.mark.parametrize("mode", (1, 2))
+def test_init_mode_given(mocker, mode):
+    """Test initialization with a given mode."""
+    comm = LoopbackCommunicator()
+    send_spy = mocker.spy(comm, 'sendcmd')
+    ik.srs.SRS830(comm, outx_mode=mode)
+    send_spy.assert_called_with(f"OUTX {mode}")
+
+
+def test_init_mode_gpibcomm(mocker):
+    """Test initialization with GPIBCommunicator"""
+    mock_gpib = mocker.MagicMock()
+    comm = GPIBCommunicator(mock_gpib, 1)
+    mock_send = mocker.patch.object(comm, 'sendcmd')
+    ik.srs.SRS830(comm)
+    mock_send.assert_called_with("OUTX 1")
+
+
+def test_init_mode_serial_comm(mocker):
+    """Test initialization with SerialCommunicator"""
+    comm = SerialCommunicator(serial.Serial())
+    mock_send = mocker.patch.object(comm, 'sendcmd')
+    ik.srs.SRS830(comm)
+    mock_send.assert_called_with("OUTX 2")
+
+
+def test_init_mode_invalid():
+    """Test initialization with invalild communicator."""
+    comm = USBCommunicator(None)
+    with pytest.warns(UserWarning) as wrn_info:
+        ik.srs.SRS830(comm)
+    wrn_msg = wrn_info[0].message.args[0]
+    assert wrn_msg == "OUTX command has not been set. Instrument behaviour " \
+                       "is unknown."
 
 
 def test_frequency_source():
@@ -164,6 +210,43 @@ def test_num_data_points():
         assert inst.num_data_points == 5
 
 
+def test_num_data_points_no_answer():
+    """Raise IOError after no answer 10 times."""
+    answer = ""
+    with expected_protocol(
+            ik.srs.SRS830,
+            [
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?"
+            ],
+            [
+                answer,
+                answer,
+                answer,
+                answer,
+                answer,
+                answer,
+                answer,
+                answer,
+                answer,
+                answer
+            ]
+    ) as inst:
+        with pytest.raises(IOError) as err_info:
+            _ = inst.num_data_points
+        err_msg = err_info.value.args[0]
+        assert err_msg == f"Expected integer response from instrument, got " \
+                          f"{repr(answer)}"
+
+
 def test_data_transfer():
     with expected_protocol(
             ik.srs.SRS830,
@@ -257,6 +340,56 @@ def test_take_measurement():
             ],
             [
                 "2",
+                "2",
+                "1.234,5.678",
+                "2",
+                "0.456,5.321"
+            ]
+    ) as inst:
+        resp = inst.take_measurement(sample_rate=1, num_samples=2)
+        np.testing.assert_array_equal(resp, [[1.234, 5.678], [0.456, 5.321]])
+
+
+def test_take_measurement_num_dat_points_fails():
+    """Simulate the failure of num_data_points.
+
+    This is the way it is currently implemented.
+    """
+    with expected_protocol(
+            ik.srs.SRS830,
+            [
+                "REST",
+                "SRAT 4",
+                "SEND 0",
+                "FAST 2",
+                "STRD",
+                "PAUS",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "SPTS?",
+                "TRCA?1,0,2",
+                "SPTS?",
+                "TRCA?2,0,2"
+            ],
+            [
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
                 "2",
                 "1.234,5.678",
                 "2",

--- a/instruments/tests/test_srs/test_srs830.py
+++ b/instruments/tests/test_srs/test_srs830.py
@@ -215,30 +215,8 @@ def test_num_data_points_no_answer():
     answer = ""
     with expected_protocol(
             ik.srs.SRS830,
-            [
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?"
-            ],
-            [
-                answer,
-                answer,
-                answer,
-                answer,
-                answer,
-                answer,
-                answer,
-                answer,
-                answer,
-                answer
-            ]
+            ["SPTS?"] * 10,
+            [answer] * 10
     ) as inst:
         with pytest.raises(IOError) as err_info:
             _ = inst.num_data_points
@@ -363,33 +341,20 @@ def test_take_measurement_num_dat_points_fails():
                 "SEND 0",
                 "FAST 2",
                 "STRD",
-                "PAUS",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
-                "SPTS?",
+                "PAUS"
+            ] +
+            [
+                "SPTS?"
+            ] * 11 +
+            [
                 "TRCA?1,0,2",
                 "SPTS?",
                 "TRCA?2,0,2"
             ],
             [
                 "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
-                "",
+            ] * 10 +
+            [
                 "2",
                 "1.234,5.678",
                 "2",

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -9,12 +9,13 @@ Module containing tests for the SRS DG645
 import pytest
 
 import instruments as ik
+from instruments.abstract_instruments.comm import GPIBCommunicator
 from instruments.units import ureg as u
 from instruments.tests import expected_protocol, make_name_test, unit_eq
 
 # TESTS ######################################################################
 
-# pylint: disable=protected-access
+# pylint: disable=no-member,protected-access
 
 test_srsdg645_name = make_name_test(ik.srs.SRSDG645)
 
@@ -64,6 +65,14 @@ def test_srsdg645_channel_delay():
 
 
 # DG645 #
+
+
+def test_srsdg645_init_gpib(mocker):
+    """Initialize SRSDG645 with GPIB Communicator."""
+    mock_gpib = mocker.MagicMock()
+    comm = GPIBCommunicator(mock_gpib, 1)
+    ik.srs.SRSDG645(comm)
+    assert comm.strip == 2
 
 
 def test_srsdg645_output_level():


### PR DESCRIPTION
- Full coverage test suite for SRS instruments
- Removed `# pragma: no cover` statements and tested these lines
- Removed `if not self._testing` to invoke a `time.sleep`, which is now
  simply mocked out in the test using an automatically used fixture.
- Fixed typos

If I didn't miss anything, this should be the last push for fully testing all specific instruments and finish the list in #246.