### PR TITLE
Remove support for new pyserial 3.5 until we fix it

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 include_package_data = True
 packages = find:
 install_requires =
-    pyserial>=3.3
+    pyserial>=3.3,<3.5
     pyvisa>=1.9
     python-vxi11>=0.8
     python-usbtmc


### PR DESCRIPTION
With the release of pyserial 3.5 the build is currently broken as our tests don't pass with it #298 . This PR disables support for it until we can fix the root problem.