### PR TITLE
Allow move_indefinitely to move in the 'negative' direction

### DIFF
--- a/src/instruments/newport/newportesp301.py
+++ b/src/instruments/newport/newportesp301.py
@@ -42,7 +42,6 @@ class NewportESP301(Instrument):
         self._command_list = []
         self._bulk_query_resp = ""
         self.terminator = "\r"
-        
 
     class Axis:
         """
@@ -870,7 +869,7 @@ class NewportESP301(Instrument):
             """
             self._newport_cmd("MT", target=self.axis_id)
 
-        def move_indefinitely(self, direction: str = '+'):
+        def move_indefinitely(self, direction: str = "+"):
             """
             Move until told to stop in the direction ("+" or "-") passed.
             """


### PR DESCRIPTION
This change allows the NewportESP301 to take a direction argument when calling the 'move_indefinitely' function. Currently, this function only allows movement in the 'positive' direction. By adding an optional 'direction' argument, the function can be used in either direction. This update should not affect any existing code, as the default if no argument is passed will still be positive movement.