### PR TITLE
add strip() to instrument read()

### DIFF
--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -161,7 +161,7 @@ class Instrument(object):
             connected instrument.
         :rtype: `str`
         """
-        return self._file.read(size, encoding)
+        return self._file.read(size, encoding).strip()
 
     # PROPERTIES #
 


### PR DESCRIPTION
I encountered som problems with whitespaces when communicating with a Thorlabs SC10.
So I simply added a `strip()` to the `instrument.read()` method which might not hurt but solved my problem.

Thanks for the great toolkit