### PR TITLE
Support data size length longer than 9 digits in binblockread

### DIFF
--- a/src/instruments/abstract_instruments/instrument.py
+++ b/src/instruments/abstract_instruments/instrument.py
@@ -271,7 +271,7 @@ class Instrument:
         as EOL terminators naturally can not be used in binary transfers.
 
         The format is as follows:
-        #{number of following digits:1-9}{num of bytes to be read}{data bytes}
+        #{number of following digits:1-F}{num of bytes to be read}{data bytes}
 
         :param int data_width: Specify the number of bytes wide each data
             point is. One of [1,2,4].
@@ -291,7 +291,7 @@ class Instrument:
             )
         else:
             # Read in the num of digits for next part
-            digits = int(self._file.read_raw(1))
+            digits = int(self._file.read_raw(1), 16)
 
             # Read in the num of bytes to be read
             num_of_bytes = int(self._file.read_raw(digits))
@@ -313,7 +313,7 @@ class Instrument:
                     tries -= 1
                 if tries == 0:
                     raise OSError(
-                        "Did not read in the required number of bytes"
+                        "Did not read in the required number of bytes "
                         "during binblock read. Got {}, expected "
                         "{}".format(len(data), num_of_bytes)
                     )


### PR DESCRIPTION
While working on a RIGOL MHO900/98 instrument class, I found that reading waveform data with a size larger than 9 digits (e.g. 500M points * 2 bytes) will encode the length of the data size in base-16. This change allowed me to read the full waveform data, although it was VERY slow on this scope.