### PR TITLE
Add tests for full coverage of instrument.py. Remove legacy checks.

### DIFF
--- a/instruments/abstract_instruments/instrument.py
+++ b/instruments/abstract_instruments/instrument.py
@@ -584,9 +584,6 @@ class Instrument:
 
         .. _PyVISA: http://pyvisa.sourceforge.net/
         """
-        if pyvisa is None:
-            raise ImportError("PyVISA is required for loading VISA "
-                              "instruments.")
         version = list(map(int, pyvisa.__version__.split(".")))
         while len(version) < 3:
             version += [0]
@@ -671,10 +668,6 @@ class Instrument:
         :return: Object representing the connected instrument.
         """
         # pylint: disable=no-member
-        if usb is None:
-            raise ImportError("USB support not imported. Do you have PyUSB "
-                              "version 1.0 or later?")
-
         dev = usb.core.find(idVendor=vid, idProduct=pid)
         if dev is None:
             raise IOError("No such device found.")

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     pyvisa>=1.9
     python-vxi11>=0.8
     python-usbtmc
-    pyusb
+    pyusb>=1.0
     ruamel.yaml~=0.15.37
     pint>=0.16.1
 


### PR DESCRIPTION
- Added tests for `open_usb` and `open_gpibethernet`
- Removed checks for modules `usb` and `pyvisa` not present since they
  are now by default part of IK