### PR TITLE
Newport error codes x00 to x09 fixed

### DIFF
--- a/instruments/newport/errors.py
+++ b/instruments/newport/errors.py
@@ -119,7 +119,7 @@ class NewportError(IOError):
                                                self._timestamp)
                 super(NewportError, self).__init__(error)
             else:
-                error_message = self.get_message('x{0}'.format(self._errcode))
+                error_message = self.get_message('x{0:02d}'.format(self._errcode))
                 error = "Newport Error: {0}. Axis: {1}. " \
                         "Error Message: {2}. " \
                         "At time : {3}".format(str(self._errcode),


### PR DESCRIPTION
The error codes corresponding to errors x00 to x09 are not associated to their corresponding axis due to improper matching of the error dictionary for single digit errors.
Using :02d format we force a two digit string which matches the corresponding error correctly. This does not affect other error codes.