### PR TITLE
Full test suite and fixes for meta-instruments in abstract instruments

### DIFF
--- a/instruments/abstract_instruments/optical_spectrum_analyzer.py
+++ b/instruments/abstract_instruments/optical_spectrum_analyzer.py
@@ -63,7 +63,8 @@ class OpticalSpectrumAnalyzer(Instrument, metaclass=abc.ABCMeta):
 
     # PROPERTIES #
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def channel(self):
         """
         Gets an iterator or list for easy Pythonic access to the various

--- a/instruments/abstract_instruments/oscilloscope.py
+++ b/instruments/abstract_instruments/oscilloscope.py
@@ -52,7 +52,8 @@ class OscilloscopeDataSource(metaclass=abc.ABCMeta):
 
     # PROPERTIES #
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self):
         """
         Gets the name of the channel. This is an abstract property.
@@ -116,7 +117,8 @@ class Oscilloscope(Instrument, metaclass=abc.ABCMeta):
 
     # PROPERTIES #
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def channel(self):
         """
         Gets an iterator or list for easy Pythonic access to the various
@@ -125,7 +127,8 @@ class Oscilloscope(Instrument, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def ref(self):
         """
         Gets an iterator or list for easy Pythonic access to the various
@@ -134,7 +137,8 @@ class Oscilloscope(Instrument, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def math(self):
         """
         Gets an iterator or list for easy Pythonic access to the various

--- a/instruments/tests/test_abstract_inst/test_electrometer.py
+++ b/instruments/tests/test_abstract_inst/test_electrometer.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the abstract electrometer class
+"""
+
+# IMPORTS ####################################################################
+
+
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol
+
+
+# TESTS ######################################################################
+
+
+@pytest.fixture
+def em(monkeypatch):
+    """Patch and return electrometer class for direct access of metaclass."""
+    inst = ik.abstract_instruments.Electrometer
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+def test_electrometer_mode(em):
+    """Get / set mode to ensure the abstract property exists."""
+    with expected_protocol(
+        em,
+        [],
+        []
+    ) as inst:
+        _ = inst.mode
+        inst.mode = 42
+
+
+def test_electrometer_unit(em):
+    """Get unit to ensure the abstract property exists."""
+    with expected_protocol(
+            em,
+            [],
+            []
+    ) as inst:
+        _ = inst.unit
+
+
+def test_electrometer_trigger_mode(em):
+    """Get / set trigger mode to ensure the abstract property exists."""
+    with expected_protocol(
+            em,
+            [],
+            []
+    ) as inst:
+        _ = inst.trigger_mode
+        inst.trigger_mode = 42
+
+
+def test_electrometer_input_range(em):
+    """Get / set input range to ensure the abstract property exists."""
+    with expected_protocol(
+            em,
+            [],
+            []
+    ) as inst:
+        _ = inst.input_range
+        inst.input_range = 42
+
+
+def test_electrometer_zero_check(em):
+    """Get / set zero check to ensure the abstract property exists."""
+    with expected_protocol(
+            em,
+            [],
+            []
+    ) as inst:
+        _ = inst.zero_check
+        inst.zero_check = 42
+
+
+def test_electrometer_zero_correct(em):
+    """Get / set zero correct to ensure the abstract property exists."""
+    with expected_protocol(
+            em,
+            [],
+            []
+    ) as inst:
+        _ = inst.zero_correct
+        inst.zero_correct = 42
+
+
+def test_electrometer_fetch(em):
+    """Raise NotImplementedError for fetch method."""
+    with expected_protocol(
+            em,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            inst.fetch()
+
+
+def test_electrometer_read_measurements(em):
+    """Raise NotImplementedError for read_measurements method."""
+    with expected_protocol(
+            em,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            inst.read_measurements()

--- a/instruments/tests/test_abstract_inst/test_multimeter.py
+++ b/instruments/tests/test_abstract_inst/test_multimeter.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the abstract multimeter class
+"""
+
+# IMPORTS ####################################################################
+
+
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol
+
+
+# TESTS ######################################################################
+
+
+@pytest.fixture
+def mul(monkeypatch):
+    """Patch and return Multimeter class for access."""
+    inst = ik.abstract_instruments.Multimeter
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+def test_multimeter_mode(mul):
+    """Get / set mode: ensure existence."""
+    with expected_protocol(
+            mul,
+            [],
+            []
+    ) as inst:
+        _ = inst.mode
+        inst.mode = 42
+
+
+def test_multimeter_trigger_mode(mul):
+    """Get / set trigger mode: ensure existence."""
+    with expected_protocol(
+            mul,
+            [],
+            []
+    ) as inst:
+        _ = inst.trigger_mode
+        inst.trigger_mode = 42
+
+
+def test_multimeter_relative(mul):
+    """Get / set relative: ensure existence."""
+    with expected_protocol(
+            mul,
+            [],
+            []
+    ) as inst:
+        _ = inst.relative
+        inst.relative = 42
+
+
+def test_multimeter_input_range(mul):
+    """Get / set input range: ensure existence."""
+    with expected_protocol(
+            mul,
+            [],
+            []
+    ) as inst:
+        _ = inst.input_range
+        inst.input_range = 42
+
+
+def test_multimeter_measure(mul):
+    """Measure: ensure existence."""
+    with expected_protocol(
+            mul,
+            [],
+            []
+    ) as inst:
+        inst.measure('mode')

--- a/instruments/tests/test_abstract_inst/test_optical_spectrum_analyzer.py
+++ b/instruments/tests/test_abstract_inst/test_optical_spectrum_analyzer.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the abstract optical spectrum analyzer class
+"""
+
+# IMPORTS ####################################################################
+
+
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol
+
+
+# TESTS ######################################################################
+
+
+@pytest.fixture
+def osa(monkeypatch):
+    """Patch and return Optical Spectrum Analyzer class for access."""
+    inst = ik.abstract_instruments.OpticalSpectrumAnalyzer
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+@pytest.fixture
+def osc(monkeypatch):
+    """Patch and return OSAChannel class for access."""
+    inst = ik.abstract_instruments.OSAChannel
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+# OPTICAL SPECTRUM ANALYZER CLASS #
+
+
+def test_osa_channel(osa):
+    """Get channel: ensure existence."""
+    with expected_protocol(
+            osa,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            _ = inst.channel
+
+
+def test_osa_start_wl(osa):
+    """Get / set start wavelength: ensure existence."""
+    with expected_protocol(
+            osa,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            _ = inst.start_wl
+        with pytest.raises(NotImplementedError):
+            inst.start_wl = 42
+
+
+def test_osa_stop_wl(osa):
+    """Get / set stop wavelength: ensure existence."""
+    with expected_protocol(
+            osa,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            _ = inst.stop_wl
+        with pytest.raises(NotImplementedError):
+            inst.stop_wl = 42
+
+
+def test_osa_bandwidth(osa):
+    """Get / set bandwidth: ensure existence."""
+    with expected_protocol(
+            osa,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            _ = inst.bandwidth
+        with pytest.raises(NotImplementedError):
+            inst.bandwidth = 42
+
+
+def test_osa_start_sweep(osa):
+    """Start sweep: ensure existence."""
+    with expected_protocol(
+            osa,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            inst.start_sweep()
+
+
+# OSAChannel #
+
+
+def test_osa_channel_wavelength(osc):
+    """Channel wavelength method: ensure existence."""
+    inst = osc()
+    with pytest.raises(NotImplementedError):
+        inst.wavelength()
+
+
+def test_osa_channel_data(osc):
+    """Channel data method: ensure existence."""
+    inst = osc()
+    with pytest.raises(NotImplementedError):
+        inst.data()

--- a/instruments/tests/test_abstract_inst/test_oscilloscope.py
+++ b/instruments/tests/test_abstract_inst/test_oscilloscope.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the abstract oscilloscope class
+"""
+
+# IMPORTS ####################################################################
+
+
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol
+
+
+# TESTS ######################################################################
+
+
+@pytest.fixture
+def osc(monkeypatch):
+    """Patch and return Oscilloscope class for access."""
+    inst = ik.abstract_instruments.Oscilloscope
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+@pytest.fixture
+def osc_ch(monkeypatch):
+    """Patch and return OscilloscopeChannel class for access."""
+    inst = ik.abstract_instruments.OscilloscopeChannel
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+@pytest.fixture
+def osc_ds(monkeypatch):
+    """Patch and return OscilloscopeDataSource class for access."""
+    inst = ik.abstract_instruments.OscilloscopeDataSource
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+# OSCILLOSCOPE #
+
+
+def test_oscilloscope_channel(osc):
+    """Get channel: ensure existence."""
+    with expected_protocol(
+            osc,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            _ = inst.channel
+
+
+def test_oscilloscope_ref(osc):
+    """Get ref: ensure existence."""
+    with expected_protocol(
+            osc,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            _ = inst.ref
+
+
+def test_oscilloscope_math(osc):
+    """Get math: ensure existence."""
+    with expected_protocol(
+            osc,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            _ = inst.math
+
+
+def test_oscilloscope_force_trigger(osc):
+    """Force a trigger: ensure existence."""
+    with expected_protocol(
+            osc,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            inst.force_trigger()
+
+
+# OSCILLOSCOPE CHANNEL #
+
+
+def test_oscilloscope_channel_coupling(osc_ch):
+    """Get / set channel coupling: ensure existence."""
+    inst = osc_ch()
+    with pytest.raises(NotImplementedError):
+        _ = inst.coupling
+    with pytest.raises(NotImplementedError):
+        inst.coupling = 42
+
+
+# OSCILLOSCOPE DATA SOURCE #
+
+
+def test_oscilloscope_data_source_init(osc_ds):
+    """Initialize Oscilloscope Data Source."""
+    parent = 'parent'
+    name = 'name'
+    inst = osc_ds(parent, name)
+    assert inst._parent == parent
+    assert inst._name == name
+    assert inst._old_dsrc is None
+
+
+def test_oscilloscope_data_source_name(osc_ds):
+    """Get data source name: ensure existence."""
+    parent = 'parent'
+    name = 'name'
+    inst = osc_ds(parent, name)
+    with pytest.raises(NotImplementedError):
+        _ = inst.name
+
+
+def test_oscilloscope_data_source_read_waveform(osc_ds):
+    """Read data source waveform: ensure existence."""
+    parent = 'parent'
+    name = 'name'
+    inst = osc_ds(parent, name)
+    with pytest.raises(NotImplementedError):
+        inst.read_waveform()

--- a/instruments/tests/test_abstract_inst/test_power_supply.py
+++ b/instruments/tests/test_abstract_inst/test_power_supply.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the abstract power supply class
+"""
+
+# IMPORTS ####################################################################
+
+
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol
+
+
+# TESTS ######################################################################
+
+
+@pytest.fixture
+def ps(monkeypatch):
+    """Patch and return Power Supply class for access."""
+    inst = ik.abstract_instruments.PowerSupply
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+@pytest.fixture
+def ps_ch(monkeypatch):
+    """Patch and return Power Supply Channel class for access."""
+    inst = ik.abstract_instruments.PowerSupplyChannel
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+# POWER SUPPLY #
+
+
+def test_power_supply_channel(ps):
+    """Get channel: ensure existence."""
+    with expected_protocol(
+            ps,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            _ = inst.channel
+
+
+def test_power_supply_voltage(ps):
+    """Get / set voltage: ensure existence."""
+    with expected_protocol(
+            ps,
+            [],
+            []
+    ) as inst:
+        _ = inst.voltage
+        inst.voltage = 42
+
+
+def test_power_supply_current(ps):
+    """Get / set current: ensure existence."""
+    with expected_protocol(
+            ps,
+            [],
+            []
+    ) as inst:
+        _ = inst.current
+        inst.current = 42
+
+
+# POWER SUPPLY CHANNEL #
+
+
+def test_power_supply_channel_mode(ps_ch):
+    """Get / set channel mode: ensure existence."""
+    inst = ps_ch()
+    _ = inst.mode
+    inst.mode = 42
+
+
+def test_power_supply_channel_voltage(ps_ch):
+    """Get / set channel voltage: ensure existence."""
+    inst = ps_ch()
+    _ = inst.voltage
+    inst.voltage = 42
+
+
+def test_power_supply_channel_current(ps_ch):
+    """Get / set channel current: ensure existence."""
+    inst = ps_ch()
+    _ = inst.current
+    inst.current = 42
+
+
+def test_power_supply_channel_output(ps_ch):
+    """Get / set channel output: ensure existence."""
+    inst = ps_ch()
+    _ = inst.output
+    inst.output = 42


### PR DESCRIPTION
Included instruments with full tests now:
- Electrometer
- Function Generator
- Multimeter
- Optical spectrum analyzer
- Oscilloscope
- Power supply

Full test suites using pytest fixtures to patch the metaclasses such
that they become accessible, see PEP 3119.

Fixed `@abc.abstractproperty` decorators in optical spectrum analyzer
and oscilloscope, since this decorator is deprecated since py3.3.