### PR TITLE
Create test suite for abstract signal generator instruments

### DIFF
--- a/instruments/tests/test_abstract_inst/test_signal_generator/test_channel.py
+++ b/instruments/tests/test_abstract_inst/test_signal_generator/test_channel.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the abstract signal generator channel class
+"""
+
+# IMPORTS ####################################################################
+
+
+import pytest
+
+import instruments as ik
+
+
+# TESTS ######################################################################
+
+
+@pytest.fixture
+def sgc(monkeypatch):
+    """Patch and return SGChannel for direct access of metaclass."""
+    inst = ik.abstract_instruments.signal_generator.SGChannel
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+def test_sg_channel_frequency(sgc):
+    """Get / set frequency: Ensure existence."""
+    inst = sgc()
+    _ = inst.frequency
+    inst.frequency = 42
+
+
+def test_sg_channel_power(sgc):
+    """Get / set power: Ensure existence."""
+    inst = sgc()
+    _ = inst.power
+    inst.power = 42
+
+
+def test_sg_channel_phase(sgc):
+    """Get / set phase: Ensure existence."""
+    inst = sgc()
+    _ = inst.phase
+    inst.phase = 42
+
+
+def test_sg_channel_output(sgc):
+    """Get / set output: Ensure existence."""
+    inst = sgc()
+    _ = inst.output
+    inst.output = 4

--- a/instruments/tests/test_abstract_inst/test_signal_generator/test_signal_generator.py
+++ b/instruments/tests/test_abstract_inst/test_signal_generator/test_signal_generator.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the abstract signal generator class
+"""
+
+# IMPORTS ####################################################################
+
+
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol
+
+
+# TESTS ######################################################################
+
+
+@pytest.fixture
+def sg(monkeypatch):
+    """Patch and return signal generator for direct access of metaclass."""
+    inst = ik.abstract_instruments.signal_generator.SignalGenerator
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+def test_signal_generator_channel(sg):
+    """Get channel: Ensure existence."""
+    with expected_protocol(
+            sg,
+            [],
+            []
+    ) as inst:
+        with pytest.raises(NotImplementedError):
+            _ = inst.channel

--- a/instruments/tests/test_abstract_inst/test_signal_generator/test_single_channel_sg.py
+++ b/instruments/tests/test_abstract_inst/test_signal_generator/test_single_channel_sg.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Module containing tests for the abstract signal generator class
+"""
+
+# IMPORTS ####################################################################
+
+
+import pytest
+
+import instruments as ik
+from instruments.tests import expected_protocol
+
+
+# TESTS ######################################################################
+
+
+@pytest.fixture
+def scsg(monkeypatch):
+    """Patch and return signal generator for direct access of metaclass."""
+    inst = ik.abstract_instruments.signal_generator.SingleChannelSG
+    monkeypatch.setattr(inst, '__abstractmethods__', set())
+    return inst
+
+
+def test_signal_generator_channel(scsg):
+    """Get channel: Ensure existence."""
+    with expected_protocol(
+            scsg,
+            [],
+            []
+    ) as inst:
+        assert inst.channel[0] == inst


### PR DESCRIPTION
Same as for the other abstract classes, now for the signal generator folder in abstract_instruments

- Full coverage
- Adopt a pytest fixture to directly access abstract classes
- Test properties / methods for existence