### PR TITLE
Skip no-commit-to-branch in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: pip install --upgrade pre-commit
     - name: Run static checks via pre-commit
-      run: pre-commit run --all --show-diff-on-failure
+      run: SKIP=no-commit-to-branch pre-commit run --all --show-diff-on-failure
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
It looks like the `no-commit-to-branch` only skips if you are not on a branch, which is usually the case in CI, such as TravisCI.

However Github Actions actually does checkout the branch, which means that this hook is run post-merge in CI, which fails even if you have no changed files.

This skips that hook in CI.