### PR TITLE
Extend APT Motor Controller to set / get home parameters

### DIFF
--- a/instruments/thorlabs/thorlabsapt.py
+++ b/instruments/thorlabs/thorlabsapt.py
@@ -1417,13 +1417,11 @@ class APTMotorController(ThorLabsAPT):
             if not isinstance(velocity, u.Quantity):
                 velocity = int(velocity)
             else:
-                # Ensure velocity is dimensionless
-                req_units = (1 / self.scale_factors[1]).units
-                try:
-                    velocity = int(
-                        (velocity.to(req_units) * self.scale_factors[1]).magnitude
-                    )
-                except:
+                # Ensure velocity is in appropriate units
+                velocity = (velocity * self.scale_factors[1]).to_reduced_units()
+                if velocity.dimensionless:
+                    velocity = int(velocity.magnitude)
+                else:
                     raise ValueError(
                         "Provided units for velocity are not compatible "
                         "with current motor scale factor."


### PR DESCRIPTION
For APT Motor Controllers, homing parameters can be set. This was so far not included in `ik`. Now it is, and tested (w/ pytests and with a "PRM1-Z8" stage).

Small addition to the overall monster APT driver.