### PR TITLE
Add py310 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
             TOXENV: "py39"
           - python-version: 3.9
             TOXENV: "py39-numpy"
+          - python-version: "3.10"
+            TOXENV: "py310"
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -112,7 +112,7 @@ send, one can use the following functions to do so:
 Python Version Compatibility
 ----------------------------
 
-At this time, Python 3.6, 3.7, 3.8, and 3.9 are supported. Should you encounter
+At this time, Python 3.6, 3.7, 3.8, 3.9, and 3.10 are supported. Should you encounter
 any problems with this library that occur in one version or another, please
 do not hesitate to let us know.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     python-vxi11>=0.8
     pyusb>=1.0
     pyvisa>=1.9
-    ruamel.yaml~=0.15.37
+    ruamel.yaml>=0.16,<0.17
 
 [options.extras_require]
 numpy = numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Operating System :: OS Independent
     License :: OSI Approved :: GNU Affero General Public License v3
     Intended Audience :: Science/Research

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39},py{36,37,38,39}-numpy,pylint
+envlist = py{36,37,38,39,310},py{36,37,38,39,310}-numpy,pylint
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
Closes #326

Adds Py310 support, and bumps `ruamel.yaml` to the `0.16.x` series. Looking into the docs, I see: 

>  The 0.17 series will also stop support for the old PyYAML functions, so a `YAML()` instance will need to be created.

So I'll make that a separate ticket to update calls and open up the versioning upper limit