### PR TITLE
Inner, outer class consistency

### DIFF
--- a/doc/source/apiref/instrument.rst
+++ b/doc/source/apiref/instrument.rst
@@ -28,6 +28,13 @@ Instrument Base Classes
     :members:
     :undoc-members:
 
+:class:`PowerSupply` - Abstract class for power supply instruments
+==================================================================
+
+.. autoclass:: instruments.abstract_instruments.PowerSupply
+    :members:
+    :undoc-members:
+
 :class:`Oscilloscope` - Abstract class for oscilloscope instruments
 ===================================================================
 

--- a/doc/source/apiref/instrument.rst
+++ b/doc/source/apiref/instrument.rst
@@ -42,6 +42,13 @@ Instrument Base Classes
     :members:
     :undoc-members:
 
+:class:`OpticalSpectrumAnalyzer` - Abstract class for optical spectrum analyzer instruments
+===========================================================================================
+
+.. autoclass:: instruments.abstract_instruments.OpticalSpectrumAnalyzer
+    :members:
+    :undoc-members:
+
 :class:`SignalGenerator` - Abstract class for Signal Generators
 ===============================================================
 

--- a/doc/source/apiref/instrument.rst
+++ b/doc/source/apiref/instrument.rst
@@ -14,10 +14,10 @@ Instrument Base Classes
     :members:
     :undoc-members:
 
-:class:`Multimeter` - Abstract class for multimeter instruments
-===============================================================
+:class:`Electrometer` - Abstract class for electrometer instruments
+===================================================================
 
-.. autoclass:: instruments.abstract_instruments.Multimeter
+.. autoclass:: instruments.abstract_instruments.Electrometer
     :members:
     :undoc-members:
 
@@ -28,10 +28,10 @@ Instrument Base Classes
     :members:
     :undoc-members:
 
-:class:`PowerSupply` - Abstract class for power supply instruments
-==================================================================
+:class:`Multimeter` - Abstract class for multimeter instruments
+===============================================================
 
-.. autoclass:: instruments.abstract_instruments.PowerSupply
+.. autoclass:: instruments.abstract_instruments.Multimeter
     :members:
     :undoc-members:
 
@@ -46,6 +46,13 @@ Instrument Base Classes
 ===========================================================================================
 
 .. autoclass:: instruments.abstract_instruments.OpticalSpectrumAnalyzer
+    :members:
+    :undoc-members:
+
+:class:`PowerSupply` - Abstract class for power supply instruments
+==================================================================
+
+.. autoclass:: instruments.abstract_instruments.PowerSupply
     :members:
     :undoc-members:
 

--- a/doc/source/apiref/instrument.rst
+++ b/doc/source/apiref/instrument.rst
@@ -28,6 +28,13 @@ Instrument Base Classes
     :members:
     :undoc-members:
 
+:class:`Oscilloscope` - Abstract class for oscilloscope instruments
+===================================================================
+
+.. autoclass:: instruments.abstract_instruments.Oscilloscope
+    :members:
+    :undoc-members:
+
 :class:`SignalGenerator` - Abstract class for Signal Generators
 ===============================================================
 

--- a/doc/source/apiref/newport.rst
+++ b/doc/source/apiref/newport.rst
@@ -14,10 +14,6 @@ Newport
     :members:
     :undoc-members:
 
-.. autoclass:: _Axis
-    :members:
-    :undoc-members:
-
 :class:`NewportESP301` Motor Controller
 =======================================
 

--- a/doc/source/apiref/newport.rst
+++ b/doc/source/apiref/newport.rst
@@ -21,14 +21,6 @@ Newport
     :members:
     :undoc-members:
 
-.. autoclass:: NewportESP301Axis
-    :members:
-    :undoc-members:
-
-.. autoclass:: NewportESP301HomeSearchMode
-    :members:
-    :undoc-members:
-
 :class:`NewportError`
 =====================
 

--- a/doc/source/apiref/srs.rst
+++ b/doc/source/apiref/srs.rst
@@ -34,7 +34,3 @@ Stanford Research Systems
 .. autoclass:: SRSDG645
     :members:
     :undoc-members:
-
-.. autoclass:: _SRSDG645Channel
-    :members:
-    :undoc-members:

--- a/doc/source/apiref/tektronix.rst
+++ b/doc/source/apiref/tektronix.rst
@@ -21,14 +21,6 @@ Tektronix
     :members:
     :undoc-members:
 
-.. autoclass:: _TekDPO4104DataSource
-    :members:
-    :undoc-members:
-
-.. autoclass:: _TekDPO4104Channel
-    :members:
-    :undoc-members:
-
 :class:`TekDPO70000` Oscilloscope
 =================================
 

--- a/instruments/abstract_instruments/__init__.py
+++ b/instruments/abstract_instruments/__init__.py
@@ -9,9 +9,5 @@ from .multimeter import Multimeter
 from .electrometer import Electrometer
 from .function_generator import FunctionGenerator
 from .oscilloscope import Oscilloscope
+from .optical_spectrum_analyzer import OpticalSpectrumAnalyzer
 from .power_supply import PowerSupply
-
-from .optical_spectrum_analyzer import (
-    OSAChannel,
-    OpticalSpectrumAnalyzer,
-)

--- a/instruments/abstract_instruments/__init__.py
+++ b/instruments/abstract_instruments/__init__.py
@@ -8,11 +8,7 @@ from .instrument import Instrument
 from .multimeter import Multimeter
 from .electrometer import Electrometer
 from .function_generator import FunctionGenerator
-from .oscilloscope import (
-    OscilloscopeChannel,
-    OscilloscopeDataSource,
-    Oscilloscope,
-)
+from .oscilloscope import Oscilloscope
 from .power_supply import (
     PowerSupplyChannel,
     PowerSupply,

--- a/instruments/abstract_instruments/__init__.py
+++ b/instruments/abstract_instruments/__init__.py
@@ -5,9 +5,9 @@ Module containing instrument abstract base classes and communication layers
 
 
 from .instrument import Instrument
-from .multimeter import Multimeter
 from .electrometer import Electrometer
 from .function_generator import FunctionGenerator
+from .multimeter import Multimeter
 from .oscilloscope import Oscilloscope
 from .optical_spectrum_analyzer import OpticalSpectrumAnalyzer
 from .power_supply import PowerSupply

--- a/instruments/abstract_instruments/__init__.py
+++ b/instruments/abstract_instruments/__init__.py
@@ -9,10 +9,7 @@ from .multimeter import Multimeter
 from .electrometer import Electrometer
 from .function_generator import FunctionGenerator
 from .oscilloscope import Oscilloscope
-from .power_supply import (
-    PowerSupplyChannel,
-    PowerSupply,
-)
+from .power_supply import PowerSupply
 
 from .optical_spectrum_analyzer import (
     OSAChannel,

--- a/instruments/abstract_instruments/optical_spectrum_analyzer.py
+++ b/instruments/abstract_instruments/optical_spectrum_analyzer.py
@@ -13,44 +13,6 @@ from instruments.abstract_instruments import Instrument
 # CLASSES #####################################################################
 
 
-class OSAChannel(metaclass=abc.ABCMeta):
-
-    """
-    Abstract base class for physical channels on an optical spectrum analyzer.
-
-    All applicable concrete instruments should inherit from this ABC to
-    provide a consistent interface to the user.
-    """
-
-    # METHODS #
-
-    @abc.abstractmethod
-    def wavelength(self, bin_format=True):
-        """
-        Gets the x-axis of the specified data source channel. This is an
-        abstract property.
-
-        :param bool bin_format: If the waveform should be transfered in binary
-            (``True``) or ASCII (``False``) formats.
-        :return: The wavelength component of the waveform.
-        :rtype: `numpy.ndarray`
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def data(self, bin_format=True):
-        """
-        Gets the y-axis of the specified data source channel. This is an
-        abstract property.
-
-        :param bool bin_format: If the waveform should be transfered in binary
-            (``True``) or ASCII (``False``) formats.
-        :return: The y-component of the waveform.
-        :rtype: `numpy.ndarray`
-        """
-        raise NotImplementedError
-
-
 class OpticalSpectrumAnalyzer(Instrument, metaclass=abc.ABCMeta):
 
     """
@@ -59,6 +21,42 @@ class OpticalSpectrumAnalyzer(Instrument, metaclass=abc.ABCMeta):
     All applicable concrete instruments should inherit from this ABC to
     provide a consistent interface to the user.
     """
+
+    class Channel(metaclass=abc.ABCMeta):
+        """
+        Abstract base class for physical channels on an optical spectrum analyzer.
+
+        All applicable concrete instruments should inherit from this ABC to
+        provide a consistent interface to the user.
+        """
+
+        # METHODS #
+
+        @abc.abstractmethod
+        def wavelength(self, bin_format=True):
+            """
+            Gets the x-axis of the specified data source channel. This is an
+            abstract property.
+
+            :param bool bin_format: If the waveform should be transfered in binary
+                (``True``) or ASCII (``False``) formats.
+            :return: The wavelength component of the waveform.
+            :rtype: `numpy.ndarray`
+            """
+            raise NotImplementedError
+
+        @abc.abstractmethod
+        def data(self, bin_format=True):
+            """
+            Gets the y-axis of the specified data source channel. This is an
+            abstract property.
+
+            :param bool bin_format: If the waveform should be transfered in binary
+                (``True``) or ASCII (``False``) formats.
+            :return: The y-component of the waveform.
+            :rtype: `numpy.ndarray`
+            """
+            raise NotImplementedError
 
     # PROPERTIES #
 

--- a/instruments/abstract_instruments/oscilloscope.py
+++ b/instruments/abstract_instruments/oscilloscope.py
@@ -13,98 +13,6 @@ from instruments.abstract_instruments import Instrument
 # CLASSES #####################################################################
 
 
-class OscilloscopeDataSource(metaclass=abc.ABCMeta):
-
-    """
-    Abstract base class for data sources (physical channels, math, ref) on
-    an oscilloscope.
-
-    All applicable concrete instruments should inherit from this ABC to
-    provide a consistent interface to the user.
-    """
-
-    def __init__(self, parent, name):
-        self._parent = parent
-        self._name = name
-        self._old_dsrc = None
-
-    def __enter__(self):
-        self._old_dsrc = self._parent.data_source
-        if self._old_dsrc != self:
-            # Set the new data source, and let __exit__ cleanup.
-            self._parent.data_source = self
-        else:
-            # There's nothing to do or undo in this case.
-            self._old_dsrc = None
-
-    def __exit__(self, type, value, traceback):
-        if self._old_dsrc is not None:
-            self._parent.data_source = self._old_dsrc
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return NotImplemented
-
-        return other.name == self.name
-
-    __hash__ = None
-
-    # PROPERTIES #
-
-    @property
-    @abc.abstractmethod
-    def name(self):
-        """
-        Gets the name of the channel. This is an abstract property.
-
-        :type: `str`
-        """
-        raise NotImplementedError
-
-    # METHODS #
-
-    @abc.abstractmethod
-    def read_waveform(self, bin_format=True):
-        """
-        Gets the waveform of the specified data source channel. This is an
-        abstract property.
-
-        :param bool bin_format: If the waveform should be transfered in binary
-            (``True``) or ASCII (``False``) formats.
-        :return: The waveform with both x and y components.
-        :rtype: `numpy.ndarray`
-        """
-        raise NotImplementedError
-
-
-class OscilloscopeChannel(metaclass=abc.ABCMeta):
-
-    """
-    Abstract base class for physical channels on an oscilloscope.
-
-    All applicable concrete instruments should inherit from this ABC to
-    provide a consistent interface to the user.
-    """
-
-    # PROPERTIES #
-
-    @property
-    @abc.abstractmethod
-    def coupling(self):
-        """
-        Gets/sets the coupling setting for the oscilloscope. This is an
-        abstract method.
-
-        :type: `~enum.Enum`
-        """
-        raise NotImplementedError
-
-    @coupling.setter
-    @abc.abstractmethod
-    def coupling(self, newval):
-        raise NotImplementedError
-
-
 class Oscilloscope(Instrument, metaclass=abc.ABCMeta):
 
     """
@@ -113,6 +21,95 @@ class Oscilloscope(Instrument, metaclass=abc.ABCMeta):
     All applicable concrete instruments should inherit from this ABC to
     provide a consistent interface to the user.
     """
+
+    class Channel(metaclass=abc.ABCMeta):
+        """
+        Abstract base class for physical channels on an oscilloscope.
+
+        All applicable concrete instruments should inherit from this ABC to
+        provide a consistent interface to the user.
+        """
+
+        # PROPERTIES #
+
+        @property
+        @abc.abstractmethod
+        def coupling(self):
+            """
+            Gets/sets the coupling setting for the oscilloscope. This is an
+            abstract method.
+
+            :type: `~enum.Enum`
+            """
+            raise NotImplementedError
+
+        @coupling.setter
+        @abc.abstractmethod
+        def coupling(self, newval):
+            raise NotImplementedError
+
+    class DataSource(metaclass=abc.ABCMeta):
+
+        """
+        Abstract base class for data sources (physical channels, math, ref) on
+        an oscilloscope.
+
+        All applicable concrete instruments should inherit from this ABC to
+        provide a consistent interface to the user.
+        """
+
+        def __init__(self, parent, name):
+            self._parent = parent
+            self._name = name
+            self._old_dsrc = None
+
+        def __enter__(self):
+            self._old_dsrc = self._parent.data_source
+            if self._old_dsrc != self:
+                # Set the new data source, and let __exit__ cleanup.
+                self._parent.data_source = self
+            else:
+                # There's nothing to do or undo in this case.
+                self._old_dsrc = None
+
+        def __exit__(self, type, value, traceback):
+            if self._old_dsrc is not None:
+                self._parent.data_source = self._old_dsrc
+
+        def __eq__(self, other):
+            if not isinstance(other, type(self)):
+                return NotImplemented
+
+            return other.name == self.name
+
+        __hash__ = None
+
+        # PROPERTIES #
+
+        @property
+        @abc.abstractmethod
+        def name(self):
+            """
+            Gets the name of the channel. This is an abstract property.
+
+            :type: `str`
+            """
+            raise NotImplementedError
+
+        # METHODS #
+
+        @abc.abstractmethod
+        def read_waveform(self, bin_format=True):
+            """
+            Gets the waveform of the specified data source channel. This is an
+            abstract property.
+
+            :param bool bin_format: If the waveform should be transfered in binary
+                (``True``) or ASCII (``False``) formats.
+            :return: The waveform with both x and y components.
+            :rtype: `numpy.ndarray`
+            """
+            raise NotImplementedError
 
     # PROPERTIES #
 

--- a/instruments/abstract_instruments/power_supply.py
+++ b/instruments/abstract_instruments/power_supply.py
@@ -12,79 +12,76 @@ from instruments.abstract_instruments import Instrument
 # CLASSES #####################################################################
 
 
-class PowerSupplyChannel(metaclass=abc.ABCMeta):
-
-    """
-    Abstract base class for power supply output channels.
-
-    All applicable concrete instruments should inherit from this ABC to
-    provide a consistent interface to the user.
-    """
-
-    # PROPERTIES #
-
-    @property
-    @abc.abstractmethod
-    def mode(self):
-        """
-        Gets/sets the output mode for the power supply channel. This is an
-        abstract method.
-
-        :type: `~enum.Enum`
-        """
-
-    @mode.setter
-    @abc.abstractmethod
-    def mode(self, newval):
-        pass
-
-    @property
-    @abc.abstractmethod
-    def voltage(self):
-        """
-        Gets/sets the output voltage for the power supply channel. This is an
-        abstract method.
-
-        :type: `~pint.Quantity`
-        """
-
-    @voltage.setter
-    @abc.abstractmethod
-    def voltage(self, newval):
-        pass
-
-    @property
-    @abc.abstractmethod
-    def current(self):
-        """
-        Gets/sets the output current for the power supply channel. This is an
-        abstract method.
-
-        :type: `~pint.Quantity`
-        """
-
-    @current.setter
-    @abc.abstractmethod
-    def current(self, newval):
-        pass
-
-    @property
-    @abc.abstractmethod
-    def output(self):
-        """
-        Gets/sets the output status for the power supply channel. This is an
-        abstract method.
-
-        :type: `bool`
-        """
-
-    @output.setter
-    @abc.abstractmethod
-    def output(self, newval):
-        pass
-
-
 class PowerSupply(Instrument, metaclass=abc.ABCMeta):
+    class Channel(metaclass=abc.ABCMeta):
+        """
+        Abstract base class for power supply output channels.
+
+        All applicable concrete instruments should inherit from this ABC to
+        provide a consistent interface to the user.
+        """
+
+        # PROPERTIES #
+
+        @property
+        @abc.abstractmethod
+        def mode(self):
+            """
+            Gets/sets the output mode for the power supply channel. This is an
+            abstract method.
+
+            :type: `~enum.Enum`
+            """
+
+        @mode.setter
+        @abc.abstractmethod
+        def mode(self, newval):
+            pass
+
+        @property
+        @abc.abstractmethod
+        def voltage(self):
+            """
+            Gets/sets the output voltage for the power supply channel. This is an
+            abstract method.
+
+            :type: `~pint.Quantity`
+            """
+
+        @voltage.setter
+        @abc.abstractmethod
+        def voltage(self, newval):
+            pass
+
+        @property
+        @abc.abstractmethod
+        def current(self):
+            """
+            Gets/sets the output current for the power supply channel. This is an
+            abstract method.
+
+            :type: `~pint.Quantity`
+            """
+
+        @current.setter
+        @abc.abstractmethod
+        def current(self, newval):
+            pass
+
+        @property
+        @abc.abstractmethod
+        def output(self):
+            """
+            Gets/sets the output status for the power supply channel. This is an
+            abstract method.
+
+            :type: `bool`
+            """
+
+        @output.setter
+        @abc.abstractmethod
+        def output(self, newval):
+            pass
 
     """
     Abstract base class for power supply instruments.
@@ -104,7 +101,7 @@ class PowerSupply(Instrument, metaclass=abc.ABCMeta):
 
         This is an abstract method.
 
-        :rtype: `PowerSupplyChannel`
+        :rtype: `PowerSupply.Channel`
         """
         raise NotImplementedError
 

--- a/instruments/abstract_instruments/power_supply.py
+++ b/instruments/abstract_instruments/power_supply.py
@@ -13,6 +13,13 @@ from instruments.abstract_instruments import Instrument
 
 
 class PowerSupply(Instrument, metaclass=abc.ABCMeta):
+    """
+    Abstract base class for power supply instruments.
+
+    All applicable concrete instruments should inherit from this ABC to
+    provide a consistent interface to the user.
+    """
+
     class Channel(metaclass=abc.ABCMeta):
         """
         Abstract base class for power supply output channels.
@@ -82,13 +89,6 @@ class PowerSupply(Instrument, metaclass=abc.ABCMeta):
         @abc.abstractmethod
         def output(self, newval):
             pass
-
-    """
-    Abstract base class for power supply instruments.
-
-    All applicable concrete instruments should inherit from this ABC to
-    provide a consistent interface to the user.
-    """
 
     # PROPERTIES #
 

--- a/instruments/glassman/glassmanfr.py
+++ b/instruments/glassman/glassmanfr.py
@@ -34,20 +34,20 @@ Kit project.
 from struct import unpack
 from enum import Enum
 
-from instruments.abstract_instruments import PowerSupply, PowerSupplyChannel
+from instruments.abstract_instruments import PowerSupply
 from instruments.units import ureg as u
 from instruments.util_fns import assume_units
 
 # CLASSES #####################################################################
 
 
-class GlassmanFR(PowerSupply, PowerSupplyChannel):
+class GlassmanFR(PowerSupply, PowerSupply.Channel):
 
     """
     The GlassmanFR is a single output power supply.
 
     Because it is a single channel output, this object inherits from both
-    PowerSupply and PowerSupplyChannel.
+    PowerSupply and PowerSupply.Channel.
 
     This class should work for any of the Glassman FR Series power supplies
     and is also likely to work for the EJ, ET, EY and FJ Series which seem

--- a/instruments/hp/hp6624a.py
+++ b/instruments/hp/hp6624a.py
@@ -7,7 +7,7 @@ Provides support for the HP6624a power supply
 
 from enum import Enum
 
-from instruments.abstract_instruments import PowerSupply, PowerSupplyChannel
+from instruments.abstract_instruments import PowerSupply
 from instruments.units import ureg as u
 from instruments.util_fns import ProxyList, unitful_property, bool_property
 
@@ -37,7 +37,7 @@ class HP6624a(PowerSupply):
 
     # INNER CLASSES #
 
-    class Channel(PowerSupplyChannel):
+    class Channel(PowerSupply.Channel):
         """
         Class representing a power output channel on the HP6624a.
 

--- a/instruments/hp/hp6652a.py
+++ b/instruments/hp/hp6652a.py
@@ -10,20 +10,20 @@ Originally contributed by Wil Langford (wil.langford+instrumentkit@gmail.com)
 
 from instruments.units import ureg as u
 
-from instruments.abstract_instruments import PowerSupply, PowerSupplyChannel
+from instruments.abstract_instruments import PowerSupply
 from instruments.util_fns import unitful_property, bool_property
 
 
 # CLASSES #####################################################################
 
 
-class HP6652a(PowerSupply, PowerSupplyChannel):
+class HP6652a(PowerSupply, PowerSupply.Channel):
 
     """
     The HP6652a is a single output power supply.
 
     Because it is a single channel output, this object inherits from both
-    PowerSupply and PowerSupplyChannel.
+    PowerSupply and PowerSupply.Channel.
 
     According to the manual, this class MIGHT be usable for any HP power supply
     with a model number HP66XYA, where X is in {4,5,7,8,9} and Y is a digit(?).

--- a/instruments/hp/hpe3631a.py
+++ b/instruments/hp/hpe3631a.py
@@ -36,7 +36,7 @@ import time
 
 from instruments.units import ureg as u
 
-from instruments.abstract_instruments import PowerSupply, PowerSupplyChannel
+from instruments.abstract_instruments import PowerSupply
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import (
     int_property,
@@ -50,7 +50,7 @@ from instruments.util_fns import (
 # CLASSES #####################################################################
 
 
-class HPe3631a(PowerSupply, PowerSupplyChannel, SCPIInstrument):
+class HPe3631a(PowerSupply, PowerSupply.Channel, SCPIInstrument):
 
     """
     The HPe3631a is a three channels voltage/current supply.

--- a/instruments/newport/__init__.py
+++ b/instruments/newport/__init__.py
@@ -6,6 +6,6 @@ Module containing Newport instruments
 from .agilis import AGUC2
 
 from .errors import NewportError
-from .newportesp301 import NewportESP301, NewportESP301Axis, NewportESP301HomeSearchMode
+from .newportesp301 import NewportESP301
 
 from .newport_pmc8742 import PicoMotorController8742

--- a/instruments/newport/__init__.py
+++ b/instruments/newport/__init__.py
@@ -3,7 +3,7 @@
 Module containing Newport instruments
 """
 
-from .agilis import _Axis, AGUC2
+from .agilis import AGUC2
 
 from .errors import NewportError
 from .newportesp301 import NewportESP301, NewportESP301Axis, NewportESP301HomeSearchMode

--- a/instruments/newport/agilis.py
+++ b/instruments/newport/agilis.py
@@ -378,7 +378,7 @@ class AGUC2(Instrument):
 
         See example in `AGUC2` for a more details
 
-        :rtype: `Axis`
+        :rtype: `AGUC2.Axis`
         """
         self.enable_remote_mode = True
         return ProxyList(self, self.Axis, AGUC2.Axes)

--- a/instruments/newport/agilis.py
+++ b/instruments/newport/agilis.py
@@ -38,264 +38,6 @@ from instruments.util_fns import ProxyList
 # CLASSES #####################################################################
 
 
-class _Axis:
-
-    """
-    Class representing one axis attached to a Controller. This will likely
-    work with the AG-UC8 controller as well.
-
-    .. warning:: This class should NOT be manually created by the user. It is
-        designed to be initialized by a Controller class
-    """
-
-    def __init__(self, cont, ax):
-        if not isinstance(cont, AGUC2):
-            raise TypeError("Don't do that.")
-
-        # set axis integer
-        if isinstance(ax, AGUC2.Axes):
-            self._ax = ax.value
-        else:
-            self._ax = ax
-
-        # set controller
-        self._cont = cont
-
-    # PROPERTIES #
-
-    @property
-    def axis_status(self):
-        """
-        Returns the status of the current axis.
-        """
-        resp = self._cont.ag_query(f"{int(self._ax)} TS")
-        if resp.find("TS") == -1:
-            return "Status code query failed."
-
-        resp = int(resp.replace(str(int(self._ax)) + "TS", ""))
-        status_message = agilis_status_message(resp)
-        return status_message
-
-    @property
-    def jog(self):
-        """
-        Start jog motion / get jog mode
-        Defined jog steps are defined with `step_amplitude` function (default
-        16). If a jog mode is supplied, the jog motion is started. Otherwise
-        the current jog mode is queried. Valid jog modes are:
-
-        -4 — Negative direction, 666 steps/s at defined step amplitude.
-        -3 — Negative direction, 1700 steps/s at max. step amplitude.
-        -2 — Negative direction, 100 step/s at max. step amplitude.
-        -1 — Negative direction, 5 steps/s at defined step amplitude.
-         0 — No move, go to READY state.
-         1 — Positive direction, 5 steps/s at defined step amplitude.
-         2 — Positive direction, 100 steps/s at max. step amplitude.
-         3 — Positive direction, 1700 steps/s at max. step amplitude.
-         4 — Positive direction, 666 steps/s at defined step amplitude.
-
-        :return: Jog motion set
-        :rtype: `int`
-        """
-        resp = self._cont.ag_query(f"{int(self._ax)} JA?")
-        return int(resp.split("JA")[1])
-
-    @jog.setter
-    def jog(self, mode):
-        mode = int(mode)
-        if mode < -4 or mode > 4:
-            raise ValueError("Jog mode out of range. Must be between -4 and " "4.")
-
-        self._cont.ag_sendcmd(f"{int(self._ax)} JA {mode}")
-
-    @property
-    def number_of_steps(self):
-        """
-        Returns the number of accumulated steps in forward direction minus
-        the number of steps in backward direction since powering the
-        controller or since the last ZP (zero position) command, whatever
-        was last.
-
-        Note:
-        The step size of the Agilis devices are not 100% repeatable and
-        vary between forward and backward direction. Furthermore, the step
-        size can be modified using the SU command. Consequently, the TP
-        command provides only limited information about the actual position
-        of the device. In particular, an Agilis device can be at very
-        different positions even though a TP command may return the same
-        result.
-
-        :return: Number of steps
-        :rtype: int
-        """
-        resp = self._cont.ag_query(f"{int(self._ax)} TP")
-        return int(resp.split("TP")[1])
-
-    @property
-    def move_relative(self):
-        """
-        Moves the axis by nn steps / Queries the status of the axis.
-        Steps must be given a number that can be converted to a signed integer
-        between -2,147,483,648 and 2,147,483,647.
-        If queried, command returns the current target position. At least this
-        is the expected behaviour, never worked with the rotation stage.
-        """
-        resp = self._cont.ag_query(f"{int(self._ax)} PR?")
-        return int(resp.split("PR")[1])
-
-    @move_relative.setter
-    def move_relative(self, steps):
-        steps = int(steps)
-        if steps < -2147483648 or steps > 2147483647:
-            raise ValueError(
-                "Number of steps are out of range. They must be "
-                "between -2,147,483,648 and 2,147,483,647"
-            )
-
-        self._cont.ag_sendcmd(f"{int(self._ax)} PR {steps}")
-
-    @property
-    def move_to_limit(self):
-        """
-        UNTESTED: SEE COMMENT ON TOP
-
-        The  command functions properly only with devices that feature a
-        limit switch like models AG-LS25, AG-M050L and AG-M100L.
-
-        Starts a jog motion at a defined speed to the limit and stops
-        automatically when the limit is activated. See `jog` command for
-        details on available modes.
-
-        Returns the distance of the current position to the limit in
-        1/1000th of the total travel.
-        """
-        resp = self._cont.ag_query(f"{int(self._ax)} MA?")
-        return int(resp.split("MA")[1])
-
-    @move_to_limit.setter
-    def move_to_limit(self, mode):
-        mode = int(mode)
-        if mode < -4 or mode > 4:
-            raise ValueError("Jog mode out of range. Must be between -4 and " "4.")
-
-        self._cont.ag_sendcmd(f"{int(self._ax)} MA {mode}")
-
-    @property
-    def step_amplitude(self):
-        """
-        Sets / Gets the step_amplitude.
-
-        Sets the step amplitude (step size) in positive and / or negative
-        direction. If the parameter is positive, it will set the step
-        amplitude in the forward direction. If the parameter is negative,
-        it will set the step amplitude in the backward direction. You can also
-        provide a tuple or list of two values (one positive, one negative),
-        which will set both values.
-        Valid values are between -50 and 50, except for 0.
-
-        :return: Tuple of first negative, then positive step amplitude
-            response.
-        :rtype: (`int`, `int`)
-        """
-        resp_neg = self._cont.ag_query(f"{int(self._ax)} SU-?")
-        resp_pos = self._cont.ag_query(f"{int(self._ax)} SU+?")
-        return int(resp_neg.split("SU")[1]), int(resp_pos.split("SU")[1])
-
-    @step_amplitude.setter
-    def step_amplitude(self, nns):
-        if not isinstance(nns, tuple) and not isinstance(nns, list):
-            nns = [nns]
-
-        # check all values for validity
-        for nn in nns:
-            nn = int(nn)
-            if nn < -50 or nn > 50 or nn == 0:
-                raise ValueError(
-                    "Step amplitude {} outside the valid range. "
-                    "It must be between -50 and -1 or between "
-                    "1 and 50.".format(nn)
-                )
-
-        for nn in nns:
-            self._cont.ag_sendcmd(f"{int(self._ax)} SU {int(nn)}")
-
-    @property
-    def step_delay(self):
-        """
-        Sets/gets the step delay of stepping mode. The delay applies for both
-        positive and negative directions. The delay is programmed as multiple
-        of 10µs. For example, a delay of 40 is equivalent to
-        40 x 10 µs = 400 µs. The maximum value of the parameter is equal to a
-        delay of 2 seconds between pulses. By default, after reset, the value
-        is 0.
-        Setter: value must be integer between 0 and 200000 included
-
-        :return: Step delay
-        :rtype: `int`
-        """
-        resp = self._cont.ag_query(f"{int(self._ax)} DL?")
-        return int(resp.split("DL")[1])
-
-    @step_delay.setter
-    def step_delay(self, nn):
-        nn = int(nn)
-        if nn < 0 or nn > 200000:
-            raise ValueError(
-                "Step delay is out of range. It must be between " "0 and 200000."
-            )
-
-        self._cont.ag_sendcmd(f"{int(self._ax)} DL {nn}")
-
-    # MODES #
-
-    def am_i_still(self, max_retries=5):
-        """
-        Function to test if an axis stands still. It queries the status of
-        the given axis and returns True (if axis is still) or False if it is
-        moving.
-        The reason this routine is implemented is because the status messages
-        can time out. If a timeout occurs, this routine will retry the query
-        until `max_retries` is reached. If query is still not successful, an
-        IOError will be raised.
-
-        :param int max_retries: Maximum number of retries
-
-        :return: True if the axis is still, False if the axis is moving
-        :rtype: bool
-        """
-        retries = 0
-
-        while retries < max_retries:
-            status = self.axis_status
-            if status == agilis_status_message(0):
-                return True
-            elif (
-                status == agilis_status_message(1)
-                or status == agilis_status_message(2)
-                or status == agilis_status_message(3)
-            ):
-                return False
-            else:
-                retries += 1
-
-        raise OSError(
-            "The function `am_i_still` ran out of maximum retries. "
-            "Could not query the status of the axis."
-        )
-
-    def stop(self):
-        """
-        Stops the axis. This is useful to interrupt a jogging motion.
-        """
-        self._cont.ag_sendcmd(f"{int(self._ax)} ST")
-
-    def zero_position(self):
-        """
-        Resets the step counter to zero. See `number_of_steps` for details.
-        """
-        self._cont.ag_sendcmd(f"{int(self._ax)} ZP")
-
-
 class AGUC2(Instrument):
 
     """
@@ -351,6 +93,263 @@ class AGUC2(Instrument):
         self._remote_mode = False
         self._sleep_time = 0.25
 
+    class Axis:
+
+        """
+        Class representing one axis attached to a Controller. This will likely
+        work with the AG-UC8 controller as well.
+
+        .. warning:: This class should NOT be manually created by the user. It is
+            designed to be initialized by a Controller class
+        """
+
+        def __init__(self, cont, ax):
+            if not isinstance(cont, AGUC2):
+                raise TypeError("Don't do that.")
+
+            # set axis integer
+            if isinstance(ax, AGUC2.Axes):
+                self._ax = ax.value
+            else:
+                self._ax = ax
+
+            # set controller
+            self._cont = cont
+
+        # PROPERTIES #
+
+        @property
+        def axis_status(self):
+            """
+            Returns the status of the current axis.
+            """
+            resp = self._cont.ag_query(f"{int(self._ax)} TS")
+            if resp.find("TS") == -1:
+                return "Status code query failed."
+
+            resp = int(resp.replace(str(int(self._ax)) + "TS", ""))
+            status_message = agilis_status_message(resp)
+            return status_message
+
+        @property
+        def jog(self):
+            """
+            Start jog motion / get jog mode
+            Defined jog steps are defined with `step_amplitude` function (default
+            16). If a jog mode is supplied, the jog motion is started. Otherwise
+            the current jog mode is queried. Valid jog modes are:
+
+            -4 — Negative direction, 666 steps/s at defined step amplitude.
+            -3 — Negative direction, 1700 steps/s at max. step amplitude.
+            -2 — Negative direction, 100 step/s at max. step amplitude.
+            -1 — Negative direction, 5 steps/s at defined step amplitude.
+             0 — No move, go to READY state.
+             1 — Positive direction, 5 steps/s at defined step amplitude.
+             2 — Positive direction, 100 steps/s at max. step amplitude.
+             3 — Positive direction, 1700 steps/s at max. step amplitude.
+             4 — Positive direction, 666 steps/s at defined step amplitude.
+
+            :return: Jog motion set
+            :rtype: `int`
+            """
+            resp = self._cont.ag_query(f"{int(self._ax)} JA?")
+            return int(resp.split("JA")[1])
+
+        @jog.setter
+        def jog(self, mode):
+            mode = int(mode)
+            if mode < -4 or mode > 4:
+                raise ValueError("Jog mode out of range. Must be between -4 and " "4.")
+
+            self._cont.ag_sendcmd(f"{int(self._ax)} JA {mode}")
+
+        @property
+        def number_of_steps(self):
+            """
+            Returns the number of accumulated steps in forward direction minus
+            the number of steps in backward direction since powering the
+            controller or since the last ZP (zero position) command, whatever
+            was last.
+
+            Note:
+            The step size of the Agilis devices are not 100% repeatable and
+            vary between forward and backward direction. Furthermore, the step
+            size can be modified using the SU command. Consequently, the TP
+            command provides only limited information about the actual position
+            of the device. In particular, an Agilis device can be at very
+            different positions even though a TP command may return the same
+            result.
+
+            :return: Number of steps
+            :rtype: int
+            """
+            resp = self._cont.ag_query(f"{int(self._ax)} TP")
+            return int(resp.split("TP")[1])
+
+        @property
+        def move_relative(self):
+            """
+            Moves the axis by nn steps / Queries the status of the axis.
+            Steps must be given a number that can be converted to a signed integer
+            between -2,147,483,648 and 2,147,483,647.
+            If queried, command returns the current target position. At least this
+            is the expected behaviour, never worked with the rotation stage.
+            """
+            resp = self._cont.ag_query(f"{int(self._ax)} PR?")
+            return int(resp.split("PR")[1])
+
+        @move_relative.setter
+        def move_relative(self, steps):
+            steps = int(steps)
+            if steps < -2147483648 or steps > 2147483647:
+                raise ValueError(
+                    "Number of steps are out of range. They must be "
+                    "between -2,147,483,648 and 2,147,483,647"
+                )
+
+            self._cont.ag_sendcmd(f"{int(self._ax)} PR {steps}")
+
+        @property
+        def move_to_limit(self):
+            """
+            UNTESTED: SEE COMMENT ON TOP
+
+            The  command functions properly only with devices that feature a
+            limit switch like models AG-LS25, AG-M050L and AG-M100L.
+
+            Starts a jog motion at a defined speed to the limit and stops
+            automatically when the limit is activated. See `jog` command for
+            details on available modes.
+
+            Returns the distance of the current position to the limit in
+            1/1000th of the total travel.
+            """
+            resp = self._cont.ag_query(f"{int(self._ax)} MA?")
+            return int(resp.split("MA")[1])
+
+        @move_to_limit.setter
+        def move_to_limit(self, mode):
+            mode = int(mode)
+            if mode < -4 or mode > 4:
+                raise ValueError("Jog mode out of range. Must be between -4 and " "4.")
+
+            self._cont.ag_sendcmd(f"{int(self._ax)} MA {mode}")
+
+        @property
+        def step_amplitude(self):
+            """
+            Sets / Gets the step_amplitude.
+
+            Sets the step amplitude (step size) in positive and / or negative
+            direction. If the parameter is positive, it will set the step
+            amplitude in the forward direction. If the parameter is negative,
+            it will set the step amplitude in the backward direction. You can also
+            provide a tuple or list of two values (one positive, one negative),
+            which will set both values.
+            Valid values are between -50 and 50, except for 0.
+
+            :return: Tuple of first negative, then positive step amplitude
+                response.
+            :rtype: (`int`, `int`)
+            """
+            resp_neg = self._cont.ag_query(f"{int(self._ax)} SU-?")
+            resp_pos = self._cont.ag_query(f"{int(self._ax)} SU+?")
+            return int(resp_neg.split("SU")[1]), int(resp_pos.split("SU")[1])
+
+        @step_amplitude.setter
+        def step_amplitude(self, nns):
+            if not isinstance(nns, tuple) and not isinstance(nns, list):
+                nns = [nns]
+
+            # check all values for validity
+            for nn in nns:
+                nn = int(nn)
+                if nn < -50 or nn > 50 or nn == 0:
+                    raise ValueError(
+                        "Step amplitude {} outside the valid range. "
+                        "It must be between -50 and -1 or between "
+                        "1 and 50.".format(nn)
+                    )
+
+            for nn in nns:
+                self._cont.ag_sendcmd(f"{int(self._ax)} SU {int(nn)}")
+
+        @property
+        def step_delay(self):
+            """
+            Sets/gets the step delay of stepping mode. The delay applies for both
+            positive and negative directions. The delay is programmed as multiple
+            of 10µs. For example, a delay of 40 is equivalent to
+            40 x 10 µs = 400 µs. The maximum value of the parameter is equal to a
+            delay of 2 seconds between pulses. By default, after reset, the value
+            is 0.
+            Setter: value must be integer between 0 and 200000 included
+
+            :return: Step delay
+            :rtype: `int`
+            """
+            resp = self._cont.ag_query(f"{int(self._ax)} DL?")
+            return int(resp.split("DL")[1])
+
+        @step_delay.setter
+        def step_delay(self, nn):
+            nn = int(nn)
+            if nn < 0 or nn > 200000:
+                raise ValueError(
+                    "Step delay is out of range. It must be between " "0 and 200000."
+                )
+
+            self._cont.ag_sendcmd(f"{int(self._ax)} DL {nn}")
+
+        # MODES #
+
+        def am_i_still(self, max_retries=5):
+            """
+            Function to test if an axis stands still. It queries the status of
+            the given axis and returns True (if axis is still) or False if it is
+            moving.
+            The reason this routine is implemented is because the status messages
+            can time out. If a timeout occurs, this routine will retry the query
+            until `max_retries` is reached. If query is still not successful, an
+            IOError will be raised.
+
+            :param int max_retries: Maximum number of retries
+
+            :return: True if the axis is still, False if the axis is moving
+            :rtype: bool
+            """
+            retries = 0
+
+            while retries < max_retries:
+                status = self.axis_status
+                if status == agilis_status_message(0):
+                    return True
+                elif (
+                    status == agilis_status_message(1)
+                    or status == agilis_status_message(2)
+                    or status == agilis_status_message(3)
+                ):
+                    return False
+                else:
+                    retries += 1
+
+            raise OSError(
+                "The function `am_i_still` ran out of maximum retries. "
+                "Could not query the status of the axis."
+            )
+
+        def stop(self):
+            """
+            Stops the axis. This is useful to interrupt a jogging motion.
+            """
+            self._cont.ag_sendcmd(f"{int(self._ax)} ST")
+
+        def zero_position(self):
+            """
+            Resets the step counter to zero. See `number_of_steps` for details.
+            """
+            self._cont.ag_sendcmd(f"{int(self._ax)} ZP")
+
     # ENUMS #
 
     class Axes(IntEnum):
@@ -379,10 +378,10 @@ class AGUC2(Instrument):
 
         See example in `AGUC2` for a more details
 
-        :rtype: `_Axis`
+        :rtype: `Axis`
         """
         self.enable_remote_mode = True
-        return ProxyList(self, _Axis, AGUC2.Axes)
+        return ProxyList(self, self.Axis, AGUC2.Axes)
 
     @property
     def enable_remote_mode(self):

--- a/instruments/newport/newportesp301.py
+++ b/instruments/newport/newportesp301.py
@@ -644,7 +644,7 @@ class NewportESP301(Instrument):
             * 4 = commutated brushless servo motor
 
             :type: `int`
-            :rtype: `MotorType`
+            :rtype: `NewportESP301.MotorType`
             """
             return self._controller.MotorType(
                 int(self._newport_cmd("QM?", target=self._axis_id))
@@ -909,7 +909,7 @@ class NewportESP301(Instrument):
         def wait_for_motion(self, poll_interval=0.01, max_wait=None):
             """
             Blocks until all movement along this axis is complete, as reported
-            by `~NewportESP301Axis.is_motion_done`.
+            by `NewportESP301.Axis.is_motion_done`.
 
             :param float poll_interval: How long (in seconds) to sleep between
                 checking if the motion is complete.
@@ -1230,7 +1230,7 @@ class NewportESP301(Instrument):
         used in the Newport ESP-301 user's manual, and so care must
         be taken when converting examples.
 
-        :type: :class:`NewportESP301Axis`
+        :type: :class:`NewportESP301.Axis`
         """
 
         return ProxyList(self, self.Axis, range(100))

--- a/instruments/newport/newportesp301.py
+++ b/instruments/newport/newportesp301.py
@@ -19,63 +19,6 @@ from instruments.newport.errors import NewportError
 from instruments.units import ureg as u
 from instruments.util_fns import assume_units, ProxyList
 
-# ENUMS #######################################################################
-
-
-class NewportESP301HomeSearchMode(IntEnum):
-
-    """
-    Enum containing different search modes code
-    """
-
-    #: Search along specified axes for the +0 position.
-    zero_position_count = 0
-    #: Search for combined Home and Index signals.
-    home_index_signals = 1
-    #: Search only for the Home signal.
-    home_signal_only = 2
-    #: Search for the positive limit signal.
-    pos_limit_signal = 3
-    #: Search for the negative limit signal.
-    neg_limit_signal = 4
-    #: Search for the positive limit and Index signals.
-    pos_index_signals = 5
-    #: Search for the negative limit and Index signals.
-    neg_index_signals = 6
-
-
-class NewportESP301Units(IntEnum):
-
-    """
-    Enum containing what `units` return means.
-    """
-
-    encoder_step = 0
-    motor_step = 1
-    millimeter = 2
-    micrometer = 3
-    inches = 4
-    milli_inches = 5
-    micro_inches = 6
-    degree = 7
-    gradian = 8
-    radian = 9
-    milliradian = 10
-    microradian = 11
-
-
-class NewportESP301MotorType(IntEnum):
-
-    """
-    Enum for different motor types.
-    """
-
-    undefined = 0
-    dc_servo = 1
-    stepper_motor = 2
-    commutated_stepper_motor = 3
-    commutated_brushless_servo = 4
-
 
 # CLASSES #####################################################################
 
@@ -100,7 +43,1178 @@ class NewportESP301(Instrument):
         self._bulk_query_resp = ""
         self.terminator = "\r"
 
-    # PROPERTIES ##
+    class Axis:
+
+        """
+        Encapsulates communication concerning a single axis
+        of an ESP-301 controller. This class should not be
+        instantiated by the user directly, but is
+        returned by `NewportESP301.axis`.
+        """
+
+        # quantities micro inch
+        # micro_inch = u.UnitQuantity('micro-inch', u.inch / 1e6, symbol='uin')
+        micro_inch = u.uinch
+
+        # Some more work might need to be done here to make
+        # the encoder_step and motor_step functional
+        # I really don't have a concrete idea how I'm
+        # going to do this until I have a physical device
+
+        _unit_dict = {
+            0: u.count,
+            1: u.count,
+            2: u.mm,
+            3: u.um,
+            4: u.inch,
+            5: u.mil,
+            6: micro_inch,  # compound unit for micro-inch
+            7: u.deg,
+            8: u.grad,
+            9: u.rad,
+            10: u.mrad,
+            11: u.urad,
+        }
+
+        def __init__(self, controller, axis_id):
+            if not isinstance(controller, NewportESP301):
+                raise TypeError(
+                    "Axis must be controlled by a Newport ESP-301 " "motor controller."
+                )
+
+            self._controller = controller
+            self._axis_id = axis_id + 1
+
+            self._units = self.units
+
+        # CONTEXT MANAGERS ##
+
+        @contextmanager
+        def _units_of(self, units):
+            """
+            Sets the units for the corresponding axis to a those given by an integer
+            label (see `NewportESP301.Units`), ensuring that the units are properly
+            reset at the completion of the context manager.
+            """
+            old_units = self._get_units()
+            self._set_units(units)
+            yield
+            self._set_units(old_units)
+
+        # PRIVATE METHODS ##
+
+        def _get_units(self):
+            """
+            Returns the integer label for the current units set for this axis.
+
+            .. seealso::
+                NewportESP301.Units
+            """
+            return self._controller.Units(
+                int(self._newport_cmd("SN?", target=self.axis_id))
+            )
+
+        def _set_units(self, new_units):
+            return self._newport_cmd("SN", target=self.axis_id, params=[int(new_units)])
+
+        # PROPERTIES ##
+
+        @property
+        def axis_id(self):
+            """
+            Get axis number of Newport Controller
+
+            :type: `int`
+            """
+            return self._axis_id
+
+        @property
+        def is_motion_done(self):
+            """
+            `True` if and only if all motion commands have
+            completed. This method can be used to wait for
+            a motion command to complete before sending the next
+            command.
+
+            :type: `bool`
+            """
+            return bool(int(self._newport_cmd("MD?", target=self.axis_id)))
+
+        @property
+        def acceleration(self):
+            """
+            Gets/sets the axis acceleration
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport unit
+            :type: `~pint.Quantity` or `float`
+            """
+
+            return assume_units(
+                float(self._newport_cmd("AC?", target=self.axis_id)),
+                self._units / (u.s ** 2),
+            )
+
+        @acceleration.setter
+        def acceleration(self, newval):
+            if newval is None:
+                return
+            newval = float(
+                assume_units(newval, self._units / (u.s ** 2))
+                .to(self._units / (u.s ** 2))
+                .magnitude
+            )
+            self._newport_cmd("AC", target=self.axis_id, params=[newval])
+
+        @property
+        def deceleration(self):
+            """
+            Gets/sets the axis deceleration
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s^2}`
+            :type: `~pint.Quantity` or float
+            """
+            return assume_units(
+                float(self._newport_cmd("AG?", target=self.axis_id)),
+                self._units / (u.s ** 2),
+            )
+
+        @deceleration.setter
+        def deceleration(self, newval):
+            if newval is None:
+                return
+            newval = float(
+                assume_units(newval, self._units / (u.s ** 2))
+                .to(self._units / (u.s ** 2))
+                .magnitude
+            )
+            self._newport_cmd("AG", target=self.axis_id, params=[newval])
+
+        @property
+        def estop_deceleration(self):
+            """
+            Gets/sets the axis estop deceleration
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s^2}`
+            :type: `~pint.Quantity` or float
+            """
+            return assume_units(
+                float(self._newport_cmd("AE?", target=self.axis_id)),
+                self._units / (u.s ** 2),
+            )
+
+        @estop_deceleration.setter
+        def estop_deceleration(self, decel):
+            decel = float(
+                assume_units(decel, self._units / (u.s ** 2))
+                .to(self._units / (u.s ** 2))
+                .magnitude
+            )
+            self._newport_cmd("AE", target=self.axis_id, params=[decel])
+
+        @property
+        def jerk(self):
+            """
+            Gets/sets the jerk rate for the controller
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport unit
+            :type: `~pint.Quantity` or `float`
+            """
+
+            return assume_units(
+                float(self._newport_cmd("JK?", target=self.axis_id)),
+                self._units / (u.s ** 3),
+            )
+
+        @jerk.setter
+        def jerk(self, jerk):
+            jerk = float(
+                assume_units(jerk, self._units / (u.s ** 3))
+                .to(self._units / (u.s ** 3))
+                .magnitude
+            )
+            self._newport_cmd("JK", target=self.axis_id, params=[jerk])
+
+        @property
+        def velocity(self):
+            """
+            Gets/sets the axis velocity
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("VA?", target=self.axis_id)), self._units / u.s
+            )
+
+        @velocity.setter
+        def velocity(self, velocity):
+            velocity = float(
+                assume_units(velocity, self._units / (u.s))
+                .to(self._units / u.s)
+                .magnitude
+            )
+            self._newport_cmd("VA", target=self.axis_id, params=[velocity])
+
+        @property
+        def max_velocity(self):
+            """
+            Gets/sets the axis maximum velocity
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("VU?", target=self.axis_id)), self._units / u.s
+            )
+
+        @max_velocity.setter
+        def max_velocity(self, newval):
+            if newval is None:
+                return
+            newval = float(
+                assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
+            )
+            self._newport_cmd("VU", target=self.axis_id, params=[newval])
+
+        @property
+        def max_base_velocity(self):
+            """
+            Gets/sets the maximum base velocity for stepper motors
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("VB?", target=self.axis_id)), self._units / u.s
+            )
+
+        @max_base_velocity.setter
+        def max_base_velocity(self, newval):
+            if newval is None:
+                return
+            newval = float(
+                assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
+            )
+            self._newport_cmd("VB", target=self.axis_id, params=[newval])
+
+        @property
+        def jog_high_velocity(self):
+            """
+            Gets/sets the axis jog high velocity
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("JH?", target=self.axis_id)), self._units / u.s
+            )
+
+        @jog_high_velocity.setter
+        def jog_high_velocity(self, newval):
+            if newval is None:
+                return
+            newval = float(
+                assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
+            )
+            self._newport_cmd("JH", target=self.axis_id, params=[newval])
+
+        @property
+        def jog_low_velocity(self):
+            """
+            Gets/sets the axis jog low velocity
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("JW?", target=self.axis_id)), self._units / u.s
+            )
+
+        @jog_low_velocity.setter
+        def jog_low_velocity(self, newval):
+            if newval is None:
+                return
+            newval = float(
+                assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
+            )
+            self._newport_cmd("JW", target=self.axis_id, params=[newval])
+
+        @property
+        def homing_velocity(self):
+            """
+            Gets/sets the axis homing velocity
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("OH?", target=self.axis_id)), self._units / u.s
+            )
+
+        @homing_velocity.setter
+        def homing_velocity(self, newval):
+            if newval is None:
+                return
+            newval = float(
+                assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
+            )
+            self._newport_cmd("OH", target=self.axis_id, params=[newval])
+
+        @property
+        def max_acceleration(self):
+            """
+            Gets/sets the axis max acceleration
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s^2}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("AU?", target=self.axis_id)),
+                self._units / (u.s ** 2),
+            )
+
+        @max_acceleration.setter
+        def max_acceleration(self, newval):
+            if newval is None:
+                return
+            newval = float(
+                assume_units(newval, self._units / (u.s ** 2))
+                .to(self._units / (u.s ** 2))
+                .magnitude
+            )
+            self._newport_cmd("AU", target=self.axis_id, params=[newval])
+
+        @property
+        def max_deceleration(self):
+            """
+            Gets/sets the axis max decceleration.
+            Max deaceleration is always the same as acceleration.
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\frac{unit}{s^2}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return self.max_acceleration
+
+        @max_deceleration.setter
+        def max_deceleration(self, decel):
+            decel = float(
+                assume_units(decel, self._units / (u.s ** 2))
+                .to(self._units / (u.s ** 2))
+                .magnitude
+            )
+            self.max_acceleration = decel
+
+        @property
+        def position(self):
+            """
+            Gets real position on axis in units
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport unit
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("TP?", target=self.axis_id)), self._units
+            )
+
+        @property
+        def desired_position(self):
+            """
+            Gets desired position on axis in units
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport unit
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("DP?", target=self.axis_id)), self._units
+            )
+
+        @property
+        def desired_velocity(self):
+            """
+            Gets the axis desired velocity in unit/s
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport unit/s
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("DV?", target=self.axis_id)), self._units / u.s
+            )
+
+        @property
+        def home(self):
+            """
+            Gets/sets the axis home position.
+            Default should be 0 as that sets current position as home
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport unit
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("DH?", target=self.axis_id)), self._units
+            )
+
+        @home.setter
+        def home(self, newval):
+            if newval is None:
+                return
+            newval = float(assume_units(newval, self._units).to(self._units).magnitude)
+            self._newport_cmd("DH", target=self.axis_id, params=[newval])
+
+        @property
+        def units(self):
+            """
+            Get the units that all commands are in reference to.
+
+            :type: `~pint.Unit` corresponding to units of axis connected  or
+                int which corresponds to Newport unit number
+            """
+            self._units = self._get_pq_unit(self._get_units())
+            return self._units
+
+        @units.setter
+        def units(self, newval):
+            if newval is None:
+                return
+            if isinstance(newval, int):
+                self._units = self._get_pq_unit(self._controller.Units(int(newval)))
+            elif isinstance(newval, u.Unit):
+                self._units = newval
+                newval = self._get_unit_num(newval)
+            self._set_units(newval)
+
+        @property
+        def encoder_resolution(self):
+            """
+            Gets/sets the resolution of the encode. The minimum number of units
+            per step. Encoder functionality must be enabled.
+
+            :units: The number of units per encoder step
+            :type: `~pint.Quantity` or `float`
+            """
+
+            return assume_units(
+                float(self._newport_cmd("SU?", target=self.axis_id)), self._units
+            )
+
+        @encoder_resolution.setter
+        def encoder_resolution(self, newval):
+            if newval is None:
+                return
+            newval = float(assume_units(newval, self._units).to(self._units).magnitude)
+            self._newport_cmd("SU", target=self.axis_id, params=[newval])
+
+        @property
+        def full_step_resolution(self):
+            """
+            Gets/sets the axis resolution of the encode. The minimum number of
+            units per step. Encoder functionality must be enabled.
+
+            :units: The number of units per encoder step
+            :type: `~pint.Quantity` or `float`
+            """
+
+            return assume_units(
+                float(self._newport_cmd("FR?", target=self.axis_id)), self._units
+            )
+
+        @full_step_resolution.setter
+        def full_step_resolution(self, newval):
+            if newval is None:
+                return
+            newval = float(assume_units(newval, self._units).to(self._units).magnitude)
+            self._newport_cmd("FR", target=self.axis_id, params=[newval])
+
+        @property
+        def left_limit(self):
+            """
+            Gets/sets the axis left travel limit
+
+            :units: The limit in units
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("SL?", target=self.axis_id)), self._units
+            )
+
+        @left_limit.setter
+        def left_limit(self, limit):
+            limit = float(assume_units(limit, self._units).to(self._units).magnitude)
+            self._newport_cmd("SL", target=self.axis_id, params=[limit])
+
+        @property
+        def right_limit(self):
+            """
+            Gets/sets the axis right travel limit
+
+            :units: units
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("SR?", target=self.axis_id)), self._units
+            )
+
+        @right_limit.setter
+        def right_limit(self, limit):
+            limit = float(assume_units(limit, self._units).to(self._units).magnitude)
+            self._newport_cmd("SR", target=self.axis_id, params=[limit])
+
+        @property
+        def error_threshold(self):
+            """
+            Gets/sets the axis error threshold
+
+            :units: units
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("FE?", target=self.axis_id)), self._units
+            )
+
+        @error_threshold.setter
+        def error_threshold(self, newval):
+            if newval is None:
+                return
+            newval = float(assume_units(newval, self._units).to(self._units).magnitude)
+            self._newport_cmd("FE", target=self.axis_id, params=[newval])
+
+        @property
+        def current(self):
+            """
+            Gets/sets the axis current (amps)
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\text{A}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("QI?", target=self.axis_id)), u.A
+            )
+
+        @current.setter
+        def current(self, newval):
+            if newval is None:
+                return
+            current = float(assume_units(newval, u.A).to(u.A).magnitude)
+            self._newport_cmd("QI", target=self.axis_id, params=[current])
+
+        @property
+        def voltage(self):
+            """
+            Gets/sets the axis voltage
+
+            :units: As specified (if a `~pint.Quantity`) or assumed to be
+                of current newport :math:`\\text{V}`
+            :type: `~pint.Quantity` or `float`
+            """
+            return assume_units(
+                float(self._newport_cmd("QV?", target=self.axis_id)), u.V
+            )
+
+        @voltage.setter
+        def voltage(self, newval):
+            if newval is None:
+                return
+            voltage = float(assume_units(newval, u.V).to(u.V).magnitude)
+            self._newport_cmd("QV", target=self.axis_id, params=[voltage])
+
+        @property
+        def motor_type(self):
+            """
+            Gets/sets the axis motor type
+            * 0 = undefined
+            * 1 = DC Servo
+            * 2 = Stepper motor
+            * 3 = commutated stepper motor
+            * 4 = commutated brushless servo motor
+
+            :type: `int`
+            :rtype: `MotorType`
+            """
+            return self._controller.MotorType(
+                int(self._newport_cmd("QM?", target=self._axis_id))
+            )
+
+        @motor_type.setter
+        def motor_type(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("QM", target=self._axis_id, params=[int(newval)])
+
+        @property
+        def feedback_configuration(self):
+            """
+            Gets/sets the axis Feedback configuration
+
+            :type: `int`
+            """
+            return int(self._newport_cmd("ZB?", target=self._axis_id)[:-2], 16)
+
+        @feedback_configuration.setter
+        def feedback_configuration(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("ZB", target=self._axis_id, params=[int(newval)])
+
+        @property
+        def position_display_resolution(self):
+            """
+            Gets/sets the position display resolution
+
+            :type: `int`
+            """
+            return int(self._newport_cmd("FP?", target=self._axis_id))
+
+        @position_display_resolution.setter
+        def position_display_resolution(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("FP", target=self._axis_id, params=[int(newval)])
+
+        @property
+        def trajectory(self):
+            """
+            Gets/sets the axis trajectory
+
+            :type: `int`
+            """
+            return int(self._newport_cmd("TJ?", target=self._axis_id))
+
+        @trajectory.setter
+        def trajectory(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("TJ", target=self._axis_id, params=[int(newval)])
+
+        @property
+        def microstep_factor(self):
+            """
+            Gets/sets the axis microstep_factor
+
+            :type: `int`
+            """
+            return int(self._newport_cmd("QS?", target=self._axis_id))
+
+        @microstep_factor.setter
+        def microstep_factor(self, newval):
+            if newval is None:
+                return
+            newval = int(newval)
+            if newval < 1 or newval > 250:
+                raise ValueError("Microstep factor must be between 1 and 250")
+            else:
+                self._newport_cmd("QS", target=self._axis_id, params=[newval])
+
+        @property
+        def hardware_limit_configuration(self):
+            """
+            Gets/sets the axis hardware_limit_configuration
+
+            :type: `int`
+            """
+            return int(self._newport_cmd("ZH?", target=self._axis_id)[:-2])
+
+        @hardware_limit_configuration.setter
+        def hardware_limit_configuration(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("ZH", target=self._axis_id, params=[int(newval)])
+
+        @property
+        def acceleration_feed_forward(self):
+            """
+            Gets/sets the axis acceleration_feed_forward setting
+
+            :type: `int`
+            """
+            return float(self._newport_cmd("AF?", target=self._axis_id))
+
+        @acceleration_feed_forward.setter
+        def acceleration_feed_forward(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("AF", target=self._axis_id, params=[float(newval)])
+
+        @property
+        def proportional_gain(self):
+            """
+            Gets/sets the axis proportional_gain
+
+            :type: `float`
+            """
+            return float(self._newport_cmd("KP?", target=self._axis_id)[:-1])
+
+        @proportional_gain.setter
+        def proportional_gain(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("KP", target=self._axis_id, params=[float(newval)])
+
+        @property
+        def derivative_gain(self):
+            """
+            Gets/sets the axis derivative_gain
+
+            :type: `float`
+            """
+            return float(self._newport_cmd("KD?", target=self._axis_id))
+
+        @derivative_gain.setter
+        def derivative_gain(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("KD", target=self._axis_id, params=[float(newval)])
+
+        @property
+        def integral_gain(self):
+            """
+            Gets/sets the axis integral_gain
+
+            :type: `float`
+            """
+            return float(self._newport_cmd("KI?", target=self._axis_id))
+
+        @integral_gain.setter
+        def integral_gain(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("KI", target=self._axis_id, params=[float(newval)])
+
+        @property
+        def integral_saturation_gain(self):
+            """
+            Gets/sets the axis integral_saturation_gain
+
+            :type: `float`
+            """
+            return float(self._newport_cmd("KS?", target=self._axis_id))
+
+        @integral_saturation_gain.setter
+        def integral_saturation_gain(self, newval):
+            if newval is None:
+                return
+            self._newport_cmd("KS", target=self._axis_id, params=[float(newval)])
+
+        @property
+        def encoder_position(self):
+            """
+            Gets the encoder position
+
+            :type:
+            """
+            with self._units_of(self._controller.Units.encoder_step):
+                return self.position
+
+        # MOVEMENT METHODS #
+
+        def search_for_home(self, search_mode=None):
+            """
+            Searches this axis only
+            for home using the method specified by ``search_mode``.
+
+            :param HomeSearchMode search_mode: Method to detect when
+                Home has been found. If None, the search mode is taken from
+                HomeSearchMode.
+            """
+            if search_mode is None:
+                search_mode = self._controller.HomeSearchMode.zero_position_count.value
+            self._controller.search_for_home(axis=self.axis_id, search_mode=search_mode)
+
+        def move(self, position, absolute=True, wait=False, block=False):
+            """
+            :param position: Position to set move to along this axis.
+            :type position: `float` or :class:`~pint.Quantity`
+            :param bool absolute: If `True`, the position ``pos`` is
+                interpreted as relative to the zero-point of the encoder.
+                If `False`, ``pos`` is interpreted as relative to the current
+                position of this axis.
+            :param bool wait: If True, will tell axis to not execute other
+                commands until movement is finished
+            :param bool block: If True, will block code until movement is finished
+            """
+            position = float(
+                assume_units(position, self._units).to(self._units).magnitude
+            )
+            if absolute:
+                self._newport_cmd("PA", params=[position], target=self.axis_id)
+            else:
+                self._newport_cmd("PR", params=[position], target=self.axis_id)
+
+            if wait:
+                self.wait_for_position(position)
+                if block:
+                    time.sleep(0.003)
+                    mot = self.is_motion_done
+                    while not mot:
+                        mot = self.is_motion_done
+
+        def move_to_hardware_limit(self):
+            """
+            move to hardware travel limit
+            """
+            self._newport_cmd("MT", target=self.axis_id)
+
+        def move_indefinitely(self):
+            """
+            Move until told to stop
+            """
+            self._newport_cmd("MV", target=self.axis_id)
+
+        def abort_motion(self):
+            """
+            Abort motion
+            """
+            self._newport_cmd("AB", target=self.axis_id)
+
+        def wait_for_stop(self):
+            """
+            Waits for axis motion to stop before next command is executed
+            """
+            self._newport_cmd("WS", target=self.axis_id)
+
+        def stop_motion(self):
+            """
+            Stop all motion on axis. With programmed deceleration rate
+            """
+            self._newport_cmd("ST", target=self.axis_id)
+
+        def wait_for_position(self, position):
+            """
+            Wait for axis to reach position before executing next command
+
+            :param position: Position to wait for on axis
+
+            :type position: float or :class:`~pint.Quantity`
+            """
+            position = float(
+                assume_units(position, self._units).to(self._units).magnitude
+            )
+            self._newport_cmd("WP", target=self.axis_id, params=[position])
+
+        def wait_for_motion(self, poll_interval=0.01, max_wait=None):
+            """
+            Blocks until all movement along this axis is complete, as reported
+            by `~NewportESP301Axis.is_motion_done`.
+
+            :param float poll_interval: How long (in seconds) to sleep between
+                checking if the motion is complete.
+            :param float max_wait: Maximum amount of time to wait before
+                raising a `IOError`. If `None`, this method will wait
+                indefinitely.
+            """
+            # FIXME: make sure that the controller is not in
+            #        programming mode, or else this might not work.
+            #        In programming mode, the "WS" command should be
+            #        sent instead, and the two parameters to this method should
+            #        be ignored.
+            poll_interval = float(assume_units(poll_interval, u.s).to(u.s).magnitude)
+            if max_wait is not None:
+                max_wait = float(assume_units(max_wait, u.s).to(u.s).magnitude)
+            tic = time.time()
+            while True:
+                if self.is_motion_done:
+                    return
+                else:
+                    if max_wait is None or (time.time() - tic) < max_wait:
+                        time.sleep(poll_interval)
+                    else:
+                        raise OSError("Timed out waiting for motion to finish.")
+
+        def enable(self):
+            """
+            Turns motor axis on.
+            """
+            self._newport_cmd("MO", target=self._axis_id)
+
+        def disable(self):
+            """
+            Turns motor axis off.
+            """
+            self._newport_cmd("MF", target=self._axis_id)
+
+        def setup_axis(self, **kwargs):
+            """
+            Setup a non-newport DC servo motor stage. Necessary parameters are.
+
+            * 'motor_type' = type of motor see 'QM' in Newport documentation
+            * 'current' = motor maximum current (A)
+            * 'voltage' = motor voltage (V)
+            * 'units' = set units (see NewportESP301.Units)(U)
+            * 'encoder_resolution' = value of encoder step in terms of (U)
+            * 'max_velocity' = maximum velocity (U/s)
+            * 'max_base_velocity' =  maximum working velocity (U/s)
+            * 'homing_velocity' = homing speed (U/s)
+            * 'jog_high_velocity' = jog high speed (U/s)
+            * 'jog_low_velocity' = jog low speed (U/s)
+            * 'max_acceleration' = maximum acceleration (U/s^2)
+            * 'acceleration' = acceleration (U/s^2)
+            * 'velocity' = velocity (U/s)
+            * 'deceleration' = set deceleration (U/s^2)
+            * 'error_threshold' = set error threshold (U)
+            * 'estop_deceleration' = estop deceleration (U/s^2)
+            * 'jerk' = jerk rate (U/s^3)
+            * 'proportional_gain' = PID proportional gain (optional)
+            * 'derivative_gain' = PID derivative gain (optional)
+            * 'integral_gain' = PID internal gain (optional)
+            * 'integral_saturation_gain' = PID integral saturation (optional)
+            * 'trajectory' = trajectory mode (optional)
+            * 'position_display_resolution' (U per step)
+            * 'feedback_configuration'
+            * 'full_step_resolution'  = (U per step)
+            * 'home' = (U)
+            * 'acceleration_feed_forward' = between 0 to 2e9
+            * 'microstep_factor' = axis microstep factor
+            * 'reduce_motor_torque_time' =  time (ms) between 0 and 60000,
+            * 'reduce_motor_torque_percentage' = percentage between 0 and 100
+            """
+
+            self.motor_type = kwargs.get("motor_type")
+            self.feedback_configuration = kwargs.get("feedback_configuration")
+            self.full_step_resolution = kwargs.get("full_step_resolution")
+            self.position_display_resolution = kwargs.get(
+                "position_display_" "resolution"
+            )
+            self.current = kwargs.get("current")
+            self.voltage = kwargs.get("voltage")
+            self.units = int(kwargs.get("units"))
+            self.encoder_resolution = kwargs.get("encoder_resolution")
+            self.max_acceleration = kwargs.get("max_acceleration")
+            self.max_velocity = kwargs.get("max_velocity")
+            self.max_base_velocity = kwargs.get("max_base_velocity")
+            self.homing_velocity = kwargs.get("homing_velocity")
+            self.jog_high_velocity = kwargs.get("jog_high_velocity")
+            self.jog_low_velocity = kwargs.get("jog_low_velocity")
+            self.acceleration = kwargs.get("acceleration")
+            self.velocity = kwargs.get("velocity")
+            self.deceleration = kwargs.get("deceleration")
+            self.estop_deceleration = kwargs.get("estop_deceleration")
+            self.jerk = kwargs.get("jerk")
+            self.error_threshold = kwargs.get("error_threshold")
+            self.proportional_gain = kwargs.get("proportional_gain")
+            self.derivative_gain = kwargs.get("derivative_gain")
+            self.integral_gain = kwargs.get("integral_gain")
+            self.integral_saturation_gain = kwargs.get("integral_saturation_gain")
+            self.home = kwargs.get("home")
+            self.microstep_factor = kwargs.get("microstep_factor")
+            self.acceleration_feed_forward = kwargs.get("acceleration_feed_forward")
+            self.trajectory = kwargs.get("trajectory")
+            self.hardware_limit_configuration = kwargs.get(
+                "hardware_limit_" "configuration"
+            )
+            if (
+                "reduce_motor_torque_time" in kwargs
+                and "reduce_motor_torque_percentage" in kwargs
+            ):
+                motor_time = kwargs["reduce_motor_torque_time"]
+                motor_time = int(assume_units(motor_time, u.ms).to(u.ms).magnitude)
+                if motor_time < 0 or motor_time > 60000:
+                    raise ValueError("Time must be between 0 and 60000 ms")
+                percentage = kwargs["reduce_motor_torque_percentage"]
+                percentage = int(
+                    assume_units(percentage, u.percent).to(u.percent).magnitude
+                )
+                if percentage < 0 or percentage > 100:
+                    raise ValueError(r"Percentage must be between 0 and 100%")
+                self._newport_cmd(
+                    "QR", target=self._axis_id, params=[motor_time, percentage]
+                )
+
+            # update motor configuration
+            self._newport_cmd("UF", target=self._axis_id)
+            self._newport_cmd("QD", target=self._axis_id)
+            # save configuration
+            self._newport_cmd("SM")
+            return self.read_setup()
+
+        def read_setup(self):
+            """
+            Returns dictionary containing:
+                'units'
+                'motor_type'
+                'feedback_configuration'
+                'full_step_resolution'
+                'position_display_resolution'
+                'current'
+                'max_velocity'
+                'encoder_resolution'
+                'acceleration'
+                'deceleration'
+                'velocity'
+                'max_acceleration'
+                'homing_velocity'
+                'jog_high_velocity'
+                'jog_low_velocity'
+                'estop_deceleration'
+                'jerk'
+                'proportional_gain'
+                'derivative_gain'
+                'integral_gain'
+                'integral_saturation_gain'
+                'home'
+                'microstep_factor'
+                'acceleration_feed_forward'
+                'trajectory'
+                'hardware_limit_configuration'
+
+            :rtype: dict of `pint.Quantity`, float and int
+            """
+
+            config = dict()
+            config["units"] = self.units
+            config["motor_type"] = self.motor_type
+            config["feedback_configuration"] = self.feedback_configuration
+            config["full_step_resolution"] = self.full_step_resolution
+            config["position_display_resolution"] = self.position_display_resolution
+            config["current"] = self.current
+            config["max_velocity"] = self.max_velocity
+            config["encoder_resolution"] = self.encoder_resolution
+            config["acceleration"] = self.acceleration
+            config["deceleration"] = self.deceleration
+            config["velocity"] = self.velocity
+            config["max_acceleration"] = self.max_acceleration
+            config["homing_velocity"] = self.homing_velocity
+            config["jog_high_velocity"] = self.jog_high_velocity
+            config["jog_low_velocity"] = self.jog_low_velocity
+            config["estop_deceleration"] = self.estop_deceleration
+            config["jerk"] = self.jerk
+            # config['error_threshold'] = self.error_threshold
+            config["proportional_gain"] = self.proportional_gain
+            config["derivative_gain"] = self.derivative_gain
+            config["integral_gain"] = self.integral_gain
+            config["integral_saturation_gain"] = self.integral_saturation_gain
+            config["home"] = self.home
+            config["microstep_factor"] = self.microstep_factor
+            config["acceleration_feed_forward"] = self.acceleration_feed_forward
+            config["trajectory"] = self.trajectory
+            config["hardware_limit_configuration"] = self.hardware_limit_configuration
+            return config
+
+        def get_status(self):
+            """
+            Returns Dictionary containing values:
+                'units'
+                'position'
+                'desired_position'
+                'desired_velocity'
+                'is_motion_done'
+
+            :rtype: dict
+            """
+            status = dict()
+            status["units"] = self.units
+            status["position"] = self.position
+            status["desired_position"] = self.desired_position
+            status["desired_velocity"] = self.desired_velocity
+            status["is_motion_done"] = self.is_motion_done
+
+            return status
+
+        @staticmethod
+        def _get_pq_unit(num):
+            """
+            Gets the units for the specified axis.
+
+            :units: The units for the attached axis
+            :type num: int
+            """
+            return NewportESP301.Axis._unit_dict[num]
+
+        def _get_unit_num(self, quantity):
+            """
+            Gets the integer label used by the Newport ESP 301 corresponding to a
+            given `~pint.Quantity`.
+
+            :param pint.Quantity quantity: Units to return a label for.
+
+            :return int:
+            """
+            for num, quant in self._unit_dict.items():
+                if quant == quantity:
+                    return num
+
+            raise KeyError(f"{quantity} is not a valid unit for Newport Axis")
+
+        # pylint: disable=protected-access
+        def _newport_cmd(self, cmd, **kwargs):
+            """
+            Passes the newport command from the axis class to the parent controller
+
+            :param cmd:
+            :param kwargs:
+            :return:
+            """
+            return self._controller._newport_cmd(cmd, **kwargs)
+
+    # ENUMS #
+
+    class HomeSearchMode(IntEnum):
+
+        """
+        Enum containing different search modes code
+        """
+
+        #: Search along specified axes for the +0 position.
+        zero_position_count = 0
+        #: Search for combined Home and Index signals.
+        home_index_signals = 1
+        #: Search only for the Home signal.
+        home_signal_only = 2
+        #: Search for the positive limit signal.
+        pos_limit_signal = 3
+        #: Search for the negative limit signal.
+        neg_limit_signal = 4
+        #: Search for the positive limit and Index signals.
+        pos_index_signals = 5
+        #: Search for the negative limit and Index signals.
+        neg_index_signals = 6
+
+    class MotorType(IntEnum):
+
+        """
+        Enum for different motor types.
+        """
+
+        undefined = 0
+        dc_servo = 1
+        stepper_motor = 2
+        commutated_stepper_motor = 3
+        commutated_brushless_servo = 4
+
+    class Units(IntEnum):
+
+        """
+        Enum containing what `units` return means.
+        """
+
+        encoder_step = 0
+        motor_step = 1
+        millimeter = 2
+        micrometer = 3
+        inches = 4
+        milli_inches = 5
+        micro_inches = 6
+        degree = 7
+        gradian = 8
+        radian = 9
+        milliradian = 10
+        microradian = 11
+
+    # PROPERTIES #
 
     @property
     def axis(self):
@@ -119,7 +1233,7 @@ class NewportESP301(Instrument):
         :type: :class:`NewportESP301Axis`
         """
 
-        return ProxyList(self, NewportESP301Axis, range(100))
+        return ProxyList(self, self.Axis, range(100))
         # return _AxisList(self)
 
     # LOW-LEVEL COMMAND METHODS ##
@@ -141,7 +1255,7 @@ class NewportESP301(Instrument):
             during ``PGM`` mode.
         """
         query_resp = None
-        if isinstance(target, NewportESP301Axis):
+        if isinstance(target, self.Axis):
             target = target.axis_id
         raw_cmd = "{target}{cmd}{params}".format(
             target=target if target is not None else "",
@@ -201,7 +1315,7 @@ class NewportESP301(Instrument):
     def search_for_home(
         self,
         axis=1,
-        search_mode=NewportESP301HomeSearchMode.zero_position_count.value,
+        search_mode=HomeSearchMode.zero_position_count.value,
         errcheck=True,
     ):
         """
@@ -210,7 +1324,7 @@ class NewportESP301(Instrument):
 
         :param int axis: Axis ID for which home should be searched for. This
             value is 1-based indexing.
-        :param NewportESP301HomeSearchMode search_mode: Method to detect when
+        :param HomeSearchMode search_mode: Method to detect when
             Home has been found.
         :param bool errcheck: Boolean to check for errors after each command
             that is sent to the instrument.
@@ -290,1107 +1404,3 @@ class NewportESP301(Instrument):
                 "Invalid program ID. Must be an integer from " "1 to 100 (inclusive)."
             )
         self._newport_cmd("EX", target=program_id)
-
-
-# pylint: disable=too-many-public-methods,too-many-instance-attributes
-class NewportESP301Axis:
-
-    """
-    Encapsulates communication concerning a single axis
-    of an ESP-301 controller. This class should not be
-    instantiated by the user directly, but is
-    returned by `NewportESP301.axis`.
-    """
-
-    # quantities micro inch
-    # micro_inch = u.UnitQuantity('micro-inch', u.inch / 1e6, symbol='uin')
-    micro_inch = u.uinch
-
-    # Some more work might need to be done here to make
-    # the encoder_step and motor_step functional
-    # I really don't have a concrete idea how I'm
-    # going to do this until I have a physical device
-
-    _unit_dict = {
-        0: u.count,
-        1: u.count,
-        2: u.mm,
-        3: u.um,
-        4: u.inch,
-        5: u.mil,
-        6: micro_inch,  # compound unit for micro-inch
-        7: u.deg,
-        8: u.grad,
-        9: u.rad,
-        10: u.mrad,
-        11: u.urad,
-    }
-
-    def __init__(self, controller, axis_id):
-        if not isinstance(controller, NewportESP301):
-            raise TypeError(
-                "Axis must be controlled by a Newport ESP-301 " "motor controller."
-            )
-
-        self._controller = controller
-        self._axis_id = axis_id + 1
-
-        self._units = self.units
-
-    # CONTEXT MANAGERS ##
-
-    @contextmanager
-    def _units_of(self, units):
-        """
-        Sets the units for the corresponding axis to a those given by an integer
-        label (see `NewportESP301Units`), ensuring that the units are properly
-        reset at the completion of the context manager.
-        """
-        old_units = self._get_units()
-        self._set_units(units)
-        yield
-        self._set_units(old_units)
-
-    # PRIVATE METHODS ##
-
-    def _get_units(self):
-        """
-        Returns the integer label for the current units set for this axis.
-
-        .. seealso::
-            NewportESP301Units
-        """
-        return NewportESP301Units(int(self._newport_cmd("SN?", target=self.axis_id)))
-
-    def _set_units(self, new_units):
-        return self._newport_cmd("SN", target=self.axis_id, params=[int(new_units)])
-
-    # PROPERTIES ##
-
-    @property
-    def axis_id(self):
-        """
-        Get axis number of Newport Controller
-
-        :type: `int`
-        """
-        return self._axis_id
-
-    @property
-    def is_motion_done(self):
-        """
-        `True` if and only if all motion commands have
-        completed. This method can be used to wait for
-        a motion command to complete before sending the next
-        command.
-
-        :type: `bool`
-        """
-        return bool(int(self._newport_cmd("MD?", target=self.axis_id)))
-
-    @property
-    def acceleration(self):
-        """
-        Gets/sets the axis acceleration
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport unit
-        :type: `~pint.Quantity` or `float`
-        """
-
-        return assume_units(
-            float(self._newport_cmd("AC?", target=self.axis_id)),
-            self._units / (u.s ** 2),
-        )
-
-    @acceleration.setter
-    def acceleration(self, newval):
-        if newval is None:
-            return
-        newval = float(
-            assume_units(newval, self._units / (u.s ** 2))
-            .to(self._units / (u.s ** 2))
-            .magnitude
-        )
-        self._newport_cmd("AC", target=self.axis_id, params=[newval])
-
-    @property
-    def deceleration(self):
-        """
-        Gets/sets the axis deceleration
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s^2}`
-        :type: `~pint.Quantity` or float
-        """
-        return assume_units(
-            float(self._newport_cmd("AG?", target=self.axis_id)),
-            self._units / (u.s ** 2),
-        )
-
-    @deceleration.setter
-    def deceleration(self, newval):
-        if newval is None:
-            return
-        newval = float(
-            assume_units(newval, self._units / (u.s ** 2))
-            .to(self._units / (u.s ** 2))
-            .magnitude
-        )
-        self._newport_cmd("AG", target=self.axis_id, params=[newval])
-
-    @property
-    def estop_deceleration(self):
-        """
-        Gets/sets the axis estop deceleration
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s^2}`
-        :type: `~pint.Quantity` or float
-        """
-        return assume_units(
-            float(self._newport_cmd("AE?", target=self.axis_id)),
-            self._units / (u.s ** 2),
-        )
-
-    @estop_deceleration.setter
-    def estop_deceleration(self, decel):
-        decel = float(
-            assume_units(decel, self._units / (u.s ** 2))
-            .to(self._units / (u.s ** 2))
-            .magnitude
-        )
-        self._newport_cmd("AE", target=self.axis_id, params=[decel])
-
-    @property
-    def jerk(self):
-        """
-        Gets/sets the jerk rate for the controller
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport unit
-        :type: `~pint.Quantity` or `float`
-        """
-
-        return assume_units(
-            float(self._newport_cmd("JK?", target=self.axis_id)),
-            self._units / (u.s ** 3),
-        )
-
-    @jerk.setter
-    def jerk(self, jerk):
-        jerk = float(
-            assume_units(jerk, self._units / (u.s ** 3))
-            .to(self._units / (u.s ** 3))
-            .magnitude
-        )
-        self._newport_cmd("JK", target=self.axis_id, params=[jerk])
-
-    @property
-    def velocity(self):
-        """
-        Gets/sets the axis velocity
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("VA?", target=self.axis_id)), self._units / u.s
-        )
-
-    @velocity.setter
-    def velocity(self, velocity):
-        velocity = float(
-            assume_units(velocity, self._units / (u.s)).to(self._units / u.s).magnitude
-        )
-        self._newport_cmd("VA", target=self.axis_id, params=[velocity])
-
-    @property
-    def max_velocity(self):
-        """
-        Gets/sets the axis maximum velocity
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("VU?", target=self.axis_id)), self._units / u.s
-        )
-
-    @max_velocity.setter
-    def max_velocity(self, newval):
-        if newval is None:
-            return
-        newval = float(
-            assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
-        )
-        self._newport_cmd("VU", target=self.axis_id, params=[newval])
-
-    @property
-    def max_base_velocity(self):
-        """
-        Gets/sets the maximum base velocity for stepper motors
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("VB?", target=self.axis_id)), self._units / u.s
-        )
-
-    @max_base_velocity.setter
-    def max_base_velocity(self, newval):
-        if newval is None:
-            return
-        newval = float(
-            assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
-        )
-        self._newport_cmd("VB", target=self.axis_id, params=[newval])
-
-    @property
-    def jog_high_velocity(self):
-        """
-        Gets/sets the axis jog high velocity
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("JH?", target=self.axis_id)), self._units / u.s
-        )
-
-    @jog_high_velocity.setter
-    def jog_high_velocity(self, newval):
-        if newval is None:
-            return
-        newval = float(
-            assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
-        )
-        self._newport_cmd("JH", target=self.axis_id, params=[newval])
-
-    @property
-    def jog_low_velocity(self):
-        """
-        Gets/sets the axis jog low velocity
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("JW?", target=self.axis_id)), self._units / u.s
-        )
-
-    @jog_low_velocity.setter
-    def jog_low_velocity(self, newval):
-        if newval is None:
-            return
-        newval = float(
-            assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
-        )
-        self._newport_cmd("JW", target=self.axis_id, params=[newval])
-
-    @property
-    def homing_velocity(self):
-        """
-        Gets/sets the axis homing velocity
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("OH?", target=self.axis_id)), self._units / u.s
-        )
-
-    @homing_velocity.setter
-    def homing_velocity(self, newval):
-        if newval is None:
-            return
-        newval = float(
-            assume_units(newval, self._units / u.s).to(self._units / u.s).magnitude
-        )
-        self._newport_cmd("OH", target=self.axis_id, params=[newval])
-
-    @property
-    def max_acceleration(self):
-        """
-        Gets/sets the axis max acceleration
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s^2}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("AU?", target=self.axis_id)),
-            self._units / (u.s ** 2),
-        )
-
-    @max_acceleration.setter
-    def max_acceleration(self, newval):
-        if newval is None:
-            return
-        newval = float(
-            assume_units(newval, self._units / (u.s ** 2))
-            .to(self._units / (u.s ** 2))
-            .magnitude
-        )
-        self._newport_cmd("AU", target=self.axis_id, params=[newval])
-
-    @property
-    def max_deceleration(self):
-        """
-        Gets/sets the axis max decceleration.
-        Max deaceleration is always the same as acceleration.
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\frac{unit}{s^2}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return self.max_acceleration
-
-    @max_deceleration.setter
-    def max_deceleration(self, decel):
-        decel = float(
-            assume_units(decel, self._units / (u.s ** 2))
-            .to(self._units / (u.s ** 2))
-            .magnitude
-        )
-        self.max_acceleration = decel
-
-    @property
-    def position(self):
-        """
-        Gets real position on axis in units
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport unit
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("TP?", target=self.axis_id)), self._units
-        )
-
-    @property
-    def desired_position(self):
-        """
-        Gets desired position on axis in units
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport unit
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("DP?", target=self.axis_id)), self._units
-        )
-
-    @property
-    def desired_velocity(self):
-        """
-        Gets the axis desired velocity in unit/s
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport unit/s
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("DV?", target=self.axis_id)), self._units / u.s
-        )
-
-    @property
-    def home(self):
-        """
-        Gets/sets the axis home position.
-        Default should be 0 as that sets current position as home
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport unit
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("DH?", target=self.axis_id)), self._units
-        )
-
-    @home.setter
-    def home(self, newval):
-        if newval is None:
-            return
-        newval = float(assume_units(newval, self._units).to(self._units).magnitude)
-        self._newport_cmd("DH", target=self.axis_id, params=[newval])
-
-    @property
-    def units(self):
-        """
-        Get the units that all commands are in reference to.
-
-        :type: `~pint.Unit` corresponding to units of axis connected  or
-            int which corresponds to Newport unit number
-        """
-        self._units = self._get_pq_unit(self._get_units())
-        return self._units
-
-    @units.setter
-    def units(self, newval):
-        if newval is None:
-            return
-        if isinstance(newval, int):
-            self._units = self._get_pq_unit(NewportESP301Units(int(newval)))
-        elif isinstance(newval, u.Unit):
-            self._units = newval
-            newval = self._get_unit_num(newval)
-        self._set_units(newval)
-
-    @property
-    def encoder_resolution(self):
-        """
-        Gets/sets the resolution of the encode. The minimum number of units
-        per step. Encoder functionality must be enabled.
-
-        :units: The number of units per encoder step
-        :type: `~pint.Quantity` or `float`
-        """
-
-        return assume_units(
-            float(self._newport_cmd("SU?", target=self.axis_id)), self._units
-        )
-
-    @encoder_resolution.setter
-    def encoder_resolution(self, newval):
-        if newval is None:
-            return
-        newval = float(assume_units(newval, self._units).to(self._units).magnitude)
-        self._newport_cmd("SU", target=self.axis_id, params=[newval])
-
-    @property
-    def full_step_resolution(self):
-        """
-        Gets/sets the axis resolution of the encode. The minimum number of
-        units per step. Encoder functionality must be enabled.
-
-        :units: The number of units per encoder step
-        :type: `~pint.Quantity` or `float`
-        """
-
-        return assume_units(
-            float(self._newport_cmd("FR?", target=self.axis_id)), self._units
-        )
-
-    @full_step_resolution.setter
-    def full_step_resolution(self, newval):
-        if newval is None:
-            return
-        newval = float(assume_units(newval, self._units).to(self._units).magnitude)
-        self._newport_cmd("FR", target=self.axis_id, params=[newval])
-
-    @property
-    def left_limit(self):
-        """
-        Gets/sets the axis left travel limit
-
-        :units: The limit in units
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("SL?", target=self.axis_id)), self._units
-        )
-
-    @left_limit.setter
-    def left_limit(self, limit):
-        limit = float(assume_units(limit, self._units).to(self._units).magnitude)
-        self._newport_cmd("SL", target=self.axis_id, params=[limit])
-
-    @property
-    def right_limit(self):
-        """
-        Gets/sets the axis right travel limit
-
-        :units: units
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("SR?", target=self.axis_id)), self._units
-        )
-
-    @right_limit.setter
-    def right_limit(self, limit):
-        limit = float(assume_units(limit, self._units).to(self._units).magnitude)
-        self._newport_cmd("SR", target=self.axis_id, params=[limit])
-
-    @property
-    def error_threshold(self):
-        """
-        Gets/sets the axis error threshold
-
-        :units: units
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(
-            float(self._newport_cmd("FE?", target=self.axis_id)), self._units
-        )
-
-    @error_threshold.setter
-    def error_threshold(self, newval):
-        if newval is None:
-            return
-        newval = float(assume_units(newval, self._units).to(self._units).magnitude)
-        self._newport_cmd("FE", target=self.axis_id, params=[newval])
-
-    @property
-    def current(self):
-        """
-        Gets/sets the axis current (amps)
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\text{A}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(float(self._newport_cmd("QI?", target=self.axis_id)), u.A)
-
-    @current.setter
-    def current(self, newval):
-        if newval is None:
-            return
-        current = float(assume_units(newval, u.A).to(u.A).magnitude)
-        self._newport_cmd("QI", target=self.axis_id, params=[current])
-
-    @property
-    def voltage(self):
-        """
-        Gets/sets the axis voltage
-
-        :units: As specified (if a `~pint.Quantity`) or assumed to be
-            of current newport :math:`\\text{V}`
-        :type: `~pint.Quantity` or `float`
-        """
-        return assume_units(float(self._newport_cmd("QV?", target=self.axis_id)), u.V)
-
-    @voltage.setter
-    def voltage(self, newval):
-        if newval is None:
-            return
-        voltage = float(assume_units(newval, u.V).to(u.V).magnitude)
-        self._newport_cmd("QV", target=self.axis_id, params=[voltage])
-
-    @property
-    def motor_type(self):
-        """
-        Gets/sets the axis motor type
-        * 0 = undefined
-        * 1 = DC Servo
-        * 2 = Stepper motor
-        * 3 = commutated stepper motor
-        * 4 = commutated brushless servo motor
-
-        :type: `int`
-        :rtype: `NewportESP301MotorType`
-        """
-        return NewportESP301MotorType(
-            int(self._newport_cmd("QM?", target=self._axis_id))
-        )
-
-    @motor_type.setter
-    def motor_type(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("QM", target=self._axis_id, params=[int(newval)])
-
-    @property
-    def feedback_configuration(self):
-        """
-        Gets/sets the axis Feedback configuration
-
-        :type: `int`
-        """
-        return int(self._newport_cmd("ZB?", target=self._axis_id)[:-2], 16)
-
-    @feedback_configuration.setter
-    def feedback_configuration(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("ZB", target=self._axis_id, params=[int(newval)])
-
-    @property
-    def position_display_resolution(self):
-        """
-        Gets/sets the position display resolution
-
-        :type: `int`
-        """
-        return int(self._newport_cmd("FP?", target=self._axis_id))
-
-    @position_display_resolution.setter
-    def position_display_resolution(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("FP", target=self._axis_id, params=[int(newval)])
-
-    @property
-    def trajectory(self):
-        """
-        Gets/sets the axis trajectory
-
-        :type: `int`
-        """
-        return int(self._newport_cmd("TJ?", target=self._axis_id))
-
-    @trajectory.setter
-    def trajectory(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("TJ", target=self._axis_id, params=[int(newval)])
-
-    @property
-    def microstep_factor(self):
-        """
-        Gets/sets the axis microstep_factor
-
-        :type: `int`
-        """
-        return int(self._newport_cmd("QS?", target=self._axis_id))
-
-    @microstep_factor.setter
-    def microstep_factor(self, newval):
-        if newval is None:
-            return
-        newval = int(newval)
-        if newval < 1 or newval > 250:
-            raise ValueError("Microstep factor must be between 1 and 250")
-        else:
-            self._newport_cmd("QS", target=self._axis_id, params=[newval])
-
-    @property
-    def hardware_limit_configuration(self):
-        """
-        Gets/sets the axis hardware_limit_configuration
-
-        :type: `int`
-        """
-        return int(self._newport_cmd("ZH?", target=self._axis_id)[:-2])
-
-    @hardware_limit_configuration.setter
-    def hardware_limit_configuration(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("ZH", target=self._axis_id, params=[int(newval)])
-
-    @property
-    def acceleration_feed_forward(self):
-        """
-        Gets/sets the axis acceleration_feed_forward setting
-
-        :type: `int`
-        """
-        return float(self._newport_cmd("AF?", target=self._axis_id))
-
-    @acceleration_feed_forward.setter
-    def acceleration_feed_forward(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("AF", target=self._axis_id, params=[float(newval)])
-
-    @property
-    def proportional_gain(self):
-        """
-        Gets/sets the axis proportional_gain
-
-        :type: `float`
-        """
-        return float(self._newport_cmd("KP?", target=self._axis_id)[:-1])
-
-    @proportional_gain.setter
-    def proportional_gain(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("KP", target=self._axis_id, params=[float(newval)])
-
-    @property
-    def derivative_gain(self):
-        """
-        Gets/sets the axis derivative_gain
-
-        :type: `float`
-        """
-        return float(self._newport_cmd("KD?", target=self._axis_id))
-
-    @derivative_gain.setter
-    def derivative_gain(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("KD", target=self._axis_id, params=[float(newval)])
-
-    @property
-    def integral_gain(self):
-        """
-        Gets/sets the axis integral_gain
-
-        :type: `float`
-        """
-        return float(self._newport_cmd("KI?", target=self._axis_id))
-
-    @integral_gain.setter
-    def integral_gain(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("KI", target=self._axis_id, params=[float(newval)])
-
-    @property
-    def integral_saturation_gain(self):
-        """
-        Gets/sets the axis integral_saturation_gain
-
-        :type: `float`
-        """
-        return float(self._newport_cmd("KS?", target=self._axis_id))
-
-    @integral_saturation_gain.setter
-    def integral_saturation_gain(self, newval):
-        if newval is None:
-            return
-        self._newport_cmd("KS", target=self._axis_id, params=[float(newval)])
-
-    @property
-    def encoder_position(self):
-        """
-        Gets the encoder position
-
-        :type:
-        """
-        with self._units_of(NewportESP301Units.encoder_step):
-            return self.position
-
-    # MOVEMENT METHODS #
-
-    def search_for_home(
-        self, search_mode=NewportESP301HomeSearchMode.zero_position_count.value
-    ):
-        """
-        Searches this axis only
-        for home using the method specified by ``search_mode``.
-
-        :param NewportESP301HomeSearchMode search_mode: Method to detect when
-            Home has been found.
-        """
-        self._controller.search_for_home(axis=self.axis_id, search_mode=search_mode)
-
-    def move(self, position, absolute=True, wait=False, block=False):
-        """
-        :param position: Position to set move to along this axis.
-        :type position: `float` or :class:`~pint.Quantity`
-        :param bool absolute: If `True`, the position ``pos`` is
-            interpreted as relative to the zero-point of the encoder.
-            If `False`, ``pos`` is interpreted as relative to the current
-            position of this axis.
-        :param bool wait: If True, will tell axis to not execute other
-            commands until movement is finished
-        :param bool block: If True, will block code until movement is finished
-        """
-        position = float(assume_units(position, self._units).to(self._units).magnitude)
-        if absolute:
-            self._newport_cmd("PA", params=[position], target=self.axis_id)
-        else:
-            self._newport_cmd("PR", params=[position], target=self.axis_id)
-
-        if wait:
-            self.wait_for_position(position)
-            if block:
-                time.sleep(0.003)
-                mot = self.is_motion_done
-                while not mot:
-                    mot = self.is_motion_done
-
-    def move_to_hardware_limit(self):
-        """
-        move to hardware travel limit
-        """
-        self._newport_cmd("MT", target=self.axis_id)
-
-    def move_indefinitely(self):
-        """
-        Move until told to stop
-        """
-        self._newport_cmd("MV", target=self.axis_id)
-
-    def abort_motion(self):
-        """
-        Abort motion
-        """
-        self._newport_cmd("AB", target=self.axis_id)
-
-    def wait_for_stop(self):
-        """
-        Waits for axis motion to stop before next command is executed
-        """
-        self._newport_cmd("WS", target=self.axis_id)
-
-    def stop_motion(self):
-        """
-        Stop all motion on axis. With programmed deceleration rate
-        """
-        self._newport_cmd("ST", target=self.axis_id)
-
-    def wait_for_position(self, position):
-        """
-        Wait for axis to reach position before executing next command
-
-        :param position: Position to wait for on axis
-
-        :type position: float or :class:`~pint.Quantity`
-        """
-        position = float(assume_units(position, self._units).to(self._units).magnitude)
-        self._newport_cmd("WP", target=self.axis_id, params=[position])
-
-    def wait_for_motion(self, poll_interval=0.01, max_wait=None):
-        """
-        Blocks until all movement along this axis is complete, as reported
-        by `~NewportESP301Axis.is_motion_done`.
-
-        :param float poll_interval: How long (in seconds) to sleep between
-            checking if the motion is complete.
-        :param float max_wait: Maximum amount of time to wait before
-            raising a `IOError`. If `None`, this method will wait
-            indefinitely.
-        """
-        # FIXME: make sure that the controller is not in
-        #        programming mode, or else this might not work.
-        #        In programming mode, the "WS" command should be
-        #        sent instead, and the two parameters to this method should
-        #        be ignored.
-        poll_interval = float(assume_units(poll_interval, u.s).to(u.s).magnitude)
-        if max_wait is not None:
-            max_wait = float(assume_units(max_wait, u.s).to(u.s).magnitude)
-        tic = time.time()
-        while True:
-            if self.is_motion_done:
-                return
-            else:
-                if max_wait is None or (time.time() - tic) < max_wait:
-                    time.sleep(poll_interval)
-                else:
-                    raise OSError("Timed out waiting for motion to finish.")
-
-    def enable(self):
-        """
-        Turns motor axis on.
-        """
-        self._newport_cmd("MO", target=self._axis_id)
-
-    def disable(self):
-        """
-        Turns motor axis off.
-        """
-        self._newport_cmd("MF", target=self._axis_id)
-
-    def setup_axis(self, **kwargs):
-        """
-        Setup a non-newport DC servo motor stage. Necessary parameters are.
-
-        * 'motor_type' = type of motor see 'QM' in Newport documentation
-        * 'current' = motor maximum current (A)
-        * 'voltage' = motor voltage (V)
-        * 'units' = set units (see NewportESP301Units)(U)
-        * 'encoder_resolution' = value of encoder step in terms of (U)
-        * 'max_velocity' = maximum velocity (U/s)
-        * 'max_base_velocity' =  maximum working velocity (U/s)
-        * 'homing_velocity' = homing speed (U/s)
-        * 'jog_high_velocity' = jog high speed (U/s)
-        * 'jog_low_velocity' = jog low speed (U/s)
-        * 'max_acceleration' = maximum acceleration (U/s^2)
-        * 'acceleration' = acceleration (U/s^2)
-        * 'velocity' = velocity (U/s)
-        * 'deceleration' = set deceleration (U/s^2)
-        * 'error_threshold' = set error threshold (U)
-        * 'estop_deceleration' = estop deceleration (U/s^2)
-        * 'jerk' = jerk rate (U/s^3)
-        * 'proportional_gain' = PID proportional gain (optional)
-        * 'derivative_gain' = PID derivative gain (optional)
-        * 'integral_gain' = PID internal gain (optional)
-        * 'integral_saturation_gain' = PID integral saturation (optional)
-        * 'trajectory' = trajectory mode (optional)
-        * 'position_display_resolution' (U per step)
-        * 'feedback_configuration'
-        * 'full_step_resolution'  = (U per step)
-        * 'home' = (U)
-        * 'acceleration_feed_forward' = between 0 to 2e9
-        * 'microstep_factor' = axis microstep factor
-        * 'reduce_motor_torque_time' =  time (ms) between 0 and 60000,
-        * 'reduce_motor_torque_percentage' = percentage between 0 and 100
-        """
-
-        self.motor_type = kwargs.get("motor_type")
-        self.feedback_configuration = kwargs.get("feedback_configuration")
-        self.full_step_resolution = kwargs.get("full_step_resolution")
-        self.position_display_resolution = kwargs.get("position_display_" "resolution")
-        self.current = kwargs.get("current")
-        self.voltage = kwargs.get("voltage")
-        self.units = int(kwargs.get("units"))
-        self.encoder_resolution = kwargs.get("encoder_resolution")
-        self.max_acceleration = kwargs.get("max_acceleration")
-        self.max_velocity = kwargs.get("max_velocity")
-        self.max_base_velocity = kwargs.get("max_base_velocity")
-        self.homing_velocity = kwargs.get("homing_velocity")
-        self.jog_high_velocity = kwargs.get("jog_high_velocity")
-        self.jog_low_velocity = kwargs.get("jog_low_velocity")
-        self.acceleration = kwargs.get("acceleration")
-        self.velocity = kwargs.get("velocity")
-        self.deceleration = kwargs.get("deceleration")
-        self.estop_deceleration = kwargs.get("estop_deceleration")
-        self.jerk = kwargs.get("jerk")
-        self.error_threshold = kwargs.get("error_threshold")
-        self.proportional_gain = kwargs.get("proportional_gain")
-        self.derivative_gain = kwargs.get("derivative_gain")
-        self.integral_gain = kwargs.get("integral_gain")
-        self.integral_saturation_gain = kwargs.get("integral_saturation_gain")
-        self.home = kwargs.get("home")
-        self.microstep_factor = kwargs.get("microstep_factor")
-        self.acceleration_feed_forward = kwargs.get("acceleration_feed_forward")
-        self.trajectory = kwargs.get("trajectory")
-        self.hardware_limit_configuration = kwargs.get(
-            "hardware_limit_" "configuration"
-        )
-        if (
-            "reduce_motor_torque_time" in kwargs
-            and "reduce_motor_torque_percentage" in kwargs
-        ):
-            motor_time = kwargs["reduce_motor_torque_time"]
-            motor_time = int(assume_units(motor_time, u.ms).to(u.ms).magnitude)
-            if motor_time < 0 or motor_time > 60000:
-                raise ValueError("Time must be between 0 and 60000 ms")
-            percentage = kwargs["reduce_motor_torque_percentage"]
-            percentage = int(
-                assume_units(percentage, u.percent).to(u.percent).magnitude
-            )
-            if percentage < 0 or percentage > 100:
-                raise ValueError(r"Percentage must be between 0 and 100%")
-            self._newport_cmd(
-                "QR", target=self._axis_id, params=[motor_time, percentage]
-            )
-
-        # update motor configuration
-        self._newport_cmd("UF", target=self._axis_id)
-        self._newport_cmd("QD", target=self._axis_id)
-        # save configuration
-        self._newport_cmd("SM")
-        return self.read_setup()
-
-    def read_setup(self):
-        """
-        Returns dictionary containing:
-            'units'
-            'motor_type'
-            'feedback_configuration'
-            'full_step_resolution'
-            'position_display_resolution'
-            'current'
-            'max_velocity'
-            'encoder_resolution'
-            'acceleration'
-            'deceleration'
-            'velocity'
-            'max_acceleration'
-            'homing_velocity'
-            'jog_high_velocity'
-            'jog_low_velocity'
-            'estop_deceleration'
-            'jerk'
-            'proportional_gain'
-            'derivative_gain'
-            'integral_gain'
-            'integral_saturation_gain'
-            'home'
-            'microstep_factor'
-            'acceleration_feed_forward'
-            'trajectory'
-            'hardware_limit_configuration'
-
-        :rtype: dict of `pint.Quantity`, float and int
-        """
-
-        config = dict()
-        config["units"] = self.units
-        config["motor_type"] = self.motor_type
-        config["feedback_configuration"] = self.feedback_configuration
-        config["full_step_resolution"] = self.full_step_resolution
-        config["position_display_resolution"] = self.position_display_resolution
-        config["current"] = self.current
-        config["max_velocity"] = self.max_velocity
-        config["encoder_resolution"] = self.encoder_resolution
-        config["acceleration"] = self.acceleration
-        config["deceleration"] = self.deceleration
-        config["velocity"] = self.velocity
-        config["max_acceleration"] = self.max_acceleration
-        config["homing_velocity"] = self.homing_velocity
-        config["jog_high_velocity"] = self.jog_high_velocity
-        config["jog_low_velocity"] = self.jog_low_velocity
-        config["estop_deceleration"] = self.estop_deceleration
-        config["jerk"] = self.jerk
-        # config['error_threshold'] = self.error_threshold
-        config["proportional_gain"] = self.proportional_gain
-        config["derivative_gain"] = self.derivative_gain
-        config["integral_gain"] = self.integral_gain
-        config["integral_saturation_gain"] = self.integral_saturation_gain
-        config["home"] = self.home
-        config["microstep_factor"] = self.microstep_factor
-        config["acceleration_feed_forward"] = self.acceleration_feed_forward
-        config["trajectory"] = self.trajectory
-        config["hardware_limit_configuration"] = self.hardware_limit_configuration
-        return config
-
-    def get_status(self):
-        """
-        Returns Dictionary containing values:
-            'units'
-            'position'
-            'desired_position'
-            'desired_velocity'
-            'is_motion_done'
-
-        :rtype: dict
-        """
-        status = dict()
-        status["units"] = self.units
-        status["position"] = self.position
-        status["desired_position"] = self.desired_position
-        status["desired_velocity"] = self.desired_velocity
-        status["is_motion_done"] = self.is_motion_done
-
-        return status
-
-    @staticmethod
-    def _get_pq_unit(num):
-        """
-        Gets the units for the specified axis.
-
-        :units: The units for the attached axis
-        :type num: int
-        """
-        return NewportESP301Axis._unit_dict[num]
-
-    def _get_unit_num(self, quantity):
-        """
-        Gets the integer label used by the Newport ESP 301 corresponding to a
-        given `~pint.Quantity`.
-
-        :param pint.Quantity quantity: Units to return a label for.
-
-        :return int:
-        """
-        for num, quant in self._unit_dict.items():
-            if quant == quantity:
-                return num
-
-        raise KeyError(f"{quantity} is not a valid unit for Newport Axis")
-
-    # pylint: disable=protected-access
-    def _newport_cmd(self, cmd, **kwargs):
-        """
-        Passes the newport command from the axis class to the parent controller
-
-        :param cmd:
-        :param kwargs:
-        :return:
-        """
-        return self._controller._newport_cmd(cmd, **kwargs)

--- a/instruments/rigol/rigolds1000.py
+++ b/instruments/rigol/rigolds1000.py
@@ -7,11 +7,7 @@ Provides support for Rigol DS-1000 series oscilloscopes.
 
 from enum import Enum
 
-from instruments.abstract_instruments import (
-    Oscilloscope,
-    OscilloscopeChannel,
-    OscilloscopeDataSource,
-)
+from instruments.abstract_instruments import Oscilloscope
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import ProxyList, bool_property, enum_property
 
@@ -41,7 +37,7 @@ class RigolDS1000Series(SCPIInstrument, Oscilloscope):
 
     # INNER CLASSES #
 
-    class DataSource(OscilloscopeDataSource):
+    class DataSource(Oscilloscope.DataSource):
         """
         Class representing a data source (channel, math, or ref) on the
         Rigol DS1000
@@ -66,7 +62,7 @@ class RigolDS1000Series(SCPIInstrument, Oscilloscope):
             data = self._parent.binblockread(2)  # TODO: check width
             return data
 
-    class Channel(DataSource, OscilloscopeChannel):
+    class Channel(DataSource, Oscilloscope.Channel):
         """
         Class representing a channel on the Rigol DS1000.
 

--- a/instruments/srs/__init__.py
+++ b/instruments/srs/__init__.py
@@ -6,5 +6,5 @@ Module containing Lakeshore instruments
 
 from .srs345 import SRS345
 from .srs830 import SRS830
-from .srsdg645 import _SRSDG645Channel, SRSDG645
+from .srsdg645 import SRSDG645
 from .srsctc100 import SRSCTC100

--- a/instruments/srs/srsdg645.py
+++ b/instruments/srs/srsdg645.py
@@ -242,7 +242,7 @@ class SRSDG645(SCPIInstrument):
         Gets a specific channel object.
 
         The desired channel is accessed by passing an EnumValue from
-        `~SRSDG645.Channels`. For example, to access channel A:
+        `SRSDG645.Channels`. For example, to access channel A:
 
         >>> import instruments as ik
         >>> inst = ik.srs.SRSDG645.open_gpibusb('/dev/ttyUSB0', 1)
@@ -250,7 +250,7 @@ class SRSDG645(SCPIInstrument):
 
         See the example in `SRSDG645` for a more complete example.
 
-        :rtype: `Channel`
+        :rtype: `SRSDG645.Channel`
         """
         return ProxyList(self, self.Channel, SRSDG645.Channels)
 

--- a/instruments/tektronix/__init__.py
+++ b/instruments/tektronix/__init__.py
@@ -4,11 +4,7 @@ Module containing Tektronix instruments
 """
 
 
-from .tekdpo4104 import (
-    TekDPO4104,
-    _TekDPO4104Channel,
-    _TekDPO4104DataSource,
-)
+from .tekdpo4104 import TekDPO4104
 from .tekdpo70000 import TekDPO70000
 from .tekawg2000 import TekAWG2000
 from .tektds224 import TekTDS224

--- a/instruments/tektronix/tekdpo4104.py
+++ b/instruments/tektronix/tekdpo4104.py
@@ -169,7 +169,7 @@ class TekDPO4104(SCPIInstrument, Oscilloscope):
         """
         Class representing a channel on the Tektronix DPO 4104.
 
-        This class inherits from `_TekDPO4104DataSource`.
+        This class inherits from `TekDPO4104.DataSource`.
 
         .. warning:: This class should NOT be manually created by the user. It is
             designed to be initialized by the `TekDPO4104` class.

--- a/instruments/tektronix/tekdpo4104.py
+++ b/instruments/tektronix/tekdpo4104.py
@@ -9,11 +9,7 @@ Provides support for the Tektronix DPO 4104 oscilloscope
 from time import sleep
 from enum import Enum
 
-from instruments.abstract_instruments import (
-    OscilloscopeChannel,
-    OscilloscopeDataSource,
-    Oscilloscope,
-)
+from instruments.abstract_instruments import Oscilloscope
 from instruments.optional_dep_finder import numpy
 from instruments.generic_scpi import SCPIInstrument
 from instruments.util_fns import ProxyList
@@ -54,7 +50,7 @@ class TekDPO4104(SCPIInstrument, Oscilloscope):
     >>> [x, y] = tek.channel[0].read_waveform()
     """
 
-    class DataSource(OscilloscopeDataSource):
+    class DataSource(Oscilloscope.DataSource):
 
         """
         Class representing a data source (channel, math, or ref) on the Tektronix
@@ -168,7 +164,7 @@ class TekDPO4104(SCPIInstrument, Oscilloscope):
 
         y_offset = _parent_property("y_offset")
 
-    class Channel(DataSource, OscilloscopeChannel):
+    class Channel(DataSource, Oscilloscope.Channel):
 
         """
         Class representing a channel on the Tektronix DPO 4104.
@@ -227,7 +223,7 @@ class TekDPO4104(SCPIInstrument, Oscilloscope):
         >>> tek = ik.tektronix.TekDPO4104.open_tcpip("192.168.0.2", 8888)
         >>> [x, y] = tek.channel[0].read_waveform()
 
-        :rtype: `Channel`
+        :rtype: `TekDPO4104.Channel`
         """
         return ProxyList(self, self.Channel, range(4))
 
@@ -243,7 +239,7 @@ class TekDPO4104(SCPIInstrument, Oscilloscope):
         >>> tek = ik.tektronix.TekDPO4104.open_tcpip("192.168.0.2", 8888)
         >>> [x, y] = tek.ref[0].read_waveform()
 
-        :rtype: `DataSource`
+        :rtype: `TekDPO4104.DataSource`
         """
         return ProxyList(
             self,
@@ -256,7 +252,7 @@ class TekDPO4104(SCPIInstrument, Oscilloscope):
         """
         Gets a data source object corresponding to the MATH channel.
 
-        :rtype: `DataSource`
+        :rtype: `TekDPO4104.DataSource`
         """
         return self.DataSource(self, "MATH")
 

--- a/instruments/tektronix/tekdpo70000.py
+++ b/instruments/tektronix/tekdpo70000.py
@@ -9,11 +9,7 @@ import abc
 from enum import Enum
 import time
 
-from instruments.abstract_instruments import (
-    Oscilloscope,
-    OscilloscopeChannel,
-    OscilloscopeDataSource,
-)
+from instruments.abstract_instruments import Oscilloscope
 from instruments.generic_scpi import SCPIInstrument
 from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
@@ -178,7 +174,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
 
     # CLASSES #
 
-    class DataSource(OscilloscopeDataSource):
+    class DataSource(Oscilloscope.DataSource):
 
         """
         Class representing a data source (channel, math, or ref) on the
@@ -500,7 +496,7 @@ class TekDPO70000(SCPIInstrument, Oscilloscope):
             )
             return rval
 
-    class Channel(DataSource, OscilloscopeChannel):
+    class Channel(DataSource, Oscilloscope.Channel):
 
         """
         Class representing a channel on the Tektronix DPO 70000.

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -130,7 +130,7 @@ class TekTDS224(SCPIInstrument, Oscilloscope):
         """
         Class representing a channel on the Tektronix TDS 224.
 
-        This class inherits from `_TekTDS224DataSource`.
+        This class inherits from `TekTDS224.DataSource`.
 
         .. warning:: This class should NOT be manually created by the user. It is
             designed to be initialized by the `TekTDS224` class.
@@ -183,7 +183,7 @@ class TekTDS224(SCPIInstrument, Oscilloscope):
         >>> tek = ik.tektronix.TekTDS224.open_tcpip('192.168.0.2', 8888)
         >>> [x, y] = tek.channel[0].read_waveform()
 
-        :rtype: `Channel`
+        :rtype: `TekTDS224.Channel`
         """
         return ProxyList(self, self.Channel, range(4))
 

--- a/instruments/tektronix/tektds224.py
+++ b/instruments/tektronix/tektds224.py
@@ -9,11 +9,7 @@ import time
 
 from enum import Enum
 
-from instruments.abstract_instruments import (
-    OscilloscopeChannel,
-    OscilloscopeDataSource,
-    Oscilloscope,
-)
+from instruments.abstract_instruments import Oscilloscope
 from instruments.generic_scpi import SCPIInstrument
 from instruments.optional_dep_finder import numpy
 from instruments.util_fns import ProxyList
@@ -23,7 +19,7 @@ from instruments.units import ureg as u
 # CLASSES #####################################################################
 
 
-class _TekTDS224DataSource(OscilloscopeDataSource):
+class _TekTDS224DataSource(Oscilloscope.DataSource):
     """
     Class representing a data source (channel, math, or ref) on the Tektronix
     TDS 224.
@@ -111,7 +107,7 @@ class _TekTDS224DataSource(OscilloscopeDataSource):
             return x, y
 
 
-class _TekTDS224Channel(_TekTDS224DataSource, OscilloscopeChannel):
+class _TekTDS224Channel(_TekTDS224DataSource, Oscilloscope.Channel):
     """
     Class representing a channel on the Tektronix TDS 224.
 

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -188,7 +188,7 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
         """
         Class representing a channel on the Tektronix TDS 5xx.
 
-        This class inherits from `_TekTDS5xxDataSource`.
+        This class inherits from `TekTDS5xx.DataSource`.
 
         .. warning:: This class should NOT be manually created by the user. It is
             designed to be initialized by the `TekTDS5xx` class.
@@ -363,7 +363,7 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
         Gets a specific oscilloscope measurement object. The desired channel is
         specified like one would access a list.
 
-        :rtype: `_TDS5xxMeasurement`
+        :rtype: `TekTDS5xx.Measurement`
         """
         return ProxyList(self, self.Measurement, range(3))
 
@@ -378,7 +378,7 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
         >>> tek = ik.tektronix.TekTDS5xx.open_tcpip('192.168.0.2', 8888)
         >>> [x, y] = tek.channel[0].read_waveform()
 
-        :rtype: `Channel`
+        :rtype: `TekTDS5xx.Channel`
         """
         return ProxyList(self, self.Channel, range(4))
 
@@ -393,7 +393,7 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
         >>> tek = ik.tektronix.TekTDS5xx.open_tcpip('192.168.0.2', 8888)
         >>> [x, y] = tek.ref[0].read_waveform()
 
-        :rtype: `DataSource`
+        :rtype: `TekTDS5xx.DataSource`
         """
         return ProxyList(
             self,
@@ -406,7 +406,7 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
         """
         Gets a data source object corresponding to the MATH channel.
 
-        :rtype: `DataSource`
+        :rtype: `TekTDS5xx.DataSource`
         """
         return ProxyList(
             self,
@@ -439,8 +439,8 @@ class TekTDS5xx(SCPIInstrument, Oscilloscope):
         """
         Gets/sets the the data source for waveform transfer.
 
-        :type: `TekTDS5xx.Source` or `_TekTDS5xxDataSource`
-        :rtype: '_TekTDS5xxDataSource`
+        :type: `TekTDS5xx.Source` or `TekTDS5xx.DataSource`
+        :rtype: `TekTDS5xx.DataSource`
         """
         name = self.query("DAT:SOU?")
         if name.startswith("CH"):

--- a/instruments/tektronix/tektds5xx.py
+++ b/instruments/tektronix/tektds5xx.py
@@ -40,11 +40,7 @@ import struct
 import time
 
 
-from instruments.abstract_instruments import (
-    OscilloscopeChannel,
-    OscilloscopeDataSource,
-    Oscilloscope,
-)
+from instruments.abstract_instruments import Oscilloscope
 from instruments.generic_scpi import SCPIInstrument
 from instruments.optional_dep_finder import numpy
 from instruments.util_fns import ProxyList
@@ -84,7 +80,7 @@ class _TekTDS5xxMeasurement:
         return self._data
 
 
-class _TekTDS5xxDataSource(OscilloscopeDataSource):
+class _TekTDS5xxDataSource(Oscilloscope.DataSource):
 
     """
     Class representing a data source (channel, math, or ref) on the Tektronix
@@ -167,7 +163,7 @@ class _TekTDS5xxDataSource(OscilloscopeDataSource):
             return x, y
 
 
-class _TekTDS5xxChannel(_TekTDS5xxDataSource, OscilloscopeChannel):
+class _TekTDS5xxChannel(_TekTDS5xxDataSource, Oscilloscope.Channel):
 
     """
     Class representing a channel on the Tektronix TDS 5xx.

--- a/instruments/teledyne/maui.py
+++ b/instruments/teledyne/maui.py
@@ -16,11 +16,7 @@ class.
 
 from enum import Enum
 
-from instruments.abstract_instruments import (
-    Oscilloscope,
-    OscilloscopeChannel,
-    OscilloscopeDataSource,
-)
+from instruments.abstract_instruments import Oscilloscope
 from instruments.optional_dep_finder import numpy
 from instruments.units import ureg as u
 from instruments.util_fns import assume_units, enum_property, bool_property, ProxyList
@@ -194,7 +190,7 @@ class MAUI(Oscilloscope):
 
     # CLASSES #
 
-    class DataSource(OscilloscopeDataSource):
+    class DataSource(Oscilloscope.DataSource):
 
         """
         Class representing a data source (channel, math, ref) on a MAUI
@@ -317,7 +313,7 @@ class MAUI(Oscilloscope):
             """,
         )
 
-    class Channel(DataSource, OscilloscopeChannel):
+    class Channel(DataSource, Oscilloscope.Channel):
 
         """
         Class representing a channel on a MAUI oscilloscope.

--- a/instruments/tests/test_abstract_inst/test_optical_spectrum_analyzer.py
+++ b/instruments/tests/test_abstract_inst/test_optical_spectrum_analyzer.py
@@ -26,7 +26,7 @@ def osa(monkeypatch):
 @pytest.fixture
 def osc(monkeypatch):
     """Patch and return OSAChannel class for access."""
-    inst = ik.abstract_instruments.OSAChannel
+    inst = ik.abstract_instruments.OpticalSpectrumAnalyzer.Channel
     monkeypatch.setattr(inst, "__abstractmethods__", set())
     return inst
 

--- a/instruments/tests/test_abstract_inst/test_oscilloscope.py
+++ b/instruments/tests/test_abstract_inst/test_oscilloscope.py
@@ -26,7 +26,7 @@ def osc(monkeypatch):
 @pytest.fixture
 def osc_ch(monkeypatch):
     """Patch and return OscilloscopeChannel class for access."""
-    inst = ik.abstract_instruments.OscilloscopeChannel
+    inst = ik.abstract_instruments.Oscilloscope.Channel
     monkeypatch.setattr(inst, "__abstractmethods__", set())
     return inst
 
@@ -34,7 +34,7 @@ def osc_ch(monkeypatch):
 @pytest.fixture
 def osc_ds(monkeypatch):
     """Patch and return OscilloscopeDataSource class for access."""
-    inst = ik.abstract_instruments.OscilloscopeDataSource
+    inst = ik.abstract_instruments.Oscilloscope.DataSource
     monkeypatch.setattr(inst, "__abstractmethods__", set())
     return inst
 

--- a/instruments/tests/test_abstract_inst/test_power_supply.py
+++ b/instruments/tests/test_abstract_inst/test_power_supply.py
@@ -26,7 +26,7 @@ def ps(monkeypatch):
 @pytest.fixture
 def ps_ch(monkeypatch):
     """Patch and return Power Supply Channel class for access."""
-    inst = ik.abstract_instruments.PowerSupplyChannel
+    inst = ik.abstract_instruments.PowerSupply.Channel
     monkeypatch.setattr(inst, "__abstractmethods__", set())
     return inst
 

--- a/instruments/tests/test_newport/test_agilis.py
+++ b/instruments/tests/test_newport/test_agilis.py
@@ -136,14 +136,14 @@ def test_aguc2_ag_query_io_error(mocker):
 def test_aguc2_axis_init_enum(axis):
     """Initialize an axis externally with an enum."""
     with expected_protocol(ik.newport.AGUC2, [], [], sep="\r\n") as agl:
-        ax = ik.newport.agilis._Axis(agl, axis)
+        ax = ik.newport.agilis.AGUC2.Axis(agl, axis)
         assert ax._ax == axis.value
 
 
 def test_aguc2_axis_init_wrong_type():
     """Raise TypeError when not initialized from AGUC2 parent class."""
     with pytest.raises(TypeError) as err_info:
-        ik.newport.agilis._Axis(42, ik.newport.AGUC2.Axes.X)
+        ik.newport.agilis.AGUC2.Axis(42, ik.newport.AGUC2.Axes.X)
     err_msg = err_info.value.args[0]
     assert err_msg == "Don't do that."
 

--- a/instruments/tests/test_newport/test_newportesp301.py
+++ b/instruments/tests/test_newport/test_newportesp301.py
@@ -42,7 +42,7 @@ def test_axis_returns_axis_class(ax):
         sep="\r",
     ) as inst:
         axis = inst.axis[ax]
-        assert isinstance(axis, ik.newport.NewportESP301Axis)
+        assert isinstance(axis, ik.newport.NewportESP301.Axis)
 
 
 def test_newport_cmd(mocker):
@@ -145,7 +145,7 @@ def test_home(mocker):
         )
 
 
-@pytest.mark.parametrize("search_mode", ik.newport.NewportESP301HomeSearchMode)
+@pytest.mark.parametrize("search_mode", ik.newport.NewportESP301.HomeSearchMode)
 def test_search_for_home(mocker, search_mode):
     """Search for home with specific method.
 
@@ -290,7 +290,7 @@ def test_axis_init():
 def test_axis_init_type_error():
     """Raise TypeError when axis initialized from wrong parent."""
     with pytest.raises(TypeError) as err_info:
-        _ = ik.newport.newportesp301.NewportESP301Axis(42, 0)
+        _ = ik.newport.newportesp301.NewportESP301.Axis(42, 0)
     err_msg = err_info.value.args[0]
     assert (
         err_msg == "Axis must be controlled by a Newport ESP-301 motor " "controller."
@@ -304,8 +304,8 @@ def test_axis_units_of(mocker):
     tested separately, thus only assert that the correct calls are
     issued.
     """
-    get_unit = ik.newport.newportesp301.NewportESP301Units.millimeter
-    set_unit = ik.newport.newportesp301.NewportESP301Units.inches
+    get_unit = ik.newport.newportesp301.NewportESP301.Units.millimeter
+    set_unit = ik.newport.newportesp301.NewportESP301.Units.inches
     with expected_protocol(
         ik.newport.NewportESP301, [ax_init[0]], [ax_init[1]], sep="\r"
     ) as inst:
@@ -324,7 +324,7 @@ def test_axis_get_units(mocker):
     Mock out the command sending and receiving.
     """
     resp = "2"
-    unit = ik.newport.newportesp301.NewportESP301Units(int(resp))
+    unit = ik.newport.newportesp301.NewportESP301.Units(int(resp))
     with expected_protocol(
         ik.newport.NewportESP301, [ax_init[0]], [ax_init[1]], sep="\r"
     ) as inst:
@@ -340,7 +340,7 @@ def test_axis_set_units(mocker):
     Mock out the actual command sending for simplicity, but assert it
     has been called.
     """
-    unit = ik.newport.newportesp301.NewportESP301Units.radian  # just pick one
+    unit = ik.newport.newportesp301.NewportESP301.Units.radian  # just pick one
     with expected_protocol(
         ik.newport.NewportESP301, [ax_init[0]], [ax_init[1]], sep="\r"
     ) as inst:
@@ -1224,7 +1224,7 @@ def test_axis_encoder_position(mocker):
     Also mock out `_newport_cmd`.
     """
     value = 42
-    get_unit = ik.newport.newportesp301.NewportESP301Units.millimeter
+    get_unit = ik.newport.newportesp301.NewportESP301.Units.millimeter
     with expected_protocol(
         ik.newport.NewportESP301, [ax_init[0]], [ax_init[1]], sep="\r"
     ) as inst:
@@ -1241,7 +1241,7 @@ def test_axis_encoder_position(mocker):
 # AXIS METHODS #
 
 
-@pytest.mark.parametrize("mode", ik.newport.newportesp301.NewportESP301HomeSearchMode)
+@pytest.mark.parametrize("mode", ik.newport.newportesp301.NewportESP301.HomeSearchMode)
 def test_axis_search_for_home(mocker, mode):
     """Search for home.
 
@@ -1480,7 +1480,7 @@ def test_axis_setup_axis(mocker):
     motor_type = 2  # stepper motor
     current = 1
     voltage = 2
-    units = ik.newport.newportesp301.NewportESP301Units.radian
+    units = ik.newport.newportesp301.NewportESP301.Units.radian
     encoder_resolution = 3.0
     max_velocity = 4
     max_base_velocity = 5
@@ -1598,7 +1598,7 @@ def test_axis_setup_axis_torque(mocker):
     motor_type = 2  # stepper motor
     current = 1
     voltage = 2
-    units = ik.newport.newportesp301.NewportESP301Units.radian
+    units = ik.newport.newportesp301.NewportESP301.Units.radian
     encoder_resolution = 3.0
     max_velocity = 4
     max_base_velocity = 5
@@ -1682,7 +1682,7 @@ def test_axis_setup_axis_torque_time_out_of_range(mocker, rmt_time):
     motor_type = 2  # stepper motor
     current = 1
     voltage = 2
-    units = ik.newport.newportesp301.NewportESP301Units.radian
+    units = ik.newport.newportesp301.NewportESP301.Units.radian
     encoder_resolution = 3.0
     max_velocity = 4
     max_base_velocity = 5
@@ -1764,7 +1764,7 @@ def test_axis_setup_axis_torque_percentage_out_of_range(mocker, rmt_perc):
     motor_type = 2  # stepper motor
     current = 1
     voltage = 2
-    units = ik.newport.newportesp301.NewportESP301Units.radian
+    units = ik.newport.newportesp301.NewportESP301.Units.radian
     encoder_resolution = 3.0
     max_velocity = 4
     max_base_velocity = 5
@@ -1844,7 +1844,7 @@ def test_axis_read_setup(mocker):
     """
     config = {
         "units": u.mm,
-        "motor_type": ik.newport.newportesp301.NewportESP301MotorType.dc_servo,
+        "motor_type": ik.newport.newportesp301.NewportESP301.MotorType.dc_servo,
         "feedback_configuration": 1,  # last 2 removed at return
         "full_step_resolution": u.Quantity(2.0, u.mm),
         "position_display_resolution": 3,
@@ -1877,7 +1877,7 @@ def test_axis_read_setup(mocker):
         axis = inst.axis[0]
         mock_cmd = mocker.patch.object(axis, "_newport_cmd")
         mock_cmd.side_effect = [
-            ik.newport.newportesp301.NewportESP301Units.millimeter.value,
+            ik.newport.newportesp301.NewportESP301.Units.millimeter.value,
             config["motor_type"].value,
             f"{config['feedback_configuration']}**",  # 2 extra
             config["full_step_resolution"].magnitude,
@@ -1934,7 +1934,7 @@ def test_axis_get_status(mocker):
         assert axis.get_status() == status
 
 
-@pytest.mark.parametrize("num", ik.newport.NewportESP301Axis._unit_dict)
+@pytest.mark.parametrize("num", ik.newport.NewportESP301.Axis._unit_dict)
 def test_axis_get_pq_unit(num):
     """Get units for specified axis."""
     with expected_protocol(
@@ -1944,7 +1944,7 @@ def test_axis_get_pq_unit(num):
         assert axis._get_pq_unit(num) == axis._unit_dict[num]
 
 
-@pytest.mark.parametrize("num", ik.newport.NewportESP301Axis._unit_dict)
+@pytest.mark.parametrize("num", ik.newport.NewportESP301.Axis._unit_dict)
 def test_axis_get_unit_num(num):
     """Get unit number from dictionary.
 

--- a/instruments/tests/test_newport/test_newportesp301.py
+++ b/instruments/tests/test_newport/test_newportesp301.py
@@ -1256,6 +1256,22 @@ def test_axis_search_for_home(mocker, mode):
         mock_search.assert_called_with(axis=1, search_mode=mode.value)
 
 
+def test_axis_search_for_home_default(mocker):
+    """Search for home without a specified search mode.
+
+    Mock out `search_for_home` of controller since already tested.
+    """
+    with expected_protocol(
+        ik.newport.NewportESP301, [ax_init[0]], [ax_init[1]], sep="\r"
+    ) as inst:
+        axis = inst.axis[0]
+        mock_search = mocker.patch.object(axis._controller, "search_for_home")
+        axis.search_for_home()
+
+        default_mode = axis._controller.HomeSearchMode.zero_position_count.value
+        mock_search.assert_called_with(axis=1, search_mode=default_mode)
+
+
 def test_axis_move_absolute(mocker):
     """Make an absolute move (default) on the axis.
 

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -28,7 +28,7 @@ def test_srsdg645_channel_init():
     initialization if not coming from a DG class.
     """
     with pytest.raises(TypeError):
-        ik.srs.srsdg645._SRSDG645Channel(42, 0)
+        ik.srs.srsdg645.SRSDG645.Channel(42, 0)
 
 
 def test_srsdg645_channel_init_channel_value():
@@ -38,7 +38,7 @@ def test_srsdg645_channel_init_channel_value():
     """
     ddg = ik.srs.SRSDG645.open_test()  # test connection
     chan = ik.srs.srsdg645.SRSDG645.Channels.B  # select a channel manually
-    assert ik.srs.srsdg645._SRSDG645Channel(ddg, chan)._chan == 3
+    assert ik.srs.srsdg645.SRSDG645.Channel(ddg, chan)._chan == 3
 
 
 def test_srsdg645_channel_delay():
@@ -47,14 +47,14 @@ def test_srsdg645_channel_delay():
     """
     with expected_protocol(
         ik.srs.SRSDG645,
-        ["DLAY?2", "DLAY 3,2,60", "DLAY 5,4,10"],
+        ["DLAY?2", "DLAY 3,2,60"],  # , "DLAY 5,4,10"],
         ["0,42"],
     ) as ddg:
         ref, t = ddg.channel["A"].delay
         assert ref == ddg.Channels.T0
         assert abs((t - u.Quantity(42, "s")).magnitude) < 1e5
         ddg.channel["B"].delay = (ddg.channel["A"], u.Quantity(1, "minute"))
-        ddg.channel["D"].delay = (ddg.channel["C"], 10)
+        # ddg.channel["D"].delay = (ddg.channel["C"], 10)
 
 
 # DG645 #

--- a/instruments/tests/test_srs/test_srsdg645.py
+++ b/instruments/tests/test_srs/test_srsdg645.py
@@ -47,14 +47,14 @@ def test_srsdg645_channel_delay():
     """
     with expected_protocol(
         ik.srs.SRSDG645,
-        ["DLAY?2", "DLAY 3,2,60"],  # , "DLAY 5,4,10"],
+        ["DLAY?2", "DLAY 3,2,60", "DLAY 5,4,10"],
         ["0,42"],
     ) as ddg:
         ref, t = ddg.channel["A"].delay
         assert ref == ddg.Channels.T0
         assert abs((t - u.Quantity(42, "s")).magnitude) < 1e5
         ddg.channel["B"].delay = (ddg.channel["A"], u.Quantity(1, "minute"))
-        # ddg.channel["D"].delay = (ddg.channel["C"], 10)
+        ddg.channel["D"].delay = (ddg.channel["C"], 10)
 
 
 # DG645 #

--- a/instruments/tests/test_tektronix/test_tekdpo4104.py
+++ b/instruments/tests/test_tektronix/test_tekdpo4104.py
@@ -50,7 +50,7 @@ def test_data_source():
     ) as inst:
         # Channel as string
         inst.data_source = "CH1"
-        assert inst.data_source == ik.tektronix.tekdpo4104._TekDPO4104Channel(inst, 0)
+        assert inst.data_source == ik.tektronix.tekdpo4104.TekDPO4104.Channel(inst, 0)
 
         # Reference channel as enum
         class RefChannel(Enum):
@@ -60,14 +60,14 @@ def test_data_source():
 
         channel = RefChannel.channel.value
         inst.data_source = RefChannel.channel
-        assert inst.data_source == ik.tektronix.tekdpo4104._TekDPO4104DataSource(
+        assert inst.data_source == ik.tektronix.tekdpo4104.TekDPO4104.DataSource(
             inst, channel
         )
 
         # Set a math channel
         math_ch = inst.math
         inst.data_source = math_ch
-        assert inst.data_source == ik.tektronix.tekdpo4104._TekDPO4104DataSource(
+        assert inst.data_source == ik.tektronix.tekdpo4104.TekDPO4104.DataSource(
             inst, math_ch.name
         )
 
@@ -209,7 +209,7 @@ def test_data_source_ref_initialize(ref):
         ref_source = inst.ref[ref]
 
         # test instance
-        assert isinstance(ref_source, ik.tektronix.tekdpo4104._TekDPO4104DataSource)
+        assert isinstance(ref_source, ik.tektronix.tekdpo4104.TekDPO4104.DataSource)
 
         # test for parent
         assert ref_source._tek is inst
@@ -221,7 +221,7 @@ def test_data_source_math_initialize():
         math_source = inst.math
 
         # test instance
-        assert isinstance(math_source, ik.tektronix.tekdpo4104._TekDPO4104DataSource)
+        assert isinstance(math_source, ik.tektronix.tekdpo4104.TekDPO4104.DataSource)
 
         # test for parent
         assert math_source._tek is inst

--- a/instruments/tests/test_tektronix/test_tektronix_tds224.py
+++ b/instruments/tests/test_tektronix/test_tektronix_tds224.py
@@ -73,7 +73,7 @@ def test_tektds224_data_source(mock_time):
         ["MATH", "CH1"],
     ) as tek:
         assert tek.data_source == tek.math
-        assert tek.data_source == ik.tektronix.tektds224._TekTDS224Channel(tek, 0)
+        assert tek.data_source == ik.tektronix.tektds224.TekTDS224.Channel(tek, 0)
         tek.data_source = tek.math
 
         # assert that time.sleep is called
@@ -94,7 +94,7 @@ def test_tektds224_data_source_with_enum():
 
 def test_tektds224_channel():
     with expected_protocol(ik.tektronix.TekTDS224, [], []) as tek:
-        assert tek.channel[0] == ik.tektronix.tektds224._TekTDS224Channel(tek, 0)
+        assert tek.channel[0] == ik.tektronix.tektds224.TekTDS224.Channel(tek, 0)
 
 
 def test_tektds224_channel_coupling():

--- a/instruments/tests/test_tektronix/test_tktds5xx.py
+++ b/instruments/tests/test_tektronix/test_tktds5xx.py
@@ -385,17 +385,17 @@ def test_sources(states):
         for idx in range(4):
             if states[idx]:
                 active_sources.append(
-                    ik.tektronix.tektds5xx._TekTDS5xxChannel(inst, idx)
+                    ik.tektronix.tektds5xx.TekTDS5xx.Channel(inst, idx)
                 )
         for idx in range(4, 7):
             if states[idx]:
                 active_sources.append(
-                    ik.tektronix.tektds5xx._TekTDS5xxDataSource(inst, f"MATH{idx-3}")
+                    ik.tektronix.tektds5xx.TekTDS5xx.DataSource(inst, f"MATH{idx - 3}")
                 )
         for idx in range(7, 11):
             if states[idx]:
                 active_sources.append(
-                    ik.tektronix.tektds5xx._TekTDS5xxDataSource(inst, f"REF{idx-6}")
+                    ik.tektronix.tektds5xx.TekTDS5xx.DataSource(inst, f"REF{idx - 6}")
                 )
         # read active sources
         active_read = inst.sources

--- a/instruments/yokogawa/yokogawa6370.py
+++ b/instruments/yokogawa/yokogawa6370.py
@@ -10,10 +10,7 @@ from enum import IntEnum, Enum
 
 from instruments.units import ureg as u
 
-from instruments.abstract_instruments import (
-    OpticalSpectrumAnalyzer,
-    OSAChannel,
-)
+from instruments.abstract_instruments import OpticalSpectrumAnalyzer
 from instruments.util_fns import (
     enum_property,
     unitful_property,
@@ -46,12 +43,12 @@ class Yokogawa6370(OpticalSpectrumAnalyzer):
 
     # INNER CLASSES #
 
-    class Channel(OSAChannel):
+    class Channel(OpticalSpectrumAnalyzer.Channel):
 
         """
         Class representing the channels on the Yokogawa 6370.
 
-        This class inherits from `OSAChannel`.
+        This class inherits from `OpticalSpectrumAnalyzer.Channel`.
 
         .. warning:: This class should NOT be manually created by the user. It
             is designed to be initialized by the `Yokogawa6370` class.

--- a/instruments/yokogawa/yokogawa7651.py
+++ b/instruments/yokogawa/yokogawa7651.py
@@ -10,10 +10,7 @@ from enum import IntEnum
 
 from instruments.units import ureg as u
 
-from instruments.abstract_instruments import (
-    PowerSupply,
-    PowerSupplyChannel,
-)
+from instruments.abstract_instruments import PowerSupply
 from instruments.abstract_instruments import Instrument
 from instruments.util_fns import assume_units, ProxyList
 
@@ -35,12 +32,12 @@ class Yokogawa7651(PowerSupply, Instrument):
 
     # INNER CLASSES #
 
-    class Channel(PowerSupplyChannel):
+    class Channel(PowerSupply.Channel):
 
         """
         Class representing the only channel on the Yokogawa 7651.
 
-        This class inherits from `PowerSupplyChannel`.
+        This class inherits from `PowerSupply.Channel`.
 
         .. warning:: This class should NOT be manually created by the user. It
             is designed to be initialized by the `Yokogawa7651` class.


### PR DESCRIPTION
I thought of tackling issue #15, which is also on the todo list for v1.0 (#190). Inner classes seem to have the advantage that the individual channels, etc., are not exposed directly to the user, so I think it makes more sense. On the todo list of instruments to fix are: 

- [x] instruments/abstract_instrument/optical_spectrum_analyzer
- [x] instruments/abstract_instrument/oscilloscope
- [x] instruments/abstract_instrument/power_supply
- [x] newport/agilis
- [x] newport/newportesp301
- [x] tektronix/tekdpo4104
- [x] tektronix/textds224
- [x] tektronix/tektds5xx
- [x] srs/srsdg645

As an example, I started with the srs/srsdg645, mostly to see how it goes and discuss above list. Pinging @scasagrande for ideas, comments, etc.