### PR TITLE
Tests and typo fix for Generic SCPI Instruments

### DIFF
--- a/instruments/generic_scpi/scpi_instrument.py
+++ b/instruments/generic_scpi/scpi_instrument.py
@@ -287,6 +287,6 @@ class SCPIInstrument(Instrument):
     @display_contrast.setter
     def display_contrast(self, newval):
         if newval < 0 or newval > 1:
-            raise ValueError("Display brightness must be a number between 0"
+            raise ValueError("Display contrast must be a number between 0"
                              " and 1.")
         self.sendcmd("DISP:CONT {}".format(newval))

--- a/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_function_generator.py
@@ -6,6 +6,7 @@ Module containing tests for generic SCPI function generator instruments
 
 # IMPORTS ####################################################################
 
+import pytest
 
 from instruments.units import ureg as u
 
@@ -94,3 +95,17 @@ def test_scpi_func_gen_offset():
 
         assert fg.channel[0].offset == 12.34 * u.V
         fg.channel[0].offset = 0.4321 * u.V
+
+
+def test_scpi_func_gen_phase():
+    """Raise NotImplementedError when set / get phase."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIFunctionGenerator,
+            [
+            ], [
+            ],
+    ) as fg:
+        with pytest.raises(NotImplementedError):
+            _ = fg.phase
+        with pytest.raises(NotImplementedError):
+            fg.phase = 42

--- a/instruments/tests/test_generic_scpi/test_scpi_instrument.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_instrument.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for generic SCPI instruments
+"""
+
+# IMPORTS ####################################################################
+
+from hypothesis import given, strategies as st
+import pytest
+
+from instruments.units import ureg as u
+
+import instruments as ik
+from instruments.tests import expected_protocol, make_name_test, unit_eq
+
+# TESTS ######################################################################
+
+
+test_scpi_multimeter_name = make_name_test(ik.generic_scpi.SCPIInstrument)
+
+
+def test_scpi_instrument_scpi_version():
+    """Get name of instrument."""
+    retval = "12345"
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                "SYST:VERS?"
+            ],
+            [
+                f"{retval}"
+            ]
+    ) as inst:
+        assert inst.scpi_version == retval
+
+
+@pytest.mark.parametrize("retval", ("0", "1"))
+def test_scpi_instrument_op_complete(retval):
+    """Check if operation is completed."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                "*OPC?"
+            ],
+            [
+                f"{retval}"
+            ]
+    ) as inst:
+        assert inst.op_complete == bool(int(retval))
+
+
+@pytest.mark.parametrize("retval", ("off", "0", 0, False))
+def test_scpi_instrument_power_on_status_off(retval):
+    """Get / set power on status for instrument to on."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                "*PSC 0",
+                "*PSC?"
+            ],
+            [
+                "0"
+            ]
+    ) as inst:
+        inst.power_on_status = retval
+        assert not inst.power_on_status
+
+
+@pytest.mark.parametrize("retval", ("on", "1", 1, True))
+def test_scpi_instrument_power_on_status_on(retval):
+    """Get / set power on status for instrument to on."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                "*PSC 1",
+                "*PSC?"
+            ],
+            [
+                "1"
+            ]
+    ) as inst:
+        inst.power_on_status = retval
+        assert inst.power_on_status
+
+
+def test_scpi_instrument_power_on_status_value_error():
+    """Raise ValueError if power on status set with invalid value."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+            ],
+            [
+            ]
+    ) as inst:
+        with pytest.raises(ValueError):
+            inst.power_on_status = 42
+
+
+def test_scpi_instrument_self_test_ok():
+    """Check if self test returns okay."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                "*TST?",
+                "*TST?"
+            ],
+            [
+                "0",  # ok
+                "not ok"
+            ]
+    ) as inst:
+        assert inst.self_test_ok
+        assert not inst.self_test_ok
+
+
+def test_scpi_instrument_reset():
+    """Reset the instrument."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                "*RST"
+            ],
+            [
+            ]
+    ) as inst:
+        inst.reset()
+
+
+def test_scpi_instrument_clear():
+    """Clear the instrument."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                "*CLS"
+            ],
+            [
+            ]
+    ) as inst:
+        inst.clear()
+
+
+def test_scpi_instrument_trigger():
+    """Trigger the instrument."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                "*TRG"
+            ],
+            [
+            ]
+    ) as inst:
+        inst.trigger()
+
+
+def test_scpi_instrument_wait_to_continue():
+    """Wait to continue the instrument."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                "*WAI"
+            ],
+            [
+            ]
+    ) as inst:
+        inst.wait_to_continue()
+
+
+def test_scpi_instrument_line_frequency():
+    """Get / set line frequency."""
+    freq_hz = 100
+    freq_mhz = u.Quantity(100000, u.mHz)
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                f"SYST:LFR {freq_hz}",
+                "SYST:LFR?",
+                f"SYST:LFR {freq_mhz.to('Hz').magnitude}",
+            ],
+            [
+                f"{freq_hz}",
+            ]
+    ) as inst:
+        inst.line_frequency = freq_hz
+        unit_eq(inst.line_frequency, freq_hz * u.hertz)
+        # send a value as mHz
+        inst.line_frequency = freq_mhz
+
+
+def test_scpi_instrument_check_error_queue():
+    """Check and clear error queue."""
+    ErrorCodes = ik.generic_scpi.SCPIInstrument.ErrorCodes
+    err1 = ErrorCodes.no_error  # is skipped
+    err2 = ErrorCodes.invalid_separator
+    err3 = 13  # invalid error number
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                f"SYST:ERR:CODE:ALL?"
+            ],
+            [
+                f"{err1.value},{err2.value},{err3}",
+            ]
+    ) as inst:
+        assert inst.check_error_queue() == [err2, err3]
+
+
+@given(val=st.floats(min_value=0, max_value=1))
+def test_scpi_instrument_display_brightness(val):
+    """Get / set display brightness."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                f"DISP:BRIG {val}",
+                f"DISP:BRIG?"
+            ],
+            [
+                f"{val}",
+            ]
+    ) as inst:
+        inst.display_brightness = val
+        assert inst.display_brightness == val
+
+
+@given(val=st.floats(allow_nan=False, allow_infinity=False).filter(
+    lambda x: x < 0 or x > 1))
+def test_scpi_instrument_display_brightness_invalid_value(val):
+    """Raise ValueError if display brightness set with invalid value."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+            ],
+            [
+            ]
+    ) as inst:
+        with pytest.raises(ValueError) as err_info:
+            inst.display_brightness = val
+        err_msg = err_info.value.args[0]
+        assert err_msg == "Display brightness must be a number between 0 " \
+                          "and 1."
+
+
+@given(val=st.floats(min_value=0, max_value=1))
+def test_scpi_instrument_display_contrast(val):
+    """Get / set display contrast."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+                f"DISP:CONT {val}",
+                f"DISP:CONT?"
+            ],
+            [
+                f"{val}",
+            ]
+    ) as inst:
+        inst.display_contrast = val
+        assert inst.display_contrast == val
+
+
+@given(val=st.floats(allow_nan=False, allow_infinity=False).filter(
+    lambda x: x < 0 or x > 1))
+def test_scpi_instrument_display_contrast_invalid_value(val):
+    """Raise ValueError if display contrast set with invalid value."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIInstrument,
+            [
+            ],
+            [
+            ]
+    ) as inst:
+        with pytest.raises(ValueError) as err_info:
+            inst.display_contrast = val
+        err_msg = err_info.value.args[0]
+        assert err_msg == "Display contrast must be a number between 0 " \
+                          "and 1."

--- a/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
+++ b/instruments/tests/test_generic_scpi/test_scpi_multimeter.py
@@ -6,6 +6,7 @@ Module containing tests for generic SCPI multimeter instruments
 
 # IMPORTS ####################################################################
 
+import pytest
 
 from instruments.units import ureg as u
 
@@ -91,6 +92,24 @@ def test_scpi_multimeter_resolution():
         dmm.resolution = 3e-06
 
 
+def test_scpi_multimeter_resolution_type_error():
+    """Raise TypeError if resolution value has the wrong type."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "CONF?"
+            ], [
+                "VOLT +1.000000E+01,+3.000000E-06"
+            ]
+    ) as dmm:
+        wrong_type = "42"
+        with pytest.raises(TypeError) as err_info:
+            dmm.resolution = wrong_type
+        err_msg = err_info.value.args[0]
+        assert err_msg == ("Resolution must be specified as an int, float, "
+                           "or SCPIMultimeter.Resolution value.")
+
+
 def test_scpi_multimeter_trigger_count():
     with expected_protocol(
             ik.generic_scpi.SCPIMultimeter,
@@ -108,6 +127,22 @@ def test_scpi_multimeter_trigger_count():
         assert dmm.trigger_count == dmm.TriggerCount.infinity
         dmm.trigger_count = dmm.TriggerCount.minimum
         dmm.trigger_count = 10
+
+
+def test_scpi_multimeter_trigger_count_type_error():
+    """Raise TypeError if trigger count value has the wrong type."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIMultimeter,
+            [
+            ], [
+            ]
+    ) as dmm:
+        wrong_type = "42"
+        with pytest.raises(TypeError) as err_info:
+            dmm.trigger_count = wrong_type
+        err_msg = err_info.value.args[0]
+        assert err_msg == ("Trigger count must be specified as an int "
+                           "or SCPIMultimeter.TriggerCount value.")
 
 
 def test_scpi_multimeter_sample_count():
@@ -128,6 +163,21 @@ def test_scpi_multimeter_sample_count():
         dmm.sample_count = dmm.SampleCount.minimum
         dmm.sample_count = 10
 
+
+def test_scpi_multimeter_sample_count_type_error():
+    """Raise TypeError if sample count is of invalid type."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIMultimeter,
+            [
+            ], [
+            ]
+    ) as dmm:
+        wrong_type = "42"
+        with pytest.raises(TypeError) as err_info:
+            dmm.sample_count = wrong_type
+        err_msg = err_info.value.args[0]
+        assert err_msg == ("Sample count must be specified as an int "
+                           "or SCPIMultimeter.SampleCount value.")
 
 def test_scpi_multimeter_trigger_delay():
     with expected_protocol(
@@ -171,6 +221,20 @@ def test_scpi_multimeter_sample_timer():
         dmm.sample_timer = 1000 * u.millisecond
 
 
+def test_scpi_multimeter_relative_not_implemented():
+    """Raise NotImplementedError when set / get relative."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIMultimeter,
+            [
+            ], [
+            ]
+    ) as dmm:
+        with pytest.raises(NotImplementedError):
+            _ = dmm.relative
+        with pytest.raises(NotImplementedError):
+            dmm.relative = 42
+
+
 def test_scpi_multimeter_measure():
     with expected_protocol(
             ik.generic_scpi.SCPIMultimeter,
@@ -181,3 +245,35 @@ def test_scpi_multimeter_measure():
             ]
     ) as dmm:
         unit_eq(dmm.measure(dmm.Mode.voltage_dc), 4.2345e-03 * u.volt)
+
+
+def test_scpi_multimeter_measure_mode_none():
+    """Read current mode if not specified, test with volt, DC mode."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIMultimeter,
+            [
+                "CONF?",
+                "MEAS:VOLT:DC?",
+            ], [
+                "VOLT:DC",
+                "+4.23450000E-03",
+            ]
+
+    ) as dmm:
+        unit_eq(dmm.measure(), 4.2345e-03 * u.volt)
+
+
+def test_scpi_multimeter_measure_invalid_mode():
+    """Raise TypeError if mode is not of type SCPIMultimeter.Mode."""
+    with expected_protocol(
+            ik.generic_scpi.SCPIMultimeter,
+            [
+            ], [
+            ]
+    ) as dmm:
+        wrong_type = 42
+        with pytest.raises(TypeError) as err_info:
+            dmm.measure(mode=wrong_type)
+        err_msg = err_info.value.args[0]
+        assert err_msg == f"Mode must be specified as a SCPIMultimeter.Mode " \
+                          f"value, got {type(wrong_type)} instead."


### PR DESCRIPTION
- All three instruments now with full coverage
- Added tests to SCPI Function Generator
- Added tests to SCPI Multimeter
- Created tests for SCPI Instrument
- Corrected a typo / copy paste error: Contrast error message returned
  description for brightness instead of contrast.