### PR TITLE
Include a replacement for " Celsius" as the unit

### DIFF
--- a/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
+++ b/instruments/tests/test_thorlabs/test_thorlabs_tc200.py
@@ -110,6 +110,14 @@ def test_tc200_temperature_set():
         tc.temperature_set = u.Quantity(40, u.degC)
 
 
+def test_tc200_temperature_set_celsius():
+    """Ensure celsius is stripped if returned by instrument, see issue #331"""
+    with expected_protocol(
+        ik.thorlabs.TC200, ["tset?"], ["tset?", "30 Celsius", "> "], sep="\r"
+    ) as tc:
+        assert tc.temperature_set == u.Quantity(30.0, u.degC)
+
+
 def test_tc200_temperature_range():
     with pytest.raises(ValueError), expected_protocol(
         ik.thorlabs.TC200, ["tmax?"], ["tmax?", "40", "> "], sep="\r"

--- a/instruments/thorlabs/tc200.py
+++ b/instruments/thorlabs/tc200.py
@@ -198,7 +198,11 @@ class TC200(Instrument):
         :rtype: `~pint.Quantity`
         """
         response = (
-            self.query("tset?").replace(" C", "").replace(" F", "").replace(" K", "")
+            self.query("tset?")
+            .replace(" Celsius", "")
+            .replace(" C", "")
+            .replace(" F", "")
+            .replace(" K", "")
         )
         return u.Quantity(float(response), u.degC)
 


### PR DESCRIPTION
See issue #331, it seems like `tset?` returns ` Celsius` as the unit.