### PR TITLE
Bug fix for `lcc25.py`, add a space after prompt ">"

### DIFF
--- a/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_lcc25.py
@@ -25,7 +25,7 @@ def test_lcc25_name():
             [
                 "*idn?",
                 "bloopbloop",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -43,8 +43,8 @@ def test_lcc25_frequency():
             [
                 "freq?",
                 "20",
-                ">freq=10.0",
-                ">"
+                "> freq=10.0",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -60,7 +60,7 @@ def test_lcc25_frequency_lowlimit():
             ],
             [
                 "freq=0.0",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -75,7 +75,7 @@ def test_lcc25_frequency_highlimit():
             ],
             [
                 "freq=160.0",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -92,8 +92,8 @@ def test_lcc25_mode():
             [
                 "mode?",
                 "2",
-                ">mode=1",
-                ">"
+                "> mode=1",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -120,8 +120,8 @@ def test_lcc25_enable():
             [
                 "enable?",
                 "0",
-                ">enable=1",
-                ">"
+                "> enable=1",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -148,8 +148,8 @@ def test_lcc25_extern():
             [
                 "extern?",
                 "0",
-                ">extern=1",
-                ">"
+                "> extern=1",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -176,8 +176,8 @@ def test_lcc25_remote():
             [
                 "remote?",
                 "0",
-                ">remote=1",
-                ">"
+                "> remote=1",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -204,8 +204,8 @@ def test_lcc25_voltage1():
             [
                 "volt1?",
                 "20",
-                ">volt1=10.0",
-                ">"
+                "> volt1=10.0",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -229,8 +229,8 @@ def test_lcc25_voltage2():
             [
                 "volt2?",
                 "20",
-                ">volt2=10.0",
-                ">"
+                "> volt2=10.0",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -248,8 +248,8 @@ def test_lcc25_minvoltage():
             [
                 "min?",
                 "20",
-                ">min=10.0",
-                ">"
+                "> min=10.0",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -267,8 +267,8 @@ def test_lcc25_maxvoltage():
             [
                 "max?",
                 "20",
-                ">max=10.0",
-                ">"
+                "> max=10.0",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -286,8 +286,8 @@ def test_lcc25_dwell():
             [
                 "dwell?",
                 "20",
-                ">dwell=10",
-                ">"
+                "> dwell=10",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -303,7 +303,7 @@ def test_lcc25_dwell_positive():
             ],
             [
                 "dwell=-10",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -320,8 +320,8 @@ def test_lcc25_increment():
             [
                 "increment?",
                 "20",
-                ">increment=10.0",
-                ">"
+                "> increment=10.0",
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -337,7 +337,7 @@ def test_lcc25_increment_positive():
             ],
             [
                 "increment=-10",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -353,7 +353,7 @@ def test_lcc25_default():
             [
                 "default",
                 "1",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -369,7 +369,7 @@ def test_lcc25_save():
             [
                 "save",
                 "1",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -385,7 +385,7 @@ def test_lcc25_set_settings():
             [
                 "set=2",
                 "1",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -411,7 +411,7 @@ def test_lcc25_get_settings():
             [
                 "get=2",
                 "1",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:
@@ -437,7 +437,7 @@ def test_lcc25_test_mode():
             [
                 "test",
                 "1",
-                ">"
+                "> "
             ],
             sep="\r"
     ) as lcc:

--- a/instruments/thorlabs/lcc25.py
+++ b/instruments/thorlabs/lcc25.py
@@ -33,7 +33,7 @@ class LCC25(Instrument):
     def __init__(self, filelike):
         super(LCC25, self).__init__(filelike)
         self.terminator = "\r"
-        self.prompt = ">"
+        self.prompt = "> "
 
     def _ack_expected(self, msg=""):
         return msg


### PR DESCRIPTION
Bug fix for Thorlabs LCC25 device to add a space after prompt. As discussed in #310, this fix works with hardware from @MarChan13. 
Also adjusted tests to represent this change.